### PR TITLE
Add configurations for Celery w.r.t. experiments

### DIFF
--- a/orchest/orchest-api/Dockerfile_celery
+++ b/orchest/orchest-api/Dockerfile_celery
@@ -19,6 +19,9 @@ RUN pip3 install aiodocker==0.18.3 \
 COPY ./lib /src
 RUN pip3 install -e /src/orchest-internals/
 
+COPY ./orchest/orchest-api/start_celery_workers.sh .
+RUN ["chmod", "+x", "start_celery_workers.sh"]
+
 COPY ./orchest/orchest-api/app /app
 WORKDIR /app
 
@@ -27,4 +30,4 @@ WORKDIR /app
 # packages.
 RUN pip3 install -r requirements.txt
 
-CMD ["celery", "worker", "-A", "app.core.tasks", "-l", "INFO"]
+CMD ["./../start_celery_workers.sh"]

--- a/orchest/orchest-api/Dockerfile_celery.dockerignore
+++ b/orchest/orchest-api/Dockerfile_celery.dockerignore
@@ -1,4 +1,5 @@
 *
 
 !orchest/orchest-api/app/
+!orchest/orchest-api/start_celery_workers.sh
 !lib

--- a/orchest/orchest-api/app/app/apis/namespace_experiments.py
+++ b/orchest/orchest-api/app/app/apis/namespace_experiments.py
@@ -182,9 +182,12 @@ class Experiment(Resource):
         # TODO: https://stackoverflow.com/questions/39191238/revoke-a-task-from-celery
         # NOTE: delete new pipeline files that were created for this specific run?
 
-        # Stop the run, whether it is in the queue or whether it is
-        # actually running.
-        revoke(run_uuid, terminate=True)
+        # According to the Celery docs we should never programmatically
+        # set ``revoke(uuid, terminate=True)`` as it actually kills the
+        # worker process and it could already be running a new task.
+
+        # TODO: for all runs part of the experiment, revoke it.
+        revoke(run_uuid)
 
         run_res = models.ScheduledRun.query.filter_by(
             run_uuid=run_uuid

--- a/orchest/orchest-api/app/config.py
+++ b/orchest/orchest-api/app/config.py
@@ -21,6 +21,16 @@ class Config:
     # config class will be loaded directly by the Celery instance.
     broker_url = 'amqp://guest:guest@rabbitmq-server:5672//'
     imports = ('app.core.tasks',)
+    task_create_missing_queues = True
+    task_default_queue = 'celery'
+    task_routes = {
+        'app.core.tasks.start_non_interactive_pipeline_run': {
+            'queue': 'experiments'
+        },
+        'app.core.tasks.run_partial': {
+            'queue': 'celery'
+        },
+    }
     # result_backend = 'rpc://'
 
 

--- a/orchest/orchest-api/start_celery_workers.sh
+++ b/orchest/orchest-api/start_celery_workers.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Experiments.
+celery worker -A app.core.tasks -l INFO -Q experiments -n worker-expriments --concurrency=1 --detach
+
+# Interactive runs. "celery" is the default queue name.
+celery worker -A app.core.tasks -l INFO -Q celery -n worker-interactive --concurrency=1

--- a/orchest/orchest-api/start_celery_workers.sh
+++ b/orchest/orchest-api/start_celery_workers.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # Experiments.
-celery worker -A app.core.tasks -l INFO -Q experiments -n worker-expriments --concurrency=1 --detach
+celery worker -A app.core.tasks \
+    -l INFO \
+    -Q experiments \
+    -n worker-expriments \
+    --statedb /userdir/.orchest/celery-state-db \
+    --concurrency=1 \
+    --detach
 
 # Interactive runs. "celery" is the default queue name.
 celery worker -A app.core.tasks -l INFO -Q celery -n worker-interactive --concurrency=1

--- a/orchest/orchest-ctl/app/main.py
+++ b/orchest/orchest-ctl/app/main.py
@@ -98,7 +98,7 @@ CONTAINER_MAPPING = {
                 "target": "/var/run/docker.sock"
             },
             {
-                # Mount in needed for copying the snapshot dir to
+                # Mount is needed for copying the snapshot dir to
                 # pipeline run dirs for experiments.
                 "source": HOST_USER_DIR,
                 "target": "/userdir"
@@ -356,11 +356,11 @@ def dev_mount_inject():
     orchest_webserver_spec['mounts'] += [
         {
             "source": os.path.join(
-                os.environ.get("HOST_PWD"), 
-                "orchest", 
-                "orchest-webserver", 
+                os.environ.get("HOST_PWD"),
+                "orchest",
+                "orchest-webserver",
                 "app"),
-            "target": "/app" 
+            "target": "/app"
         }
     ]
 
@@ -404,7 +404,7 @@ def dev_mount_inject():
         "80/tcp": 80,
         "443/tcp": 443
     }
-    
+
 
 def status():
 


### PR DESCRIPTION
Experiments now run sequentially but in parallel with interactive pipeline runs. Thus you can always interactively run a pipeline.

Additionally, celery tasks (for experiments) are now persisted to disk.