### PR TITLE
Remove deprecated pyarrow.serialize/deserialize calls, make memory passing more efficient.

### DIFF
--- a/orchest-sdk/python/orchest/transfer.py
+++ b/orchest-sdk/python/orchest/transfer.py
@@ -144,7 +144,6 @@ def _output_to_disk(
     if isinstance(serialization, Serialization):
         with pa.OSFile(f"{full_path}.{serialization}", "wb") as f:
             f.write(obj)
-            f.close()
     else:
         raise ValueError("Function not defined for specified 'serialization'")
 

--- a/orchest-sdk/python/orchest/transfer.py
+++ b/orchest-sdk/python/orchest/transfer.py
@@ -215,7 +215,7 @@ def _get_output_disk(full_path: str, serialization: str) -> Any:
     """Gets data from disk.
 
     Raises:
-        ValueError: If the serialization argument is invalid.
+        ValueError: If the serialization argument is unsupported.
     """
     file_path = f"{full_path}.{serialization}"
     if serialization == Serialization.ARROW_TABLE.name:
@@ -245,7 +245,7 @@ def _get_output_disk(full_path: str, serialization: str) -> Any:
         with open(file_path, "rb") as input_file:
             return pickle.load(input_file)
     else:
-        raise ValueError("The specified serialization is invalid: %s")
+        raise ValueError("The specified serialization is unsupported: %s")
 
 
 def get_output_disk(step_uuid: str, serialization: Serialization) -> Any:
@@ -521,7 +521,7 @@ def _get_output_memory(obj_id: plasma.ObjectID, client: plasma.PlasmaClient) -> 
         return pickle.loads(buffer)
 
     else:
-        raise ValueError("Object was serialized with an invalid serialization")
+        raise ValueError("Object was serialized with an unsupported serialization")
 
 
 def get_output_memory(step_uuid: str, consumer: Optional[str] = None) -> Any:

--- a/orchest-sdk/python/requirements.txt
+++ b/orchest-sdk/python/requirements.txt
@@ -1,4 +1,4 @@
 SQLAlchemy
 boto3
-pyarrow==1.0.1
+pyarrow==2.0.0
 requests

--- a/orchest-sdk/python/requirements.txt
+++ b/orchest-sdk/python/requirements.txt
@@ -1,5 +1,5 @@
 SQLAlchemy
 boto3
 pandas 
-pyarrow==2.0.0
+pyarrow>=2.0.0
 requests

--- a/orchest-sdk/python/requirements.txt
+++ b/orchest-sdk/python/requirements.txt
@@ -1,4 +1,5 @@
 SQLAlchemy
 boto3
+pandas 
 pyarrow==2.0.0
 requests

--- a/orchest-sdk/python/requirements.txt
+++ b/orchest-sdk/python/requirements.txt
@@ -1,5 +1,5 @@
 SQLAlchemy
 boto3
 pandas 
-pyarrow>=2.0.0
+pyarrow>=2.0.0,<3.0.0
 requests

--- a/orchest-sdk/python/setup.py
+++ b/orchest-sdk/python/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     version="0.2.0",
     packages=setuptools.find_packages(),
     install_requires=[
-        "pyarrow==2.0.0",
+        "pyarrow>=2.0.0",
         "boto3>=1.13.26",
         "requests>=2.23.0",
         "SQLAlchemy>=1.3.18",

--- a/orchest-sdk/python/setup.py
+++ b/orchest-sdk/python/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     version="0.2.0",
     packages=setuptools.find_packages(),
     install_requires=[
-        "pyarrow==1.0.1",
+        "pyarrow==2.0.0",
         "boto3>=1.13.26",
         "requests>=2.23.0",
         "SQLAlchemy>=1.3.18",

--- a/orchest-sdk/python/setup.py
+++ b/orchest-sdk/python/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     version="0.2.0",
     packages=setuptools.find_packages(),
     install_requires=[
-        "pyarrow>=2.0.0",
+        "pyarrow>=2.0.0,<3.0.0",
         "boto3>=1.13.26",
         "requests>=2.23.0",
         "SQLAlchemy>=1.3.18",

--- a/orchest-sdk/python/tests/test_transfer.py
+++ b/orchest-sdk/python/tests/test_transfer.py
@@ -152,7 +152,8 @@ def test_memory(mock_get_step_uuid, data_1, test_transfer, plasma_store):
 @patch("orchest.Config.STEP_DATA_DIR", "tests/userdir/.data/{step_uuid}")
 def test_memory_out_of_memory(mock_get_step_uuid, plasma_store):
     data_1 = generate_data((PLASMA_KILOBYTES + 1) * KILOBYTE)
-    data_size = pa.serialize(data_1).total_bytes
+    ser_data, _ = transfer.serialize(data_1)
+    data_size = ser_data.size
     assert data_size > PLASMA_STORE_CAPACITY
 
     orchest.Config.PIPELINE_DEFINITION_PATH = "tests/userdir/pipeline-basic.json"
@@ -174,7 +175,8 @@ def test_memory_disk_fallback(mock_get_step_uuid, plasma_store):
 
     # Do as if we are uuid-1
     data_1 = generate_data((PLASMA_KILOBYTES + 1) * KILOBYTE)
-    data_size = pa.serialize(data_1).total_bytes
+    ser_data, _ = transfer.serialize(data_1)
+    data_size = ser_data.size
     assert data_size > PLASMA_STORE_CAPACITY
 
     mock_get_step_uuid.return_value = "uuid-1______________"

--- a/orchest-sdk/python/tests/test_transfer.py
+++ b/orchest-sdk/python/tests/test_transfer.py
@@ -26,18 +26,20 @@ def generate_data(total_size):
     nrows = int(total_size / np.dtype("float64").itemsize)
     return np.random.randn(nrows)
 
+
 def get_test_record_batch():
     test_record_batch = [
         pa.array([1, 2, 3, 4]),
-        pa.array(['foo', 'bar', 'baz', None]),
-        pa.array([True, None, False, True])
-        ]
-    test_record_batch = pa.record_batch(
-        test_record_batch, names=['f0', 'f1', 'f2'])
+        pa.array(["foo", "bar", "baz", None]),
+        pa.array([True, None, False, True]),
+    ]
+    test_record_batch = pa.record_batch(test_record_batch, names=["f0", "f1", "f2"])
     return test_record_batch
+
 
 def get_test_table():
     return pa.Table.from_batches([get_test_record_batch()])
+
 
 class CustomClass:
     def __init__(self, x):
@@ -70,9 +72,9 @@ def plasma_store(monkeypatch):
         np.random.rand(10, 5, 2),
         np.array([CustomClass(1) for _ in range(3)]),
         get_test_record_batch(),
-        get_test_table()
+        get_test_table(),
     ],
-    ids=["basic", "ndarray", "ndarray-objects", "record_batch", "table"]
+    ids=["basic", "ndarray", "ndarray-objects", "record_batch", "table"],
 )
 @pytest.mark.parametrize(
     "test_transfer",
@@ -96,12 +98,10 @@ def test_disk(mock_get_step_uuid, data_1, test_transfer, plasma_store):
     mock_get_step_uuid.return_value = "uuid-2______________"
     input_data = transfer.get_inputs()
 
-    if isinstance(data_1, pa.RecordBatch) or \
-        isinstance(data_1, pa.Table):
+    if isinstance(data_1, (pa.RecordBatch, pa.Table)):
         assert input_data[0].equals(data_1)
     else:
         assert (input_data == data_1).all()
-
 
 
 # TODO: add tests for other kwargs
@@ -112,9 +112,9 @@ def test_disk(mock_get_step_uuid, data_1, test_transfer, plasma_store):
         np.random.rand(10, 5, 2),
         np.array([CustomClass(1) for _ in range(3)]),
         get_test_record_batch(),
-        get_test_table()
+        get_test_table(),
     ],
-    ids=["basic", "ndarray", "ndarray-objects", "record_batch", "table"]
+    ids=["basic", "ndarray", "ndarray-objects", "record_batch", "table"],
 )
 @pytest.mark.parametrize(
     "test_transfer",
@@ -142,8 +142,7 @@ def test_memory(mock_get_step_uuid, data_1, test_transfer, plasma_store):
     mock_get_step_uuid.return_value = "uuid-2______________"
     input_data = transfer.get_inputs()
 
-    if isinstance(data_1, pa.RecordBatch) or \
-        isinstance(data_1, pa.Table):
+    if isinstance(data_1, (pa.RecordBatch, pa.Table)):
         assert input_data[0].equals(data_1)
     else:
         assert (input_data == data_1).all()
@@ -194,10 +193,7 @@ def test_memory_disk_fallback(mock_get_step_uuid, plasma_store):
 @patch("orchest.transfer.get_step_uuid")
 @patch("orchest.Config.STEP_DATA_DIR", "tests/userdir/.data/{step_uuid}")
 def test_memory_pickle_fallback_and_disk_fallback(mock_get_step_uuid, plasma_store):
-    data_1 = [
-        CustomClass(generate_data(KILOBYTE))
-        for _ in range(PLASMA_KILOBYTES + 1)
-    ]
+    data_1 = [CustomClass(generate_data(KILOBYTE)) for _ in range(PLASMA_KILOBYTES + 1)]
     serialized, _ = transfer.serialize(data_1)
     assert serialized.size > PLASMA_STORE_CAPACITY
 

--- a/services/memory-server/requirements-dev.txt
+++ b/services/memory-server/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements.txt
 networkx==2.4
-pyarrow==1.0.1
+pyarrow==2.0.0
 -e ../../orchest-sdk/python
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements-dev.txt
+++ b/services/memory-server/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements.txt
 networkx==2.4
-pyarrow==2.0.0
+pyarrow>=2.0.0
 -e ../../orchest-sdk/python
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements-dev.txt
+++ b/services/memory-server/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements.txt
 networkx==2.4
-pyarrow>=2.0.0
+pyarrow>=2.0.0,<3.0.0
 -e ../../orchest-sdk/python
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements.txt
+++ b/services/memory-server/requirements.txt
@@ -1,5 +1,5 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements-dev.txt
 networkx==2.4
-pyarrow>=2.0.0
+pyarrow>=2.0.0,<3.0.0
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements.txt
+++ b/services/memory-server/requirements.txt
@@ -1,5 +1,5 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements-dev.txt
 networkx==2.4
-pyarrow==2.0.0
+pyarrow>=2.0.0
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements.txt
+++ b/services/memory-server/requirements.txt
@@ -1,5 +1,5 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements-dev.txt
 networkx==2.4
-pyarrow==1.0.1
+pyarrow==2.0.0
 -e ../../lib/python/orchest-internals


### PR DESCRIPTION
This PR aims to remove references to `pyarrow.serialize` and `pyarrow.deserialize` since they are
deprecated.

It improves data serialization by avoiding an unnecessary serialization that was previously
done to pickles.

Getting data from memory and disk has been made more efficient by avoiding unnecessary
copies of in-memory data.

