### PR TITLE
Improve InteractiveRun and Experiment POST endpoints

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -183,6 +183,8 @@ class ExperimentList(Resource):
                 # storing and transmitting results) associated to the task.
                 # Uncomment the line below if applicable.
                 res.forget()
+
+            return experiment, 201
         else:
             logging.error("\n".join(experiment_creation_error_messages))
 
@@ -201,7 +203,9 @@ class ExperimentList(Resource):
             ).update({"status": "FAILURE"})
             db.session.commit()
 
-        return experiment, 201
+            return {
+                "message": "Failed to create experiment because not all referenced environments are available."
+            }, 500
 
 
 @api.route("/<string:experiment_uuid>")

--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -190,12 +190,12 @@ class ExperimentList(Resource):
             # and the db while avoiding multiple update statements
             # (1 for each object)
             for pipeline_run in experiment["pipeline_runs"]:
-                pipeline_run.status = "FAILURE"
+                pipeline_run.status = "SUCCESS"
                 for step in pipeline_run["pipeline_steps"]:
                     step.status = "FAILURE"
             models.NonInteractiveRun.query.filter_by(
                 experiment_uuid=post_data["experiment_uuid"]
-            ).update({"status": "FAILURE"})
+            ).update({"status": "SUCCESS"})
             models.NonInteractiveRunPipelineStep.query.filter_by(
                 experiment_uuid=post_data["experiment_uuid"]
             ).update({"status": "FAILURE"})

--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 import uuid
 
 from celery.contrib.abortable import AbortableAsyncResult
@@ -48,9 +49,23 @@ class ExperimentList(Resource):
         scheduled_start = post_data["scheduled_start"]
         scheduled_start = datetime.fromisoformat(scheduled_start)
 
+        experiment = {
+            "experiment_uuid": post_data["experiment_uuid"],
+            "project_uuid": post_data["project_uuid"],
+            "pipeline_uuid": post_data["pipeline_uuid"],
+            "scheduled_start": scheduled_start,
+            "total_number_of_pipeline_runs": len(post_data["pipeline_definitions"]),
+        }
+        db.session.add(models.Experiment(**experiment))
+        db.session.commit()
+
         pipeline_runs = []
         pipeline_run_spec = post_data["pipeline_run_spec"]
         env_uuid_docker_id_mappings = None
+        # this way we write the entire exp to db, but avoid
+        # launching any run (celery task) if we detected a problem
+        startup_error_messages = []
+        tasks_to_launch = []
 
         # TODO: This can be made more efficient, since the pipeline
         #       is the same for all pipeline runs. The only
@@ -96,6 +111,9 @@ class ExperimentList(Resource):
             db.session.bulk_save_objects(pipeline_steps)
             db.session.commit()
 
+            non_interactive_run["pipeline_steps"] = pipeline_steps
+            pipeline_runs.append(non_interactive_run)
+
             # get docker ids of images to use and make it so that the
             # images will not be deleted in case they become
             # outdated by an environment rebuild
@@ -112,10 +130,9 @@ class ExperimentList(Resource):
                         is_interactive=False,
                     )
                 except errors.ImageNotFound as e:
