### PR TITLE
Add status indication for experiments

### DIFF
--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -183,9 +183,19 @@ class Experiment(BaseModel):
         db.String(36),
         primary_key=False
     )
+    total_number_of_pipeline_runs = db.Column(
+        db.Integer,
+        unique=False,
+        nullable=False,
+    )
     scheduled_start = db.Column(
         db.DateTime,
         nullable=False
+    )
+    completed_pipeline_runs = db.Column(
+        db.Integer,
+        unique=False,
+        default=0,
     )
 
     pipeline_runs = db.relationship('NonInteractiveRun', lazy='joined')

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -232,12 +232,19 @@ experiment = Model('Experiment', {
     'pipeline_uuid': fields.String(
         required=True,
         description='UUID of pipeline'),
+    'total_number_of_pipeline_runs': fields.Integer(
+        required=True,
+        description='Total number of pipeline runs part of the experiment'),
     'pipeline_runs': fields.List(
         fields.Nested(non_interactive_run),
         description='Collection of pipeline runs part of the experiment'),
     'scheduled_start': fields.String(
         required=True,
         description='Time at which the experiment is scheduled to start'),
+    'completed_pipeline_runs': fields.Integer(
+        required=True,
+        default=0,
+        description='Number of completed pipeline runs part of the experiment'),
 })
 
 experiments = Model('Experiments', {


### PR DESCRIPTION
Add `total_number_of_pipeline_runs` and `completed_pipeline_runs` attributes to the `Experiment` schema.