### PR TITLE
Wrap docker sdk images.list with internal util function

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -139,3 +139,14 @@ def get_orchest_mounts(project_dir, host_project_dir, mount_form="docker-sdk"):
                 mounts.append(mount)
 
     return mounts
+
+
+def docker_images_list_safe(docker_client, *args, attempt_count=10, **kwargs):
+    while True:
+        attempt_count -= 1
+        try:
+            return docker_client.images.list(*args, **kwargs)
+        except Exception as e:
+            logging.debug("Failed to call docker_client.images.list(): %s" % e)
+        if attempt_count == 0:
+            break

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -6,6 +6,7 @@ from app.connections import docker_client
 import app.models as models
 from app.utils import register_schema, remove_if_dangling
 from _orchest.internals import config as _config
+from _orchest.utils import docker_images_list_safe
 
 api = Namespace("environment-images", description="Managing environment images")
 api = register_schema(api)
@@ -58,7 +59,7 @@ class ProjectEnvironmentImages(Resource):
 
         image_names_to_remove = [
             img.attrs["RepoTags"][0]
-            for img in docker_client.images.list()
+            for img in docker_images_list_safe(docker_client)
             if img.attrs["RepoTags"]
             and isinstance(img.attrs["RepoTags"][0], str)
             and img.attrs["RepoTags"][0].startswith(image_name)
@@ -114,7 +115,7 @@ class ProjectEnvironmentDanglingImages(Resource):
             ]
         }
 
-        project_env_images = docker_client.images.list(filters=filters)
+        project_env_images = docker_images_list_safe(docker_client, filters=filters)
 
         for docker_img in project_env_images:
             remove_if_dangling(docker_img)

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -6,7 +6,7 @@ from app.connections import docker_client
 import app.models as models
 from app.utils import register_schema, remove_if_dangling
 from _orchest.internals import config as _config
-from _orchest.utils import docker_images_list_safe
+from _orchest.internals.utils import docker_images_list_safe
 
 api = Namespace("environment-images", description="Managing environment images")
 api = register_schema(api)

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -10,7 +10,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 
 from config import CONFIG_CLASS
 from _orchest.internals import config as _config
-from _orchest.utils import docker_images_list_safe
+from _orchest.internals.utils import docker_images_list_safe
 from app.connections import docker_client
 from app.core.sio_streamed_task import SioStreamedTask
 

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -10,6 +10,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 
 from config import CONFIG_CLASS
 from _orchest.internals import config as _config
+from _orchest.utils import docker_images_list_safe
 from app.connections import docker_client
 from app.core.sio_streamed_task import SioStreamedTask
 
@@ -49,11 +50,11 @@ def cleanup_env_build_docker_artifacts(filters):
     # image is deleted. What we are actually doing here is getting the last image created by the build process
     # by getting all the images created by the build process. Removing n-1 of them will result in a no op,
     # but 1 of them will cause the "ancestor" images to be removed as well.
-    images_to_prune = docker_client.images.list(filters=filters)
+    images_to_prune = docker_images_list_safe(docker_client, filters=filters)
     tries = 0
     while images_to_prune:
         docker_client.images.prune(filters=filters)
-        images_to_prune = docker_client.images.list(filters=filters)
+        images_to_prune = docker_images_list_safe(docker_client, filters=filters)
         # be as responsive as possible, only sleep at the first iteration if necessary
         if images_to_prune:
             tries += 1


### PR DESCRIPTION
By default the Docker SDK for Python suffers from a race condition when calling client.images.list(). As one of the images retrieved by the loop could be missing, in which case it throws an exception:

https://github.com/docker/docker-py/blob/master/docker/models/images.py

This PR wraps the list function to avoid the issue by retrying on failure.