### PR TITLE
File viewer hierarchical navigation and refresh

### DIFF
--- a/services/base-images/runnable-shared/runner/runner/runners.py
+++ b/services/base-images/runnable-shared/runner/runner/runners.py
@@ -92,23 +92,24 @@ class NotebookRunner(Runner):
         # TODO: extend this mapping
         kernel_mapping = {"python": "python3", "r": "ir", "julia": "julia-1.5"}
 
-        nb = None
-
         with open(file_path) as f:
             nb = nbformat.read(f, as_version=4)
 
-            original_nb_kernelspec_name = nb.metadata.kernelspec.name
+        original_nb_kernelspec_name = nb.metadata.kernelspec.name
 
-            # set kernel based on language
-            nb.metadata.kernelspec.name = kernel_mapping[
-                nb.metadata.kernelspec.language
-            ]
+        # set kernel based on language
+        nb.metadata.kernelspec.name = kernel_mapping[nb.metadata.kernelspec.language]
 
-            # log file
-            log_file_path = self.get_log_file_path()
-            with open(log_file_path, "a") as log_file:
-                ep = PartialExecutePreprocessor(log_file=log_file)
-                ep.preprocess(nb, {"metadata": {"path": self.working_dir}})
+        # log file
+        log_file_path = self.get_log_file_path()
+        with open(log_file_path, "a") as log_file:
+            ep = PartialExecutePreprocessor(
+                log_file=log_file,
+                nb_path=file_path,
+                write_after_run=self.write_after_run,
+                original_kernelspec_name=original_nb_kernelspec_name,
+            )
+            ep.preprocess(nb, {"metadata": {"path": self.working_dir}})
 
         if self.write_after_run:
             with open(file_path, "w", encoding="utf-8") as f:

--- a/services/orchest-api/app/app/core/pipelines.py
+++ b/services/orchest-api/app/app/core/pipelines.py
@@ -290,7 +290,17 @@ class PipelineStepRunner:
             # The status code will be 0 for "SUCCESS" and -N otherwise. A
             # negative value -N indicates that the child was terminated
             # by signal N (POSIX only).
