### PR TITLE
Fix memory server allocation

### DIFF
--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -583,7 +583,10 @@ def _get_container_specs(
     # TODO: Fix `shm_size` passing to the memory-server once we know the
     # exact conversion between shm-size of Docker and the size of the
     # store.
-    shm_size = utils.calculate_shm_size(data_passing_memory_size)
+    data_passing_memory_size_int = utils.parse_string_memory_size(
+        data_passing_memory_size
+    )
+    shm_size = utils.calculate_shm_size(data_passing_memory_size_int)
     container_specs["memory-server"] = {
         "image": "orchest/memory-server:latest",
         "detach": True,
@@ -594,7 +597,7 @@ def _get_container_specs(
         "shm_size": shm_size,
         "environment": [
             f"ORCHEST_PIPELINE_PATH={pipeline_path}",
-            f"ORCHEST_MEMORY_SIZE={shm_size}",
+            f"ORCHEST_MEMORY_SIZE={data_passing_memory_size_int}",
         ],
         # Labels are used to have a way of keeping track of the
         # containers attributes through ``Session.from_container_IDs``

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -362,7 +362,7 @@ def remove_if_dangling(img) -> bool:
 
 
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
-    """Returns string value of memory in bytes"""
+    """Returns value of memory in bytes specified by input string"""
 
     # seems like this is already int (assumed to be number of bytes)
     if isinstance(memory_size, int):

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -390,7 +390,6 @@ def calculate_shm_size(data_passing_memory_size: int) -> int:
         The shm-size for the Docker container.
 
     """
-    # The default `shm_size` of a container is 67108864. So we round
-    # it up, just to be safe.
-    allocation = 80000000
-    return data_passing_memory_size + allocation
+    # We need to overallocate by a fraction of 1.2 to make /dev/shm large enough for the
+    # request amount in `data_passing_memory_size`
+    return int(data_passing_memory_size * 1.2)

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -383,6 +383,10 @@ def calculate_shm_size(data_passing_memory_size: int) -> int:
     the Docker container is not equal to the request size for the
     memory-server.
 
+    If the Plasma server tries to allocate more than is available in /dev/shm it
+    will not fail but issue a warning. However, not full amount requested will be
+    available to the user.
+
     Args:
         data_passing_memory_size: Requested size for the memory-server.
 
@@ -390,6 +394,6 @@ def calculate_shm_size(data_passing_memory_size: int) -> int:
         The shm-size for the Docker container.
 
     """
-    # We need to overallocate by a fraction of 1.2 to make /dev/shm large enough for the
+    # We need to overallocate by a fraction to make /dev/shm large enough for the
     # request amount in `data_passing_memory_size`
     return int(data_passing_memory_size * 1.2)

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -393,5 +393,4 @@ def calculate_shm_size(data_passing_memory_size: int) -> int:
     # The default `shm_size` of a container is 67108864. So we round
     # it up, just to be safe.
     allocation = 80000000
-
-    return size + allocation
+    return data_passing_memory_size + allocation

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -364,7 +364,7 @@ def remove_if_dangling(img) -> bool:
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
     """Simply converts string description of memory size to number of bytes
 
-    Allowable inputs are: [KB|MB|GB]+\s+[\d]+
+    Allowable inputs are: [\d]+\s+[KB|MB|GB]+
     """
 
     # seems like this is already int (assumed to be number of bytes)

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -384,8 +384,8 @@ def calculate_shm_size(data_passing_memory_size: int) -> int:
     memory-server.
 
     If the Plasma server tries to allocate more than is available in /dev/shm it
-    will not fail but issue a warning. However, not full amount requested will be
-    available to the user.
+    will not fail but issue a warning. However, the full amount requested will
+    not be available to the user.
 
     Args:
         data_passing_memory_size: Requested size for the memory-server.

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -368,7 +368,7 @@ def parse_string_memory_size(memory_size: Union[str, int]) -> int:
     if isinstance(memory_size, int):
         return memory_size
 
-    conversion = {"KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3}
+    conversion = {"KB": 1000, "MB": 1000 ** 2, "GB": 1000 ** 3}
     size, unit = memory_size[:-2], memory_size[-2:]
     size = int(float(size) * conversion[unit])
 

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -361,7 +361,21 @@ def remove_if_dangling(img) -> bool:
     return False
 
 
-def calculate_shm_size(data_passing_memory_size: Union[str, int]) -> int:
+def parse_string_memory_size(memory_size: Union[str, int]) -> int:
+    """Returns string value of memory in bytes"""
+
+    # seems like this is already int (assumed to be number of bytes)
+    if isinstance(memory_size, int):
+        return memory_size
+
+    conversion = {"KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3}
+    size, unit = memory_size[:-2], memory_size[-2:]
+    size = int(float(size) * conversion[unit])
+
+    return size
+
+
+def calculate_shm_size(data_passing_memory_size: int) -> int:
     """Calculates the shm-size for the Docker container.
 
     Given a size for the memory-server we need to do a certain
@@ -379,10 +393,5 @@ def calculate_shm_size(data_passing_memory_size: Union[str, int]) -> int:
     # The default `shm_size` of a container is 67108864. So we round
     # it up, just to be safe.
     allocation = 80000000
-    if isinstance(data_passing_memory_size, int):
-        return data_passing_memory_size + allocation
 
-    conversion = {"KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3}
-    size, unit = data_passing_memory_size[:-2], data_passing_memory_size[-2:]
-    size = int(float(size) * conversion[unit])
     return size + allocation

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -364,7 +364,7 @@ def remove_if_dangling(img) -> bool:
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
     """Simply converts string description of memory size to number of bytes
 
-    Allowable inputs are: [\d]+\s*[KB|MB|GB]+
+    Allowable inputs are: [\d]+\s*(KB|MB|GB)+
     """
 
     # seems like this is already int (assumed to be number of bytes)

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -362,7 +362,7 @@ def remove_if_dangling(img) -> bool:
 
 
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
-    """Returns value of memory in bytes specified by input string"""
+    """Simply converts string memory size to number of bytes"""
 
     # seems like this is already int (assumed to be number of bytes)
     if isinstance(memory_size, int):

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -362,7 +362,10 @@ def remove_if_dangling(img) -> bool:
 
 
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
-    """Simply converts string memory size to number of bytes"""
+    """Simply converts string description of memory size to number of bytes
+
+    Allowable inputs are: [KB|MB|GB]+\s+[\d]+
+    """
 
     # seems like this is already int (assumed to be number of bytes)
     if isinstance(memory_size, int):

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -364,7 +364,7 @@ def remove_if_dangling(img) -> bool:
 def parse_string_memory_size(memory_size: Union[str, int]) -> int:
     """Simply converts string description of memory size to number of bytes
 
-    Allowable inputs are: [\d]+\s+[KB|MB|GB]+
+    Allowable inputs are: [\d]+\s*[KB|MB|GB]+
     """
 
     # seems like this is already int (assumed to be number of bytes)


### PR DESCRIPTION
Overallocating by a fraction instead of a fixed size to increase the probability with which the user gets exactly the requested size for the memory server.