### PR TITLE
improvements to project initialization

### DIFF
--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -23,6 +23,8 @@ class Config:
     DEFAULT_DATASOURCES = _config.DEFAULT_DATASOURCES
     ORCHEST_API_ADDRESS = _config.ORCHEST_API_ADDRESS
 
+    PROJECT_ORCHEST_GIT_IGNORE_CONTENT = "\n".join(["logs/", "data/"])
+
     FLASK_ENV = os.environ.get("FLASK_ENV", "PRODUCTION")
 
     DEBUG = True

--- a/services/orchest-webserver/app/app/views/core.py
+++ b/services/orchest-webserver/app/app/views/core.py
@@ -941,7 +941,18 @@ def register_views(app, db):
                     # this line does not strictly need to be there, since the new directory will be picked up
                     # on the GET request and initialized, placing it here is more explicit and less relying
                     # on the POST->GET pattern from the GUI
-                    init_project(project_path)
+                    try:
+                        init_project(project_path)
+                    except Exception as e:
+                        return (
+                            jsonify(
+                                {
+                                    "message": "Failed to create the project. Error: %s"
+                                    % e
+                                }
+                            ),
+                            409,
+                        )
                 else:
                     return (
                         jsonify({"message": "Project directory already exists."}),

--- a/services/orchest-webserver/app/app/views/core.py
+++ b/services/orchest-webserver/app/app/views/core.py
@@ -951,7 +951,7 @@ def register_views(app, db):
                                     % e
                                 }
                             ),
-                            409,
+                            500,
                         )
                 else:
                     return (

--- a/services/orchest-webserver/app/app/views/core.py
+++ b/services/orchest-webserver/app/app/views/core.py
@@ -543,6 +543,82 @@ def register_views(app, db):
             db.session.delete(removed_proj)
         db.session.commit()
 
+        # refresh kernels after change in environments
+        populate_kernels(app, db)
+
+    def init_project(project_path: str):
+        """Inits an orchest project.
+
+        Given a directory it will detect what parts are missing from the .orchest directory for the project to
+        be considered initialized, e.g. the actual .orchest directory, .gitignore file, environments directory, etc.
+        As part of process initialization environments are built and kernels refreshed.
+
+        Args:
+            project_path: Directory of the project
+
+        Returns:
+
+        """
+        projects_dir = os.path.join(app.config["USER_DIR"], "projects")
+        full_project_path = os.path.join(projects_dir, project_path)
+
+        new_project = Project(
+            uuid=str(uuid.uuid4()),
+            path=project_path,
+        )
+        db.session.add(new_project)
+        db.session.commit()
+
+        try:
+            # this would actually be created as a collateral effect when populating with default environments,
+            # let's not rely on that
+            expected_internal_dir = os.path.join(full_project_path, ".orchest")
+            if os.path.isfile(expected_internal_dir):
+                raise NotADirectoryError(
+                    "The expected internal directory (.orchest) is a file."
+                )
+            elif not os.path.isdir(expected_internal_dir):
+                os.makedirs(expected_internal_dir)
+
+            # init the .gitignore file if it is not there already
+            expected_git_ignore_file = os.path.join(
+                full_project_path, ".orchest", ".gitignore"
+            )
+            if os.path.isdir(expected_git_ignore_file):
+                raise FileExistsError(".orchest/.gitignore is a directory")
+            elif not os.path.isfile(expected_git_ignore_file):
+                with open(expected_git_ignore_file, "w") as ign_file:
+                    ign_file.write(app.config["PROJECT_ORCHEST_GIT_IGNORE_CONTENT"])
+
+            # initialize with default environments only if the project has no environments directory
+            expected_env_dir = os.path.join(
+                full_project_path, ".orchest", "environments"
+            )
+            if os.path.isfile(expected_env_dir):
+                raise NotADirectoryError(
+                    "The expected environments directory (.orchest/environments) is a file."
+                )
+            elif not os.path.isdir(expected_env_dir):
+                populate_default_environments(new_project.uuid)
+
+            # refresh kernels after change in environments, given that  either we added the default environments
+            # or the project has environments of its own
+            populate_kernels(app, db)
+
+            # build environments on project creation
+            build_environments_for_project(new_project.uuid)
+
+        # some calls rely on the project being in the db, like populate_default_environments or populate_kernels,
+        # for this reason we need to commit the project to the db before the init actually finishes
+        # if an exception is raised during project init we have to cleanup the newly added project from the db
+        # TODO: make use of the complete cleanup of a project from orchest once that is implemented, so that we
+        #  use the same code path
+        except Exception as e:
+            db.session.delete(new_project)
+            db.session.commit()
+            populate_kernels(app, db)
+            raise e
+
     @app.route("/", methods=["GET"])
     def index():
 
@@ -777,11 +853,11 @@ def register_views(app, db):
     @app.route("/async/projects", methods=["GET", "POST", "DELETE"])
     def projects():
 
-        project_dir = os.path.join(app.config["USER_DIR"], "projects")
+        projects_dir = os.path.join(app.config["USER_DIR"], "projects")
         project_paths = [
             name
-            for name in os.listdir(project_dir)
-            if os.path.isdir(os.path.join(project_dir, name))
+            for name in os.listdir(projects_dir)
+            if os.path.isdir(os.path.join(projects_dir, name))
         ]
 
         # look for projects that have been removed through the filesystem by the user, cleanup
@@ -791,37 +867,19 @@ def register_views(app, db):
         ).all()
         cleanup_fs_removed_projects(fs_removed_projects)
 