-            self._status = "FAILURE" if data.get("StatusCode") else "SUCCESS"
+            if data.get("StatusCode") != 0:
+                self._status = "FAILURE"
+                logging.error(
+                    "Docker container for step %s failed with output:\n%s"
+                    % (
+                        self.properties["uuid"],
+                        "".join(await container.log(stdout=True, stderr=True)),
+                    )
+                )
+            else:
+                self._status = "SUCCESS"
 
         except Exception as e:
             logging.error("Failed to run Docker container: %s" % e)

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -395,7 +395,6 @@ aside.mdc-drawer {
 
   .react-codemirror2 {
     padding: $generalPadding;
-    padding-bottom: 0;
 
     .CodeMirror {
       width: 100%;
@@ -464,6 +463,13 @@ button.text-button {
   top: $generalPadding;
   right: $generalPadding;
   z-index: 99;
+
+  button {
+    margin-left: 10px;
+    &:first-of-type {
+      margin-left: 0;
+    }
+  }
 }
 
 .view-pipeline-settings {

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -12,7 +12,7 @@ $generalPadding: 20px;
 $mdcComponentPadding: 16px;
 $codeSize: 14px;
 $defaultFontSize: 15px;
-$borderColor: rgba(0, 0, 0, 0.15);
+$borderColor: rgba(0, 0, 0, 0.12);
 $stepBorderRadius: 6px;
 
 $pipelineStepHeight: 105px;
@@ -344,8 +344,44 @@ aside.mdc-drawer {
   p {
     padding: $generalPadding;
 
-    h4 {
+    h3 {
       font-weight: 500;
+    }
+  }
+
+  .file-description {
+    border-bottom: 1px solid $borderColor;
+    z-index: 9;
+
+    .step-navigation {
+      overflow: auto;
+      padding-top: $generalPadding;
+
+      .parents {
+        float: left;
+        button {
+          margin-right: $mdcComponentPadding;
+          &:last-of-type {
+            margin-right: 0;
+          }
+        }
+      }
+      .children {
+        float: right;
+        text-align: right;
+
+        button {
+          margin-left: $mdcComponentPadding;
+          &:last-of-type {
+            margin-left: 0;
+          }
+        }
+      }
+      span {
+        font-size: $codeSize;
+        display: block;
+        color: #999;
+      }
     }
   }
 
@@ -359,18 +395,15 @@ aside.mdc-drawer {
 
   .react-codemirror2 {
     padding: $generalPadding;
+    padding-bottom: 0;
 
-    .cm-s-default {
+    .CodeMirror {
       width: 100%;
       height: 100%;
     }
 
     width: 100%;
     height: 100%;
-  }
-
-  .close-button {
-    z-index: 99;
   }
 }
 
@@ -416,10 +449,21 @@ iframe.fullsize {
   }
 }
 
-.close-button {
+button.text-button {
+  border: 0;
+  border-bottom: 1px dotted #c6cbd1;
+  background: none;
+  &:hover {
+    border-bottom: 1px solid black;
+  }
+  cursor: pointer;
+}
+
+.top-buttons {
   position: absolute;
   top: $generalPadding;
   right: $generalPadding;
+  z-index: 99;
 }
 
 .view-pipeline-settings {

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -372,7 +372,7 @@ aside.mdc-drawer {
 
         button {
           margin-left: $mdcComponentPadding;
-          &:last-of-type {
+          &:first-of-type {
             margin-left: 0;
           }
         }

--- a/services/orchest-webserver/app/static/js/jupyter/Jupyter.js
+++ b/services/orchest-webserver/app/static/js/jupyter/Jupyter.js
@@ -1,13 +1,13 @@
+import { setWithRetry } from "../utils/webserver-utils";
+
 class Jupyter {
   constructor(jupyterHolderJEl) {
     this.jupyterHolder = jupyterHolderJEl;
     this.iframe = undefined;
+    this.baseAddress = "";
+    this.reloadOnShow = false;
 
     this.initializeJupyter();
-
-    this.baseAddress = "";
-
-    this.reloadOnShow = false;
   }
 
   updateJupyterInstance(baseAddress) {
@@ -87,7 +87,7 @@ class Jupyter {
       this.iframe.contentWindow._orchest_docmanager.openOrReveal(filePath);
     } else {
       this.setJupyterAddress(
-        this.baseAddress + "/lab/workspaces/main/tree/" + filePath
+        this.baseAddress + "/lab/workspaces/main/tree/" + filePath + "?reset"
       );
     }
   }

--- a/services/orchest-webserver/app/static/js/utils/webserver-utils.js
+++ b/services/orchest-webserver/app/static/js/utils/webserver-utils.js
@@ -183,3 +183,32 @@ export function getPipelineJSONEndpoint(
   }
   return pipelineURL;
 }
+
+export function getPipelineStepParents(stepUUID, pipelineJSON) {
+  let incomingConnections = [];
+  for (let [_, step] of Object.entries(pipelineJSON.steps)) {
+    if (step.uuid == stepUUID) {
+      incomingConnections = step.incoming_connections;
+      break;
+    }
+  }
+
+  let parentSteps = [];
+  for (let parentStepUUID of incomingConnections) {
+    parentSteps.push(pipelineJSON.steps[parentStepUUID]);
+  }
+
+  return parentSteps;
+}
+
+export function getPipelineStepChildren(stepUUID, pipelineJSON) {
+  let childSteps = [];
+
+  for (let [_, step] of Object.entries(pipelineJSON.steps)) {
+    if (step.incoming_connections.indexOf(stepUUID) !== -1) {
+      childSteps.push(step);
+    }
+  }
+
+  return childSteps;
+}

--- a/services/orchest-webserver/app/static/js/views/FilePreviewView.js
+++ b/services/orchest-webserver/app/static/js/views/FilePreviewView.js
@@ -1,13 +1,19 @@
 import React, { Fragment } from "react";
 import MDCButtonReact from "../lib/mdc-components/MDCButtonReact";
 import PipelineView from "./PipelineView";
-import { makeRequest, PromiseManager, makeCancelable } from "../lib/utils/all";
+import {
+  makeRequest,
+  PromiseManager,
+  RefManager,
+  makeCancelable,
+} from "../lib/utils/all";
 import MDCLinearProgressReact from "../lib/mdc-components/MDCLinearProgressReact";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import {
   getPipelineJSONEndpoint,
   getPipelineStepParents,
   getPipelineStepChildren,
+  setWithRetry,
 } from "../utils/webserver-utils";
 require("codemirror/mode/python/python");
 require("codemirror/mode/shell/shell");
@@ -16,6 +22,10 @@ require("codemirror/mode/r/r");
 class FilePreviewView extends React.Component {
   componentWillUnmount() {
     this.promiseManager.cancelCancelablePromises();
+
+    for (let interval of this.retryIntervals) {
+      clearInterval(interval);
+    }
   }
 
   loadPipelineView() {
@@ -42,13 +52,15 @@ class FilePreviewView extends React.Component {
 
     this.state = {
       notebookHtml: undefined,
-      textFile: undefined,
+      fileDescription: undefined,
       loadingFile: true,
       parentSteps: [],
       childSteps: [],
     };
 
+    this.refManager = new RefManager();
     this.promiseManager = new PromiseManager();
+    this.retryIntervals = [];
   }
 
   componentDidUpdate(prevProps) {
@@ -65,7 +77,7 @@ class FilePreviewView extends React.Component {
     return new Promise((resolve, reject) => {
       this.setState({
         loadingFile: true,
-        textFile: undefined,
+        fileDescription: undefined,
       });
 
       let pipelineURL = this.props.pipelineRun
@@ -110,26 +122,33 @@ class FilePreviewView extends React.Component {
   }
 
   fetchAll() {
-    this.setState({
-      loadingFile: true,
-    });
-
-    let fetchAllPromise = makeCancelable(
-      Promise.all([this.fetchFile(), this.fetchPipeline()]),
-      this.promiseManager
-    );
-
-    fetchAllPromise.promise.then(() => {
+    return new Promise((resolve, reject) => {
       this.setState({
-        loadingFile: false,
+        loadingFile: true,
       });
+
+      let fetchAllPromise = makeCancelable(
+        Promise.all([this.fetchFile(), this.fetchPipeline()]),
+        this.promiseManager
+      );
+
+      fetchAllPromise.promise
+        .then(() => {
+          this.setState({
+            loadingFile: false,
+          });
+          resolve();
+        })
+        .catch(() => {
+          reject();
+        });
     });
   }
 
   fetchFile() {
     return new Promise((resolve, reject) => {
       this.setState({
-        textFile: undefined,
+        fileDescription: undefined,
       });
 
       let fileURL = `/async/file-viewer/${this.props.project_uuid}/${this.props.pipeline_uuid}/${this.props.step_uuid}`;
@@ -146,7 +165,7 @@ class FilePreviewView extends React.Component {
       fetchFilePromise.promise
         .then((response) => {
           this.setState({
-            textFile: JSON.parse(response),
+            fileDescription: JSON.parse(response),
           });
           resolve();
         })
@@ -176,17 +195,72 @@ class FilePreviewView extends React.Component {
     ));
   }
 
+  refreshFile() {
+    // cache scroll position
+    this.cachedScrollPosition = 0;
+    if (
+      this.state.fileDescription.ext == "ipynb" &&
+      this.refManager.refs.htmlNotebookIframe
+    ) {
+      this.cachedScrollPosition = this.refManager.refs.htmlNotebookIframe.contentWindow.scrollY;
+    } else if (this.refManager.refs.fileViewer) {
+      this.cachedScrollPosition = this.refManager.refs.fileViewer.scrollTop;
+    }
+
+    this.fetchAll().then(() => {
+      if (
+        this.state.fileDescription.ext == "ipynb" &&
+        this.refManager.refs.htmlNotebookIframe
+      ) {
+        this.retryIntervals.push(
+          setWithRetry(
+            this.cachedScrollPosition,
+            (value) => {
+              this.refManager.refs.htmlNotebookIframe.contentWindow.scrollTo(
+                this.refManager.refs.htmlNotebookIframe.contentWindow.scrollX,
+                value
+              );
+            },
+            () => {
+              return this.refManager.refs.htmlNotebookIframe.contentWindow
+                .scrollY;
+            },
+            25,
+            100
+          )
+        );
+      } else if (this.refManager.refs.fileViewer) {
+        this.retryIntervals.push(
+          setWithRetry(
+            this.cachedScrollPosition,
+            (value) => {
+              this.refManager.refs.fileViewer.scrollTop = value;
+            },
+            () => {
+              return this.refManager.refs.fileViewer.scrollTop;
+            },
+            25,
+            100
+          )
+        );
+      }
+    });
+  }
+
   render() {
     let parentStepElements = this.renderNavStep(this.state.parentSteps);
     let childStepElements = this.renderNavStep(this.state.childSteps);
 
     return (
-      <div className={"view-page file-viewer no-padding"}>
+      <div
+        className={"view-page file-viewer no-padding"}
+        ref={this.refManager.nrefs.fileViewer}
+      >
         <div className="top-buttons">
           <MDCButtonReact
-            classNames={["refresh-button padding-right"]}
+            classNames={["refresh-button"]}
             icon="refresh"
-            onClick={this.fetchAll.bind(this)}
+            onClick={this.refreshFile.bind(this)}
           />
           <MDCButtonReact
             classNames={["close-button"]}
@@ -201,9 +275,9 @@ class FilePreviewView extends React.Component {
           } else {
             let fileComponent;
 
-            if (this.state.textFile.ext != "ipynb") {
+            if (this.state.fileDescription.ext != "ipynb") {
               let fileMode = this.MODE_MAPPING[
-                this.state.textFile.ext.toLowerCase()
+                this.state.fileDescription.ext.toLowerCase()
               ];
               if (!fileMode) {
                 fileMode = null;
@@ -211,7 +285,7 @@ class FilePreviewView extends React.Component {
 
               fileComponent = (
                 <CodeMirror
-                  value={this.state.textFile.content}
+                  value={this.state.fileDescription.content}
                   options={{
                     mode: fileMode,
                     theme: "jupyter",
@@ -220,11 +294,12 @@ class FilePreviewView extends React.Component {
                   }}
                 />
               );
-            } else if (this.state.textFile.ext == "ipynb") {
+            } else if (this.state.fileDescription.ext == "ipynb") {
               fileComponent = (
                 <iframe
+                  ref={this.refManager.nrefs.htmlNotebookIframe}
                   className={"notebook-iframe borderless fullsize"}
-                  srcDoc={this.state.textFile.content}
+                  srcDoc={this.state.fileDescription.content}
                 ></iframe>
               );
             } else {
@@ -242,8 +317,8 @@ class FilePreviewView extends React.Component {
               <Fragment>
                 <div className="file-description">
                   <h3>
-                    Step: {this.state.textFile.step_title} (
-                    {this.state.textFile.filename})
+                    Step: {this.state.fileDescription.step_title} (
+                    {this.state.fileDescription.filename})
                   </h3>
                   <div className="step-navigation">
                     <div className="parents">
@@ -257,9 +332,6 @@ class FilePreviewView extends React.Component {
                   </div>
                 </div>
                 <div className="file-holder">{fileComponent}</div>
-                <p>
-                  <i>Read only.</i>
-                </p>
               </Fragment>
             );
           }

--- a/services/orchest-webserver/app/static/js/views/FilePreviewView.js
+++ b/services/orchest-webserver/app/static/js/views/FilePreviewView.js
@@ -66,8 +66,7 @@ class FilePreviewView extends React.Component {
   componentDidUpdate(prevProps) {
     if (
       this.props.step_uuid !== prevProps.step_uuid ||
-      this.props.pipeline_uuid !== prevProps.pipeline_uuid ||
-      this.props.pipelineRun !== prevProps.pipelineRun
+      this.props.pipeline_uuid !== prevProps.pipeline_uuid
     ) {
       this.fetchAll();
     }

--- a/services/orchest-webserver/app/static/js/views/PipelineSettingsView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineSettingsView.js
@@ -278,11 +278,13 @@ class PipelineSettingsView extends React.Component {
           }
         })()}
 
-        <MDCButtonReact
-          classNames={["close-button"]}
-          icon="close"
-          onClick={this.closeSettings.bind(this)}
-        />
+        <div className="top-buttons">
+          <MDCButtonReact
+            classNames={["close-button"]}
+            icon="close"
+            onClick={this.closeSettings.bind(this)}
+          />
+        </div>
       </div>
     );
   }

--- a/services/orchest-webserver/app/static/js/views/PipelineView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineView.js
@@ -1304,7 +1304,7 @@ class PipelineView extends React.Component {
           relativeToAbsolutePath(
             this.state.steps[this.state.openedStep].file_path,
             cwd
-          )
+          ).slice(1)
         );
 
         orchest.showJupyter();


### PR DESCRIPTION
This PR introduces the ability to navigate the file viewer through the parent/child steps connected to the file being viewed.

In addition, notebooks will now be serialized to disk when a cell is executed such that notebook outputs can be viewed when it's executed on the scheduler.