### PR TITLE
Introduce zoom for the Pipeline editor/viewer

### DIFF
--- a/lib/javascript/utils/all.js
+++ b/lib/javascript/utils/all.js
@@ -333,23 +333,6 @@ export class PersistentLocalConfig {
   }
 }
 
-export function nodeCenter(el) {
-  let position = {};
-
-  position.x = el.offset().left + el.width() / 2;
-  position.y = el.offset().top + el.height() / 2;
-
-  return position;
-}
-
-export function correctedPosition(x, y, el) {
-  let elementOffset = el.offset();
-  let position = {};
-  position.x = x - elementOffset.left;
-  position.y = y - elementOffset.top;
-  return position;
-}
-
 export function globalMDCVars() {
   return {
     mdcthemeprimary: "#000000",

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -659,15 +659,16 @@ span.code {
 
       button {
         margin-bottom: 0;
+        margin-top: $generalPadding;
+      }
+
+      .navigation-buttons {
+        display: inline-block;
       }
 
       .selection-buttons {
         display: inline-block;
         padding-left: $generalPadding;
-
-        button {
-          margin-top: $generalPadding;
-        }
       }
     }
 
@@ -684,10 +685,9 @@ span.code {
 
   .pipeline-steps-outer-holder {
     height: 100%;
+    width: 100%;
     overflow: hidden;
-    position: relative;
-    background-image: url("../image/cross-fill.svg");
-    background-repeat: repeat;
+    position: absolute;
 
     &.dragging {
       cursor: grabbing;
@@ -696,8 +696,11 @@ span.code {
 
   .pipeline-steps-holder {
     height: 100%;
-    position: relative;
+    position: absolute;
     user-select: none;
+    background-image: url("../image/cross-fill.svg");
+    background-repeat: repeat;
+    border: 1px solid #e5e5e5;
 
     .step-selector {
       position: absolute;

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -664,6 +664,10 @@ span.code {
       .selection-buttons {
         display: inline-block;
         padding-left: $generalPadding;
+
+        button {
+          margin-top: $generalPadding;
+        }
       }
     }
 

--- a/services/orchest-webserver/app/static/image/cross-fill.svg
+++ b/services/orchest-webserver/app/static/image/cross-fill.svg
@@ -1,4 +1,4 @@
 <svg width="40" height="41" viewBox="0 0 40 41" fill="none" xmlns="http://www.w3.org/2000/svg">
-<line x1="39.5" y1="40" x2="39.5" y2="3.74913e-06" stroke="black" stroke-opacity="0.1"/>
-<line x1="40" y1="40.5" x2="3.77099e-06" y2="40.5" stroke="black" stroke-opacity="0.1"/>
+<line x1="39.5" y1="40" x2="39.5" y2="3.74913e-06" stroke="#e5e5e5" />
+<line x1="40" y1="40.5" x2="3.77099e-06" y2="40.5" stroke="#e5e5e5" />
 </svg>

--- a/services/orchest-webserver/app/static/js/components/PipelineStep.js
+++ b/services/orchest-webserver/app/static/js/components/PipelineStep.js
@@ -13,7 +13,7 @@ class PipelineStep extends React.Component {
   }
 
   updatePosition(position) {
-    // note: outside of normal React loop for performance
+    // note: DOM update outside of normal React loop for performance
     this.refManager.refs.container.style.transform =
       "translateX(" + position[0] + "px) translateY(" + position[1] + "px)";
   }

--- a/services/orchest-webserver/app/static/js/utils/webserver-utils.js
+++ b/services/orchest-webserver/app/static/js/utils/webserver-utils.js
@@ -132,3 +132,13 @@ export class BackgroundTaskPoller {
     );
   }
 }
+
+export function getScrollLineHeight() {
+  const el = document.createElement("div");
+  el.style.fontSize = "initial";
+  el.style.display = "none";
+  document.body.appendChild(el);
+  const fontSize = window.getComputedStyle(el).fontSize;
+  document.body.removeChild(el);
+  return fontSize ? window.parseInt(fontSize) : undefined;
+}

--- a/services/orchest-webserver/app/static/js/views/EnvironmentEditView.js
+++ b/services/orchest-webserver/app/static/js/views/EnvironmentEditView.js
@@ -45,7 +45,7 @@ class EnvironmentEditView extends React.Component {
         props.environment &&
         DEFAULT_BASE_IMAGES.indexOf(props.environment.base_image) == -1
           ? DEFAULT_BASE_IMAGES.concat(props.environment.base_image)
-          : DEFAULT_BASE_IMAGES.slice(),
+          : [...DEFAULT_BASE_IMAGES],
       newEnvironment: props.environment === undefined,
       showingBuildLogs: true,
       ignoreIncomingLogs: false,

--- a/services/orchest-webserver/app/static/js/views/PipelineView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineView.js
@@ -1741,6 +1741,9 @@ class PipelineView extends React.Component {
      * displacement for the transformed/scaled parent (pipelineStepHolder)
      * that avoids visual displacement when the origin of the
      * transformed/scaled parent is modified.
+     *
+     * the adjustedScaleFactor was derived by analysing the geometric behavior
+     * of applying the css transform: translate(...) scale(...);.
      */
 
     let adjustedScaleFactor = scaleFactor - 1;

--- a/services/orchest-webserver/app/static/js/views/PipelineView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineView.js
@@ -1422,7 +1422,7 @@ class PipelineView extends React.Component {
   setPipelineHolderOrigin(newOrigin) {
     this.pipelineOrigin = newOrigin;
 
-    let pipelineStepsolderOffset = $(
+    let pipelineStepsHolderOffset = $(
       this.refManager.refs.pipelineStepsHolder
     ).offset();
 
@@ -1431,9 +1431,9 @@ class PipelineView extends React.Component {
     ).offset();
 
     let initialX =
-      pipelineStepsolderOffset.left - pipelineStepsOuterHolderOffset.left;
+      pipelineStepsHolderOffset.left - pipelineStepsOuterHolderOffset.left;
     let initialY =
-      pipelineStepsolderOffset.top - pipelineStepsOuterHolderOffset.top;
+      pipelineStepsHolderOffset.top - pipelineStepsOuterHolderOffset.top;
 
     let translateXY = this.originTransformMapping(
       [...this.pipelineOrigin],
@@ -1737,6 +1737,12 @@ class PipelineView extends React.Component {
   }
 
   originTransformMapping(origin, scaleFactor) {
+    /* By multiplying the transform-origin with the scaleFactor we get the right
+     * displacement for the transformed/scaled parent (pipelineStepHolder)
+     * that avoids visual displacement when the origin of the
+     * transformed/scaled parent is modified.
+     */
+
     let adjustedScaleFactor = scaleFactor - 1;
     origin[0] *= adjustedScaleFactor;
     origin[1] *= adjustedScaleFactor;

--- a/services/orchest-webserver/app/static/js/views/PipelineView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineView.js
@@ -1435,7 +1435,7 @@ class PipelineView extends React.Component {
     let initialY =
       pipelineStepsHolderOffset.top - pipelineStepsOuterHolderOffset.top;
 
-    let translateXY = this.originTransformMapping(
+    let translateXY = this.originTransformScaling(
       [...this.pipelineOrigin],
       this.scaleFactor
     );
@@ -1736,7 +1736,7 @@ class PipelineView extends React.Component {
     ];
   }
 
-  originTransformMapping(origin, scaleFactor) {
+  originTransformScaling(origin, scaleFactor) {
     /* By multiplying the transform-origin with the scaleFactor we get the right
      * displacement for the transformed/scaled parent (pipelineStepHolder)
      * that avoids visual displacement when the origin of the


### PR DESCRIPTION
This PR introduces a cool new feature to Orchest: the ability to zoom around in the pipeline editor.

Initial version has been tested, but further cross-device testing seems necessary given intricacies of scroll-wheel mouse events.

In this PR two GUI elements (- and + buttons) are added and the behavior of the center button now includes resetting zoom scale to 1.