-                    return (
+                    startup_error_messages.append(
                         f"Pipeline was referencing environments for "
-                        f"which an image does not exist, {e}",
-                        500,
+                        f"which an image does not exist, {e}"
                     )
             else:
                 image_mappings = [
@@ -131,49 +148,59 @@ class ExperimentList(Resource):
                 db.session.bulk_save_objects(image_mappings)
                 db.session.commit()
 
-            # Create Celery object with the Flask context and construct the
-            # kwargs for the job.
-            celery = make_celery(current_app)
-            run_config = pipeline_run_spec["run_config"]
-            run_config["env_uuid_docker_id_mappings"] = env_uuid_docker_id_mappings
-            celery_job_kwargs = {
-                "experiment_uuid": post_data["experiment_uuid"],
-                "project_uuid": post_data["project_uuid"],
-                "pipeline_definition": pipeline.to_dict(),
-                "run_config": run_config,
-            }
+            if len(startup_error_messages) == 0:
+                # prepare the args for the task
+                run_config = pipeline_run_spec["run_config"]
+                run_config["env_uuid_docker_id_mappings"] = env_uuid_docker_id_mappings
+                celery_job_kwargs = {
+                    "experiment_uuid": post_data["experiment_uuid"],
+                    "project_uuid": post_data["project_uuid"],
+                    "pipeline_definition": pipeline.to_dict(),
+                    "run_config": run_config,
+                }
 
-            # Start the run as a background task on Celery. Due to circular
-            # imports we send the task by name instead of importing the
-            # function directly.
-            res = celery.send_task(
-                "app.core.tasks.start_non_interactive_pipeline_run",
-                eta=scheduled_start,
-                kwargs=celery_job_kwargs,
-                task_id=task_id,
-            )
-
-            # NOTE: this is only if a backend is configured.  The task does
-            # not return anything. Therefore we can forget its result and
-            # make sure that the Celery backend releases recourses (for
-            # storing and transmitting results) associated to the task.
-            # Uncomment the line below if applicable.
-            res.forget()
-
-            non_interactive_run["pipeline_steps"] = pipeline_steps
-            pipeline_runs.append(non_interactive_run)
-
-        experiment = {
-            "experiment_uuid": post_data["experiment_uuid"],
-            "project_uuid": post_data["project_uuid"],
-            "pipeline_uuid": post_data["pipeline_uuid"],
-            "scheduled_start": scheduled_start,
-            "total_number_of_pipeline_runs": len(pipeline_runs),
-        }
-        db.session.add(models.Experiment(**experiment))
-        db.session.commit()
+                # Due to circular imports we use the task name instead of
+                # importing the function directly.
+                tasks_to_launch.append(
+                    {
+                        "name": "app.core.tasks.start_non_interactive_pipeline_run",
+                        "eta": scheduled_start,
+                        "kwargs": celery_job_kwargs,
+                        "task_id": task_id,
+                    }
+                )
 
         experiment["pipeline_runs"] = pipeline_runs
+
+        if len(startup_error_messages) == 0:
+            # Create Celery object with the Flask context
+            celery = make_celery(current_app)
+            for task in tasks_to_launch:
+                res = celery.send_task(**task)
+                # NOTE: this is only if a backend is configured.  The task does
+                # not return anything. Therefore we can forget its result and
+                # make sure that the Celery backend releases recourses (for
+                # storing and transmitting results) associated to the task.
+                # Uncomment the line below if applicable.
+                res.forget()
+        else:
+            logging.error("\n".join(startup_error_messages))
+
+            # simple way to update both in memory objects
+            # and the db while avoiding multiple update statements
+            # (1 for each object)
+            for pipeline_run in experiment["pipeline_runs"]:
+                pipeline_run.status = "FAILURE"
+                for step in pipeline_run["pipeline_steps"]:
+                    step.status = "FAILURE"
+            models.NonInteractiveRun.query.filter_by(
+                experiment_uuid=post_data["experiment_uuid"]
+            ).update({"status": "FAILURE"})
+            models.NonInteractiveRunPipelineStep.query.filter_by(
+                experiment_uuid=post_data["experiment_uuid"]
+            ).update({"status": "FAILURE"})
+            db.session.commit()
+
         return experiment, 201
 
 

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -106,11 +106,13 @@ class RunList(Resource):
             # simple way to update both in memory objects
             # and the db while avoiding multiple update statements
             # (1 for each object)
-            run["status"] = "FAILURE"
+            # TODO: make it so that the client does not rely
+            # on SUCCESS as a status
+            run["status"] = "SUCCESS"
             for step in run["pipeline_steps"]:
                 step.status = "FAILURE"
             models.InteractiveRun.query.filter_by(run_uuid=task_id).update(
-                {"status": "FAILURE"}
+                {"status": "SUCCESS"}
             )
             models.InteractiveRunPipelineStep.query.filter_by(run_uuid=task_id).update(
                 {"status": "FAILURE"}

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -115,7 +115,7 @@ def build_docker_image(
                 % e
             )
             user_logs_file_object.write(
-                f'Base image `{build_context["base_image"]}` not found. Pulling image...'
+                f'Base image `{build_context["base_image"]}` not found. Pulling image...\n'
             )
         except Exception as e:
             complete_logs_file_object.write(

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -5,6 +5,7 @@ import logging
 import os
 import requests
 import time
+import docker
 
 from celery.contrib.abortable import AbortableAsyncResult
 
@@ -86,13 +87,17 @@ def update_environment_build_status(
 
 
 def build_docker_image(
-    image_name, context_path, dockerfile_path, user_logs_file_object, complete_logs_path
+    image_name,
+    build_context,
+    dockerfile_path,
+    user_logs_file_object,
+    complete_logs_path,
 ):
     """Build a docker image with the given tag, context_path and docker file.
 
     Args:
         image_name:
-        context_path:
+        build_context:
         dockerfile_path:
         user_logs_file_object: file object to which logs from the user script are written.
         complete_logs_path: path to where to store the full logs are written
@@ -102,9 +107,24 @@ def build_docker_image(
     """
     with open(complete_logs_path, "w") as complete_logs_file_object:
 
+        try:
+            docker_client.images.get(build_context["base_image"])
+        except docker.errors.ImageNotFound as e:
+            complete_logs_file_object.write(
+                "Docker error ImageNotFound: need to pull image as part of the build. Error: %s"
+                % e
+            )
+            user_logs_file_object.write(
+                f'Base image `{build_context["base_image"]}` not found. Pulling image...'
+            )
+        except Exception as e:
+            complete_logs_file_object.write(
+                "docker_client.images.get() call to Docker API failed."
+            )
+
         # connect to docker and issue the build
         generator = docker_client.api.build(
-            path=context_path,
+            path=build_context["snapshot_path"],
             dockerfile=dockerfile_path,
             tag=image_name,
             rm=True,
@@ -343,7 +363,10 @@ def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_pat
         docker_ignore.write(".orchest\n")
         docker_ignore.write("%s\n" % docker_file_name)
 
-    return snapshot_path
+    return {
+        "snapshot_path": snapshot_path,
+        "base_image": environment_properties["base_image"],
+    }
 
 
 def build_environment_task(task_uuid, project_uuid, environment_uuid, project_path):

--- a/services/orchest-webserver/app/static/js/views/CreateExperimentView.js
+++ b/services/orchest-webserver/app/static/js/views/CreateExperimentView.js
@@ -208,11 +208,13 @@ class CreateExperimentView extends React.Component {
           this.runExperiment();
         })
         .catch((result) => {
-          requestBuild(
-            this.props.experiment.project_uuid,
-            result.data,
-            "CreateExperiment"
-          );
+          if (result.reason === "gate-failed") {
+            requestBuild(
+              this.props.experiment.project_uuid,
+              result.data,
+              "CreateExperiment"
+            ).catch((e) => {});
+          }
         });
     } else {
       orchest.alert("Error", validation.reason);
@@ -240,83 +242,103 @@ class CreateExperimentView extends React.Component {
       );
     }
 
-    let experimentData = {
+    // TODO: instead of bouncing three requests
+    // (orchest-api, orchest-webserver, orchest-webserver)
+    // perhaps wrap this into one larger request that goes straight
+    // to orchest-webserver (more ACID? - no partial success)
+    let pipelineDefinitions = this.generatePipelineDefinitions(
+      this.state.pipeline,
+      this.state.generatedPipelineRuns,
+      this.state.selectedIndices
+    );
+
+    let pipelineRunIds = new Array(pipelineDefinitions.length);
+    for (let x = 0; x < pipelineRunIds.length; x++) {
+      pipelineRunIds[x] = x + 1;
+    }
+
+    let apiExperimentData = {
+      experiment_uuid: this.props.experiment.uuid,
       pipeline_uuid: this.state.pipeline.uuid,
-      pipeline_name: this.state.pipeline.name,
-      name: this.props.experiment.name,
-      strategy_json: JSON.stringify(this.state.parameterizedSteps),
-      draft: false,
+      project_uuid: this.props.experiment.project_uuid,
+      pipeline_definitions: pipelineDefinitions,
+      pipeline_run_ids: pipelineRunIds,
+      pipeline_run_spec: {
+        run_type: "full",
+        uuids: [],
+      },
+      scheduled_start: formValueScheduledStart,
     };
 
-    makeRequest("PUT", "/store/experiments/" + this.props.experiment.uuid, {
+    makeRequest("POST", "/catch/api-proxy/api/experiments/", {
       type: "json",
-      content: experimentData,
+      content: apiExperimentData,
     })
       .then((response) => {
-        // after storing on the web server trigger the Orchest API
-        let result = JSON.parse(response);
+        let apiResult = JSON.parse(response);
 
-        let experimentUUID = result.uuid;
-
-        let pipelineDefinitions = this.generatePipelineDefinitions(
-          this.state.pipeline,
-          this.state.generatedPipelineRuns,
-          this.state.selectedIndices
-        );
-
-        let pipelineRunIds = new Array(pipelineDefinitions.length);
-        for (let x = 0; x < pipelineRunIds.length; x++) {
-          pipelineRunIds[x] = x + 1;
-        }
-
-        let apiExperimentData = {
-          experiment_uuid: experimentUUID,
+        let experimentData = {
           pipeline_uuid: this.state.pipeline.uuid,
-          project_uuid: this.props.experiment.project_uuid,
-          pipeline_definitions: pipelineDefinitions,
-          pipeline_run_ids: pipelineRunIds,
-          pipeline_run_spec: {
-            run_type: "full",
-            uuids: [],
-          },
-          scheduled_start: formValueScheduledStart,
+          pipeline_name: this.state.pipeline.name,
+          name: this.props.experiment.name,
+          strategy_json: JSON.stringify(this.state.parameterizedSteps),
+          draft: false,
         };
 
-        makeRequest("POST", "/catch/api-proxy/api/experiments/", {
-          type: "json",
-          content: apiExperimentData,
-        })
-          .then((response) => {
-            let result = JSON.parse(response);
+        let webserverPromises = [];
 
-            // TODO: instead of bouncing three requests
-            // (orchest-webserver, orchest-api, orchest-webserver)
-            // perhaps wrap this into one larger request that goes straight
-            // to orchest-webserver (more ACID? - no partial success)
-            makeRequest("POST", "/async/pipelineruns/create", {
-              type: "json",
-              content: {
-                experiment_uuid: experimentUUID,
-                generated_pipeline_runs: this.state.generatedPipelineRuns,
-                experiment_json: result,
-                pipeline_run_ids: pipelineRunIds,
-              },
-            })
-              .then(() => {
-                orchest.loadView(ExperimentsView, {
-                  project_uuid: this.props.experiment.project_uuid,
-                });
-              })
-              .catch((e) => {
-                console.log(e);
-              });
-          })
-          .catch((e) => {
-            console.log(e);
+        let storeExperimentPromise = makeRequest(
+          "PUT",
+          "/store/experiments/" + this.props.experiment.uuid,
+          {
+            type: "json",
+            content: experimentData,
+          }
+        );
+        webserverPromises.push(storeExperimentPromise);
+
+        storeExperimentPromise.catch((e) => {
+          console.log(e);
+        });
+
+        let pipelineRunsPromise = makeRequest(
+          "POST",
+          "/async/pipelineruns/create",
+          {
+            type: "json",
+            content: {
+              experiment_uuid: experimentUUID,
+              generated_pipeline_runs: this.state.generatedPipelineRuns,
+              experiment_json: apiResult,
+              pipeline_run_ids: pipelineRunIds,
+            },
+          }
+        );
+        webserverPromises.push(pipelineRunsPromise);
+
+        pipelineRunsPromise.catch((e) => {
+          console.log(e);
+        });
+
+        Promise.all(webserverPromises).then(() => {
+          orchest.loadView(ExperimentsView, {
+            project_uuid: this.props.experiment.project_uuid,
           });
+        });
       })
-      .catch((e) => {
-        console.log(e);
+      .catch((response) => {
+        try {
+          let data = JSON.parse(response.body);
+          orchest.alert(
+            "Error",
+            "There was a problem submitting your experiment. " + data.message
+          );
+        } catch {
+          orchest.alert(
+            "Error",
+            "There was a problem submitting your experiment. Unknown error."
+          );
+        }
       });
   }
 


### PR DESCRIPTION
This PR is a minor refactor of the API endpoints for POSTing interactive runs and experiments. 

It improves logging and storing to db in the case of a failure that made it impossible to start a run (interactive or belonging to an experiment) through the request.

Moreover, it delivers an improved experience in the case a user is actually able to start an interactive run through the GUI when a docker image which is a dependency of the pipeline has been deleted. The GUI will now correctly display a failure and the right button(s), e.g. the run won't be stuck in a permanent pending (and cancelable) state anymore.