-        # create UUID entry for all projects that do not yet exist
+        # detect new projects by detecting directories that were not registered in the db as projects
         existing_project_paths = [
             project.path
             for project in Project.query.filter(Project.path.in_(project_paths)).all()
         ]
-
         new_project_paths = set(project_paths) - set(existing_project_paths)
-
         for new_project_path in new_project_paths:
-            new_project = Project(
-                uuid=str(uuid.uuid4()),
-                path=new_project_path,
-            )
-            db.session.add(new_project)
-            db.session.commit()
-
-            expected_env_dir = os.path.join(
-                project_dir, new_project_path, ".orchest", "environments"
-            )
-            # initialize with default environments if the project has no environments directory, e.g.
-            # if it was just created through the file system or git clone'd into the projects dir
-            if not os.path.isdir(expected_env_dir):
-                logging.info(
-                    f"No environment directory detected ({expected_env_dir}), initializing..."
+            try:
+                init_project(new_project_path)
+            except Exception as e:
+                logging.error(
+                    f"Error during project initialization of {new_project_path}: {e}"
                 )
-                populate_default_environments(new_project.uuid)
-
-            # build environments on project detection
-            build_environments_for_project(new_project.uuid)
-
-        # end of UUID creation
 
         if request.method == "GET":
 
@@ -848,7 +906,7 @@ def register_views(app, db):
             if project != None:
 
                 project_path = project_uuid_to_path(project_uuid)
-                full_project_path = os.path.join(project_dir, project_path)
+                full_project_path = os.path.join(projects_dir, project_path)
 
                 # go through each environment and delete it
                 proj_envs = get_environments(project_uuid)
@@ -876,27 +934,14 @@ def register_views(app, db):
             project_path = request.json["name"]
 
             if project_path not in project_paths:
-                full_project_path = os.path.join(project_dir, project_path)
+                full_project_path = os.path.join(projects_dir, project_path)
                 if not os.path.isdir(full_project_path):
-
-                    new_project = Project(
-                        uuid=str(uuid.uuid4()),
-                        path=project_path,
-                    )
-                    db.session.add(new_project)
-                    db.session.commit()
-
                     os.makedirs(full_project_path)
-
-                    # initialize with default environments
-                    populate_default_environments(new_project.uuid)
-
-                    # refresh kernels after change in environments
-                    populate_kernels(app, db)
-
-                    # build environments on project creation
-                    build_environments_for_project(new_project.uuid)
-
+                    # note that given the current pattern we have in the GUI, where we POST and then GET projects,
+                    # this line does not strictly need to be there, since the new directory will be picked up
+                    # on the GET request and initialized, placing it here is more explicit and less relying
+                    # on the POST->GET pattern from the GUI
+                    init_project(project_path)
                 else:
                     return (
                         jsonify({"message": "Project directory already exists."}),


### PR DESCRIPTION
improvements to project initialization

Creating a project through the GUI, importing a project through the GUI, creating a directory
in userdir/projects or cloning into userdir/projects will use the same function to initialize the project.
Initializing a project means checking that the correct directory and files are presents, like the .orchest directory or its content, and
creating them when they are not, after that environments are built and kernels refreshed.

