### PR TITLE
Move Orchest database backend to postgres

### DIFF
--- a/services/auth-server/app/app/__init__.py
+++ b/services/auth-server/app/app/__init__.py
@@ -17,11 +17,15 @@ def create_app(config_class=None):
     app = Flask(__name__)
     app.config.from_object(config_class)
 
-    # Initialize the database and create the database file.
+    # Create the database if it does not exist yet. Roughly equal to
+    # a "CREATE DATABASE IF NOT EXISTS <db_name>" call.
     if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
         create_database(app.config["SQLALCHEMY_DATABASE_URI"])
+
     db.init_app(app)
     with app.app_context():
+        # This call will create tables if needed (the ones which do not
+        # exist in the database yet).
         db.create_all()
 
     register_views(app)

--- a/services/auth-server/app/app/__init__.py
+++ b/services/auth-server/app/app/__init__.py
@@ -7,6 +7,8 @@ Additinal note:
         https://docs.pytest.org/en/latest/goodpractices.html
 """
 from flask import Flask
+from sqlalchemy_utils import create_database, database_exists
+
 from app.views import register_views
 from app.connections import db
 
@@ -16,6 +18,8 @@ def create_app(config_class=None):
     app.config.from_object(config_class)
 
     # Initialize the database and create the database file.
+    if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
+        create_database(app.config["SQLALCHEMY_DATABASE_URI"])
     db.init_app(app)
     with app.app_context():
         db.create_all()

--- a/services/auth-server/app/app/models.py
+++ b/services/auth-server/app/app/models.py
@@ -10,6 +10,10 @@ class User(db.Model):
     uuid = db.Column(
         db.String(36),
         primary_key=True,
+        # required to be referenced as a foreign key by the Token table,
+        # since postgres does not accept foreign keys referencing non
+        # unique fields
+        unique=True,
     )
 
     username = db.Column(

--- a/services/auth-server/app/config.py
+++ b/services/auth-server/app/config.py
@@ -1,6 +1,6 @@
 class Config:
     DEBUG = False
-    SQLALCHEMY_DATABASE_URI = "sqlite:////userdir/.orchest/auth-server.db"
+    SQLALCHEMY_DATABASE_URI = "postgresql://postgres@orchest-database/auth_server"
 
     TOKEN_DURATION_HOURS = 24
 

--- a/services/auth-server/requirements.txt
+++ b/services/auth-server/requirements.txt
@@ -1,3 +1,5 @@
 Flask==1.1.1
 Werkzeug==0.16.0
 Flask-SQLAlchemy==2.4.1
+psycopg2-binary==2.8.6
+SQLAlchemy-Utils==0.36.8

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -61,12 +61,15 @@ def create_app(config_class=None, use_db=True):
             # atomic operation that will result in an error if the
             # directory is already there, this cleanup operation will
             # run only once per container.
-            if os.system("mkdir /tmp/interactive_cleanup_done > /dev/null 2>&1") == 0:
+            try:
+                os.mkdir("/tmp/interactive_cleanup_done")
                 InteractiveSession.query.delete()
                 InteractivePipelineRun.query.filter(
                     InteractivePipelineRun.status.in_(["PENDING", "STARTED"])
                 ).delete(synchronize_session="fetch")
                 db.session.commit()
+            except FileExistsError:
+                pass
 
     # Register blueprints.
     app.register_blueprint(api, url_prefix="/api")

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -12,16 +12,24 @@ from sqlalchemy_utils import create_database, database_exists
 
 from app.apis import blueprint as api
 from app.connections import db
-from app.models import (
-    InteractiveSession,
-    InteractiveRun,
-    InteractiveRunPipelineStep,
-    InteractiveRunImageMapping,
-)
 from config import CONFIG_CLASS
 
 
 def create_app(config_class=None, use_db=True):
+    """Create the Flask app and return it.
+
+    Args:
+        config_class: Configuration class. See orchest-api/app/config.
+        use_db: If true, associate a database to the Flask app instance,
+            which implies connecting to a given database and possibly
+            creating such database and/or tables if they do not exist
+            already. The reason to differentiate instancing the app
+            through this argument is that the celery worker does not
+            need to connect to the db that "belongs" to the orchest-api.
+
+    Returns:
+        Flask.app
+    """
     app = Flask(__name__)
     app.config.from_object(config_class)
 
@@ -43,9 +51,5 @@ def create_app(config_class=None, use_db=True):
 
     # Register blueprints.
     app.register_blueprint(api, url_prefix="/api")
-
-    # create celery database if needed
-    if not database_exists(CONFIG_CLASS.result_backend_sqlalchemy_uri):
-        create_database(CONFIG_CLASS.result_backend_sqlalchemy_uri)
 
     return app

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -30,11 +30,15 @@ def create_app(config_class=None, use_db=True):
     CORS(app, resources={r"/*": {"origins": "*"}})
 
     if use_db:
-        # Initialize the database and create the database file.
+        # Create the database if it does not exist yet. Roughly equal to
+        # a "CREATE DATABASE IF NOT EXISTS <db_name>" call.
         if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
             create_database(app.config["SQLALCHEMY_DATABASE_URI"])
+
         db.init_app(app)
         with app.app_context():
+            # This call will create tables if needed (the ones which do
+            # not exist in the database yet).
             db.create_all()
 
     # Register blueprints.

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -36,14 +36,6 @@ def create_app(config_class=None, use_db=True):
         db.init_app(app)
         with app.app_context():
             db.create_all()
-            # cleanup stuff that is temporary/ephemireal, the cleanup
-            # happens on startup so that it's still possible to inspect
-            # the db on shutdown
-            InteractiveSession.query.delete()
-            InteractiveRun.query.delete()
-            InteractiveRunPipelineStep.query.delete()
-            InteractiveRunImageMapping.query.delete()
-            db.session.commit()
 
     # Register blueprints.
     app.register_blueprint(api, url_prefix="/api")

--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -271,7 +271,6 @@ class PipelineRun(Resource):
         ).one_or_none()
         if non_interactive_run is None:
             abort(404, "Given experiment has no run with given run_uuid")
-        print(non_interactive_run.__dict__)
         return non_interactive_run.__dict__
 
     @api.doc("set_pipeline_run_status")

--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -90,6 +90,10 @@ class ExperimentList(Resource):
                 "status": "PENDING",
             }
             db.session.add(models.NonInteractiveRun(**non_interactive_run))
+            # need to flush because otherwise the bulk insertion of
+            # pipeline steps will lead to foreign key errors
+            # https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations-caveats
+            db.session.flush()
 
             # TODO: this code is also in `namespace_runs`. Could
             #       potentially be put in a function for modularity.

--- a/services/orchest-api/app/app/apis/namespace_experiments.py
+++ b/services/orchest-api/app/app/apis/namespace_experiments.py
@@ -4,7 +4,7 @@ import uuid
 
 from celery.contrib.abortable import AbortableAsyncResult
 from docker import errors
-from flask import current_app, request
+from flask import current_app, request, abort
 from flask_restplus import Namespace, Resource
 
 from app import schema
@@ -89,7 +89,7 @@ class ExperimentList(Resource):
                 "project_uuid": post_data["project_uuid"],
                 "status": "PENDING",
             }
-            db.session.add(models.NonInteractiveRun(**non_interactive_run))
+            db.session.add(models.NonInteractivePipelineRun(**non_interactive_run))
             # need to flush because otherwise the bulk insertion of
             # pipeline steps will lead to foreign key errors
             # https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations-caveats
@@ -103,9 +103,8 @@ class ExperimentList(Resource):
             pipeline_steps = []
             for step_uuid in step_uuids:
                 pipeline_steps.append(
-                    models.NonInteractiveRunPipelineStep(
+                    models.PipelineRunStep(
                         **{
-                            "experiment_uuid": post_data["experiment_uuid"],
                             "run_uuid": task_id,
                             "step_uuid": step_uuid,
                             "status": "PENDING",
@@ -131,7 +130,6 @@ class ExperimentList(Resource):
                         task_id,
                         post_data["project_uuid"],
                         pipeline.get_environments(),
-                        is_interactive=False,
                     )
                 except errors.ImageNotFound as e:
                     experiment_creation_error_messages.append(
@@ -140,7 +138,7 @@ class ExperimentList(Resource):
                     )
             else:
                 image_mappings = [
-                    models.NonInteractiveRunImageMapping(
+                    models.PipelineRunImageMapping(
                         **{
                             "run_uuid": task_id,
                             "orchest_environment_uuid": env_uuid,
@@ -199,12 +197,14 @@ class ExperimentList(Resource):
                 pipeline_run.status = "SUCCESS"
                 for step in pipeline_run["pipeline_steps"]:
                     step.status = "FAILURE"
-            models.NonInteractiveRun.query.filter_by(
+
+                models.PipelineRunStep.query.filter_by(
+                    run_uuid=pipeline_run["run_uuid"]
+                ).update({"status": "FAILURE"})
+
+            models.NonInteractivePipelineRun.query.filter_by(
                 experiment_uuid=post_data["experiment_uuid"]
             ).update({"status": "SUCCESS"})
-            models.NonInteractiveRunPipelineStep.query.filter_by(
-                experiment_uuid=post_data["experiment_uuid"]
-            ).update({"status": "FAILURE"})
             db.session.commit()
 
             return {
@@ -266,10 +266,12 @@ class PipelineRun(Resource):
     @api.marshal_with(schema.non_interactive_run, code=200)
     def get(self, experiment_uuid, run_uuid):
         """Fetch a pipeline run of an experiment given their ids."""
-        non_interactive_run = models.NonInteractiveRun.query.get_or_404(
-            ident=(experiment_uuid, run_uuid),
-            description="Given experiment has no run with given run_uuid",
-        )
+        non_interactive_run = models.NonInteractivePipelineRun.query.filter_by(
+            run_uuid=run_uuid,
+        ).one_or_none()
+        if non_interactive_run is None:
+            abort(404, "Given experiment has no run with given run_uuid")
+        print(non_interactive_run.__dict__)
         return non_interactive_run.__dict__
 
     @api.doc("set_pipeline_run_status")
@@ -293,7 +295,7 @@ class PipelineRun(Resource):
             "run_uuid": run_uuid,
         }
         update_status_db(
-            status_update, model=models.NonInteractiveRun, filter_by=filter_by
+            status_update, model=models.NonInteractivePipelineRun, filter_by=filter_by
         )
 
         return {"message": "Status was updated successfully"}, 200
@@ -317,8 +319,8 @@ class PipelineStepStatus(Resource):
     @api.marshal_with(schema.non_interactive_run, code=200)
     def get(self, experiment_uuid, run_uuid, step_uuid):
         """Fetch a pipeline step of a run of an experiment given uuids."""
-        step = models.NonInteractiveRunPipelineStep.query.get_or_404(
-            ident=(experiment_uuid, run_uuid, step_uuid),
+        step = models.PipelineRunStep.query.get_or_404(
+            ident=(run_uuid, step_uuid),
             description="Combination of given experiment, run and step not found",
         )
         return step.__dict__
@@ -330,13 +332,12 @@ class PipelineStepStatus(Resource):
         status_update = request.get_json()
 
         filter_by = {
-            "experiment_uuid": experiment_uuid,
             "run_uuid": run_uuid,
             "step_uuid": step_uuid,
         }
         update_status_db(
             status_update,
-            model=models.NonInteractiveRunPipelineStep,
+            model=models.PipelineRunStep,
             filter_by=filter_by,
         )
 
@@ -399,13 +400,15 @@ def stop_experiment(experiment_uuid) -> bool:
         # it's aborted status
         res.abort()
 
-    # Update the status of the run and step entries to "REVOKED".
-    models.NonInteractiveRun.query.filter_by(
-        experiment_uuid=experiment.experiment_uuid
-    ).update({"status": "REVOKED"})
-    models.NonInteractiveRunPipelineStep.query.filter_by(
-        experiment_uuid=experiment.experiment_uuid
-    ).update({"status": "REVOKED"})
+        # Update the status of the run and step entries to "REVOKED".
+        models.NonInteractivePipelineRun.query.filter_by(run_uuid=run_uuid).update(
+            {"status": "REVOKED"}
+        )
+
+        models.PipelineRunStep.query.filter_by(run_uuid=run_uuid).update(
+            {"status": "REVOKED"}
+        )
+
     db.session.commit()
     return True
 

--- a/services/orchest-api/app/app/apis/namespace_pipelines.py
+++ b/services/orchest-api/app/app/apis/namespace_pipelines.py
@@ -44,8 +44,8 @@ def delete_pipeline(project_uuid, pipeline_uuid):
     """
     # any interactive run related to the pipeline is stopped
     # if necessary, then deleted
-    interactive_runs = models.PipelineRun.query.filter_by(
-        project_uuid=project_uuid, pipeline_uuid=pipeline_uuid, type="PipelineRun"
+    interactive_runs = models.InteractivePipelineRun.query.filter_by(
+        project_uuid=project_uuid, pipeline_uuid=pipeline_uuid
     ).all()
     for run in interactive_runs:
         if run.status in ["PENDING", "STARTED"]:

--- a/services/orchest-api/app/app/apis/namespace_pipelines.py
+++ b/services/orchest-api/app/app/apis/namespace_pipelines.py
@@ -44,8 +44,8 @@ def delete_pipeline(project_uuid, pipeline_uuid):
     """
     # any interactive run related to the pipeline is stopped
     # if necessary, then deleted
-    interactive_runs = models.InteractiveRun.query.filter_by(
-        project_uuid=project_uuid, pipeline_uuid=pipeline_uuid
+    interactive_runs = models.PipelineRun.query.filter_by(
+        project_uuid=project_uuid, pipeline_uuid=pipeline_uuid, type="PipelineRun"
     ).all()
     for run in interactive_runs:
         if run.status in ["PENDING", "STARTED"]:

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -45,8 +45,8 @@ def delete_project(project_uuid):
 
     # any interactive run related to the pipeline is stopped
     # if necessary, then deleted
-    interactive_runs = models.PipelineRun.query.filter_by(
-        project_uuid=project_uuid, type="PipelineRun"
+    interactive_runs = models.InteractivePipelineRun.query.filter_by(
+        project_uuid=project_uuid
     ).all()
     for run in interactive_runs:
         if run.status in ["PENDING", "STARTED"]:

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -45,8 +45,8 @@ def delete_project(project_uuid):
 
     # any interactive run related to the pipeline is stopped
     # if necessary, then deleted
-    interactive_runs = models.InteractiveRun.query.filter_by(
-        project_uuid=project_uuid,
+    interactive_runs = models.PipelineRun.query.filter_by(
+        project_uuid=project_uuid, type="PipelineRun"
     ).all()
     for run in interactive_runs:
         if run.status in ["PENDING", "STARTED"]:
@@ -72,8 +72,8 @@ def delete_project(project_uuid):
         # stop and delete any session if it exists
         stop_interactive_session(session.project_uuid, session.pipeline_uuid)
 
-    # any experiment related to the pipeline is stopped if necessary
-    # , then deleted
+    # any experiment related to the pipeline is stopped if necessary,
+    # then deleted
     experiments = (
         models.Experiment.query.filter_by(
             project_uuid=project_uuid,

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -5,7 +5,7 @@ Note: "run" is short for "interactive pipeline run".
 import uuid
 from celery.contrib.abortable import AbortableAsyncResult
 from docker import errors
-from flask import current_app, request
+from flask import current_app, request, abort
 from flask_restplus import Namespace, Resource, marshal
 import logging
 
@@ -32,16 +32,18 @@ class RunList(Resource):
         completed.
         """
 
-        query = models.InteractiveRun.query
+        query = models.PipelineRun.query
 
         # Ability to query a specific runs given the `pipeline_uuid` or `project_uuid`
         # through the URL (using `request.args`).
         if "pipeline_uuid" in request.args and "project_uuid" in request.args:
             query = query.filter_by(
-                pipeline_uuid=request.args.get("pipeline_uuid")
+                pipeline_uuid=request.args.get("pipeline_uuid"), type="PipelineRun"
             ).filter_by(project_uuid=request.args.get("project_uuid"))
         elif "project_uuid" in request.args:
-            query = query.filter_by(project_uuid=request.args.get("project_uuid"))
+            query = query.filter_by(
+                project_uuid=request.args.get("project_uuid"), type="PipelineRun"
+            )
 
         runs = query.all()
         return {"runs": [run.__dict__ for run in runs]}, 200
@@ -69,7 +71,7 @@ class RunList(Resource):
             "project_uuid": post_data["project_uuid"],
             "status": "PENDING",
         }
-        db.session.add(models.InteractiveRun(**run))
+        db.session.add(models.PipelineRun(**run))
         # need to flush because otherwise the bulk insertion of pipeline
         # steps will lead to foreign key errors
         # https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations-caveats
@@ -82,7 +84,7 @@ class RunList(Resource):
         pipeline_steps = []
         for step_uuid in step_uuids:
             pipeline_steps.append(
-                models.InteractiveRunPipelineStep(
+                models.PipelineRunStep(
                     **{"run_uuid": task_id, "step_uuid": step_uuid, "status": "PENDING"}
                 )
             )
@@ -98,7 +100,6 @@ class RunList(Resource):
                 task_id,
                 post_data["project_uuid"],
                 pipeline.get_environments(),
-                is_interactive=True,
             )
         except errors.ImageNotFound as e:
             logging.error(
@@ -114,10 +115,10 @@ class RunList(Resource):
             run["status"] = "SUCCESS"
             for step in run["pipeline_steps"]:
                 step.status = "FAILURE"
-            models.InteractiveRun.query.filter_by(run_uuid=task_id).update(
+            models.PipelineRun.query.filter_by(run_uuid=task_id).update(
                 {"status": "SUCCESS"}
             )
-            models.InteractiveRunPipelineStep.query.filter_by(run_uuid=task_id).update(
+            models.PipelineRunStep.query.filter_by(run_uuid=task_id).update(
                 {"status": "FAILURE"}
             )
             db.session.commit()
@@ -160,10 +161,12 @@ class Run(Resource):
     @api.doc("get_run")
     @api.marshal_with(schema.interactive_run, code=200)
     def get(self, run_uuid):
-        """Fetches a pipeline run given its UUID."""
-        run = models.InteractiveRun.query.get_or_404(
-            run_uuid, description="Run not found"
-        )
+        """Fetches an interactive pipeline run given its UUID."""
+        run = models.PipelineRun.query.filter_by(
+            run_uuid=run_uuid, type="PipelineRun"
+        ).one_or_none()
+        if run is None:
+            abort(404, description="Run not found")
         return run.__dict__
 
     @api.doc("set_run_status")
@@ -172,7 +175,7 @@ class Run(Resource):
         """Sets the status of a pipeline run."""
         post_data = request.get_json()
 
-        res = models.InteractiveRun.query.filter_by(run_uuid=run_uuid).update(
+        res = models.PipelineRun.query.filter_by(run_uuid=run_uuid).update(
             {"status": post_data["status"]}
         )
 
@@ -200,7 +203,7 @@ class StepStatus(Resource):
     @api.marshal_with(schema.pipeline_run_pipeline_step, code=200)
     def get(self, run_uuid, step_uuid):
         """Fetches the status of a pipeline step of a specific run."""
-        step = models.InteractiveRunPipelineStep.query.get_or_404(
+        step = models.PipelineRunStep.query.get_or_404(
             ident=(run_uuid, step_uuid),
             description="Run and step combination not found",
         )
@@ -212,18 +215,12 @@ class StepStatus(Resource):
         """Sets the status of a pipeline step."""
         status_update = request.get_json()
 
-        # TODO: don't we want to do this async? Since otherwise the API
-        #       call might be blocking another since they both execute
-        #       on the database? SQLite can only have one process write
-        #       to the db. If this becomes an issue than we could also
-        #       use an in-memory db (since that is a lot faster than
-        #       disk). Otherwise we might have to use PostgreSQL.
         # TODO: first check the status and make sure it says PENDING or
         #       whatever. Because if is empty then this would write it
         #       and then get overwritten afterwards with "PENDING".
         filter_by = {"run_uuid": run_uuid, "step_uuid": step_uuid}
         update_status_db(
-            status_update, model=models.InteractiveRunPipelineStep, filter_by=filter_by
+            status_update, model=models.PipelineRunStep, filter_by=filter_by
         )
 
         return {"message": "Status was updated successfully"}, 200
@@ -242,15 +239,11 @@ def stop_pipeline_run(run_uuid) -> bool:
         True if a cancellation was issued to the run, false if the
         run did not exist or was not PENDING/STARTED.
     """
-    interactive_run = models.InteractiveRun.query.filter(
-        models.InteractiveRun.status.in_(["PENDING", "STARTED"]),
-        models.InteractiveRun.run_uuid == run_uuid,
+    interactive_run = models.PipelineRun.query.filter(
+        models.PipelineRun.status.in_(["PENDING", "STARTED"]),
+        models.PipelineRun.run_uuid == run_uuid,
     ).one_or_none()
-    non_interactive_run = models.NonInteractiveRun.query.filter(
-        models.NonInteractiveRun.status.in_(["PENDING", "STARTED"]),
-        models.NonInteractiveRun.run_uuid == run_uuid,
-    ).one_or_none()
-    if interactive_run is None and non_interactive_run is None:
+    if interactive_run is None:
         return False
 
     celery_app = make_celery(current_app)

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -70,6 +70,10 @@ class RunList(Resource):
             "status": "PENDING",
         }
         db.session.add(models.InteractiveRun(**run))
+        # need to flush because otherwise the bulk insertion of pipeline
+        # steps will lead to foreign key errors
+        # https://docs.sqlalchemy.org/en/13/orm/persistence_techniques.html#bulk-operations-caveats
+        db.session.flush()
 
         # Set an initial value for the status of the pipeline steps that
         # will be run.

--- a/services/orchest-api/app/app/celery_app.py
+++ b/services/orchest-api/app/app/celery_app.py
@@ -4,8 +4,8 @@ from sqlalchemy_utils import create_database, database_exists
 from config import CONFIG_CLASS
 
 
-def make_celery(app, create_backend_db=False):
-    if create_backend_db:
+def make_celery(app, use_backend_db=False):
+    if use_backend_db:
         # create celery database if needed
         if not database_exists(CONFIG_CLASS.result_backend_sqlalchemy_uri):
             create_database(CONFIG_CLASS.result_backend_sqlalchemy_uri)

--- a/services/orchest-api/app/app/celery_app.py
+++ b/services/orchest-api/app/app/celery_app.py
@@ -1,9 +1,15 @@
 from celery import Celery
+from sqlalchemy_utils import create_database, database_exists
 
 from config import CONFIG_CLASS
 
 
-def make_celery(app):
+def make_celery(app, create_backend_db=False):
+    if create_backend_db:
+        # create celery database if needed
+        if not database_exists(CONFIG_CLASS.result_backend_sqlalchemy_uri):
+            create_database(CONFIG_CLASS.result_backend_sqlalchemy_uri)
+
     celery = Celery(app.import_name, config_source=CONFIG_CLASS)
     celery.conf.update(app.config)
 

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -23,7 +23,7 @@ logger = get_task_logger(__name__)
 # databases) is called twice, which means celery-worker needs the
 # /userdir bind to access the DB which is probably not a good idea.
 # create_all should only be called once per app right?
-celery = make_celery(create_app(CONFIG_CLASS, use_db=False), create_backend_db=True)
+celery = make_celery(create_app(CONFIG_CLASS, use_db=False), use_backend_db=True)
 
 
 # This will not work yet, because Celery does not yet support asyncio

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -23,7 +23,7 @@ logger = get_task_logger(__name__)
 # databases) is called twice, which means celery-worker needs the
 # /userdir bind to access the DB which is probably not a good idea.
 # create_all should only be called once per app right?
-celery = make_celery(create_app(CONFIG_CLASS, use_db=False))
+celery = make_celery(create_app(CONFIG_CLASS, use_db=False), create_backend_db=True)
 
 
 # This will not work yet, because Celery does not yet support asyncio

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -127,7 +127,7 @@ class Experiment(BaseModel):
         # with relationship(), it’s important to note first and foremost
         # that the relationship.cascade setting must still be configured
         # to match the desired “delete” or “set null” behavior
-        # Essentially, the specifed behaviour in the FK column
+        # Essentially, the specified behaviour in the FK column
         # and the one specified in the relationship must match.
         cascade="all, delete",
     )

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -213,10 +213,12 @@ class NonInteractivePipelineRun(PipelineRun):
     # https://docs.sqlalchemy.org/en/14/orm/session_basics.html#update-and-delete-with-arbitrary-where-clause
     #
     # Single table inheritance is the inheritance of choice, mostly
-    # because of the drawbacks of joined table inheritance. Settng the
+    # because of the drawbacks of joined table inheritance. Setting the
     # tablename to None will result in using single table inheritance,
     # setting it to a string will result in using joined table
     # inheritance.
+    # Note that single table inheritance will NOT create a new table for
+    # each "child" of the inheritance.
     __tablename__ = None
 
     # TODO: verify why the experiment_uuid should be part of the

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -9,6 +9,7 @@ TODO:
 """
 from app.connections import db
 from sqlalchemy import Index, UniqueConstraint, ForeignKeyConstraint
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 class BaseModel(db.Model):
@@ -43,14 +44,14 @@ class InteractiveSession(BaseModel):
     )  # IPv4
     # Used to connect to Jupyter notebook server.
     notebook_server_info = db.Column(
-        db.JSON,
+        JSONB,
         unique=True,
         nullable=True,
     )
     # Docker container IDs. Used internally to identify the resources of
     # a specific session.
     container_ids = db.Column(
-        db.JSON,
+        JSONB,
         unique=False,
         nullable=True,
     )
@@ -128,7 +129,6 @@ class InteractiveRun(PipelineRun):
 
 class NonInteractiveRun(PipelineRun):
     __tablename__ = "non_interactive_runs"
-    __bind_key__ = "persistent_db"
 
     # TODO: verify why the experiment_uuid should be part of the
     # primary key
@@ -166,7 +166,6 @@ class NonInteractiveRun(PipelineRun):
 
 class NonInteractiveRunPipelineStep(PipelineRunPipelineStep):
     __tablename__ = "non_interactive_run_pipeline_steps"
-    __bind_key__ = "persistent_db"
 
     # TODO: verify why we have the exp uuid as a column, seems to be
     # redundant info since we already have the run_uuid
@@ -190,7 +189,6 @@ class NonInteractiveRunPipelineStep(PipelineRunPipelineStep):
 
 class Experiment(BaseModel):
     __tablename__ = "experiments"
-    __bind_key__ = "persistent_db"
 
     experiment_uuid = db.Column(db.String(36), primary_key=True)
     project_uuid = db.Column(
@@ -229,7 +227,6 @@ class EnvironmentBuild(BaseModel):
     """
 
     __tablename__ = "environment_build"
-    __bind_key__ = "persistent_db"
     __table_args__ = (Index("uuid_proj_env_index", "project_uuid", "environment_uuid"),)
 
     # https://stackoverflow.com/questions/63164261/celery-task-id-max-length
@@ -293,7 +290,6 @@ class NonInteractiveRunImageMapping(BaseModel):
     """
 
     __tablename__ = "non_interactive_pipeline_run_image_mapping"
-    __bind_key__ = "persistent_db"
     __table_args__ = (
         UniqueConstraint("run_uuid", "orchest_environment_uuid"),
         UniqueConstraint("run_uuid", "docker_img_id"),

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -21,6 +21,34 @@ class BaseModel(db.Model):
         return {c.name: getattr(self, c.name) for c in self.__table__.columns}
 
 
+class EnvironmentBuild(BaseModel):
+    """State of environment builds.
+
+    Table meant to store the state of the build task of an environment,
+    i.e. when we need to build an image starting from a base image plus
+    optional sh code. This is not related to keeping track of
+    environments or images to decide if a project or pipeline can be
+    run.
+
+    """
+
+    __tablename__ = "environment_build"
+    __table_args__ = (Index("uuid_proj_env_index", "project_uuid", "environment_uuid"),)
+
+    # https://stackoverflow.com/questions/63164261/celery-task-id-max-length
+    build_uuid = db.Column(db.String(36), primary_key=True, unique=True, nullable=False)
+    project_uuid = db.Column(db.String(36), nullable=False, index=True)
+    environment_uuid = db.Column(db.String(36), nullable=False, index=True)
+    project_path = db.Column(db.String(4096), nullable=False, index=True)
+    requested_time = db.Column(db.DateTime, unique=False, nullable=False)
+    started_time = db.Column(db.DateTime, unique=False, nullable=True)
+    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
+    status = db.Column(db.String(15), unique=False, nullable=True)
+
+    def __repr__(self):
+        return f"<EnvironmentBuildTask: {self.build_uuid}>"
+
+
 class InteractiveSession(BaseModel):
     __tablename__ = "interactive_sessions"
 
@@ -60,133 +88,6 @@ class InteractiveSession(BaseModel):
         return f"<Launch {self.pipeline_uuid}>"
 
 
-class PipelineRun(BaseModel):
-    __abstract__ = True
-
-    project_uuid = db.Column(
-        db.String(36),
-    )
-    pipeline_uuid = db.Column(
-        db.String(36),
-        unique=False,
-        nullable=False,
-    )
-    status = db.Column(db.String(15), unique=False, nullable=True)
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.run_uuid}>"
-
-
-class PipelineRunPipelineStep(BaseModel):
-    __abstract__ = True
-
-    step_uuid = db.Column(db.String(36), primary_key=True)
-    status = db.Column(db.String(15), unique=False, nullable=True)
-    started_time = db.Column(db.DateTime, unique=False, nullable=True)
-    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.run_uuid}.{self.step_uuid}>"
-
-
-class InteractiveRunPipelineStep(PipelineRunPipelineStep):
-    __tablename__ = "interactive_run_pipeline_steps"
-
-    run_uuid = db.Column(
-        db.String(36),
-        db.ForeignKey("interactive_runs.run_uuid", ondelete="CASCADE"),
-        primary_key=True,
-    )
-
-
-class InteractiveRun(PipelineRun):
-    __tablename__ = "interactive_runs"
-
-    run_uuid = db.Column(db.String(36), primary_key=True)
-
-    # https://docs.sqlalchemy.org/en/14/orm/cascades.html#using-foreign-key-on-delete-cascade-with-orm-relationships
-    # In order to use ON DELETE foreign key cascades in conjunction
-    # with relationship(), it’s important to note first and foremost
-    # that the relationship.cascade setting must still be configured
-    # to match the desired “delete” or “set null” behavior
-    # Essentially, the specifed behaviour in the FK column
-    # and the one specified in the relationship must match.
-    pipeline_steps = db.relationship(
-        "InteractiveRunPipelineStep",
-        lazy="joined",
-        # do not rely on the db to delete
-        # TODO: can be set to true after we move away from sqllite
-        passive_deletes=False,
-        cascade="all, delete",
-    )
-    image_mappings = db.relationship(
-        "InteractiveRunImageMapping",
-        lazy="joined",
-        passive_deletes=False,
-        cascade="all, delete",
-    )
-
-
-class NonInteractiveRun(PipelineRun):
-    __tablename__ = "non_interactive_runs"
-
-    # TODO: verify why the experiment_uuid should be part of the
-    # primary key
-    experiment_uuid = db.Column(
-        db.String(36),
-        db.ForeignKey("experiments.experiment_uuid", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    # needs to be unique to be a FK constraint for images mappings
-    # that can delete on cascade
-    run_uuid = db.Column(db.String(36), primary_key=True, unique=True)
-    # This run_id is used to identify the pipeline run within the
-    # experiment and maintain a consistent ordering.
-    pipeline_run_id = db.Column(
-        db.Integer,
-        unique=False,
-        nullable=False,
-    )
-    started_time = db.Column(db.DateTime, unique=False, nullable=True)
-    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
-
-    pipeline_steps = db.relationship(
-        "NonInteractiveRunPipelineStep",
-        lazy="joined",
-        passive_deletes=False,
-        cascade="all, delete",
-    )
-    image_mappings = db.relationship(
-        "NonInteractiveRunImageMapping",
-        lazy="joined",
-        passive_deletes=False,
-        cascade="all, delete",
-    )
-
-
-class NonInteractiveRunPipelineStep(PipelineRunPipelineStep):
-    __tablename__ = "non_interactive_run_pipeline_steps"
-
-    # TODO: verify why we have the exp uuid as a column, seems to be
-    # redundant info since we already have the run_uuid
-    experiment_uuid = db.Column(
-        db.String(36),
-        primary_key=True,
-    )
-    run_uuid = db.Column(
-        db.String(36),
-        primary_key=True,
-    )
-
-    __table_args__ = (
-        ForeignKeyConstraint(
-            [experiment_uuid, run_uuid],
-            [NonInteractiveRun.experiment_uuid, NonInteractiveRun.run_uuid],
-            ondelete="CASCADE",
-        ),
-    )
-
-
 class Experiment(BaseModel):
     __tablename__ = "experiments"
 
@@ -208,80 +109,137 @@ class Experiment(BaseModel):
     )
 
     pipeline_runs = db.relationship(
-        "NonInteractiveRun", lazy="joined", passive_deletes=False, cascade="all, delete"
+        "NonInteractivePipelineRun",
+        lazy="joined",
+        # let the db take care of cascading deletions
+        # https://docs.sqlalchemy.org/en/13/orm/relationship_api.html#sqlalchemy.orm.relationship.params.passive_deletes
+        # A value of True indicates that unloaded child items should not
+        # be loaded during a delete operation on the parent. Normally,
+        # when a parent item is deleted, all child items are loaded so
+        # that they can either be marked as deleted, or have their
+        # foreign key to the parent set to NULL. Marking this flag as
+        # True usually implies an ON DELETE <CASCADE|SET NULL> rule is
+        # in place which will handle updating/deleting child rows on the
+        # database side.
+        passive_deletes=True,
+        # https://docs.sqlalchemy.org/en/14/orm/cascades.html#using-foreign-key-on-delete-cascade-with-orm-relationships
+        # In order to use ON DELETE foreign key cascades in conjunction
+        # with relationship(), it’s important to note first and foremost
+        # that the relationship.cascade setting must still be configured
+        # to match the desired “delete” or “set null” behavior
+        # Essentially, the specifed behaviour in the FK column
+        # and the one specified in the relationship must match.
+        cascade="all, delete",
     )
 
     def __repr__(self):
         return f"<Experiment: {self.experiment_uuid}>"
 
 
-class EnvironmentBuild(BaseModel):
-    """State of environment builds.
+class PipelineRun(BaseModel):
+    __tablename__ = "pipeline_runs"
 
-    Table meant to store the state of the build task of an environment,
-    i.e. when we need to build an image starting from a base image plus
-    optional sh code. This is not related to keeping track of
-    environments or images to decide if a project or pipeline can be
-    run.
-
-    """
-
-    __tablename__ = "environment_build"
-    __table_args__ = (Index("uuid_proj_env_index", "project_uuid", "environment_uuid"),)
-
-    # https://stackoverflow.com/questions/63164261/celery-task-id-max-length
-    build_uuid = db.Column(db.String(36), primary_key=True, unique=True, nullable=False)
-    project_uuid = db.Column(db.String(36), nullable=False, index=True)
-    environment_uuid = db.Column(db.String(36), nullable=False, index=True)
-    project_path = db.Column(db.String(4096), nullable=False, index=True)
-    requested_time = db.Column(db.DateTime, unique=False, nullable=False)
-    started_time = db.Column(db.DateTime, unique=False, nullable=True)
-    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
-    status = db.Column(db.String(15), unique=False, nullable=True)
-
-    def __repr__(self):
-        return f"<EnvironmentBuildTask: {self.build_uuid}>"
-
-
-class InteractiveRunImageMapping(BaseModel):
-    """Stores mappings between an interactive run and the environment
-     images it uses.
-
-    Used to understand if an image can be removed from the docker
-    environment if it's not used by a run which is PENDING or STARTED.
-
-    """
-
-    __tablename__ = "interactive_run_image_mapping"
-    __table_args__ = (
-        UniqueConstraint("run_uuid", "orchest_environment_uuid"),
-        UniqueConstraint("run_uuid", "docker_img_id"),
+    project_uuid = db.Column(
+        db.String(36),
     )
-
-    run_uuid = db.Column(
-        db.ForeignKey(InteractiveRun.run_uuid, ondelete="CASCADE"),
+    pipeline_uuid = db.Column(
+        db.String(36),
         unique=False,
         nullable=False,
-        index=True,
-        primary_key=True,
     )
-    orchest_environment_uuid = db.Column(
-        db.String(36), unique=False, nullable=False, primary_key=True
+    run_uuid = db.Column(db.String(36), primary_key=True)
+    status = db.Column(db.String(15), unique=False, nullable=True)
+    started_time = db.Column(db.DateTime, unique=False, nullable=True)
+    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
+    type = db.Column(db.String(50))
+
+    pipeline_steps = db.relationship(
+        "PipelineRunStep",
+        lazy="joined",
+        passive_deletes=True,
+        cascade="all, delete",
     )
-    docker_img_id = db.Column(
-        db.String(), unique=False, nullable=False, primary_key=True
+    image_mappings = db.relationship(
+        "PipelineRunImageMapping",
+        lazy="joined",
+        passive_deletes=True,
+        cascade="all, delete",
     )
+
+    # related to inheritance, the "type" column will be used to
+    # differentiate the different classes of entities
+    __mapper_args__ = {
+        "polymorphic_identity": "PipelineRun",
+        "polymorphic_on": type,
+    }
 
     def __repr__(self):
-        return (
-            f"<InteractiveRunImageMapping: {self.run_uuid} | "
-            f"{self.orchest_environment_uuid} | "
-            f"{self.docker_img_id}>"
-        )
+        return f"<{self.__class__.__name__}: {self.run_uuid}>"
 
 
-class NonInteractiveRunImageMapping(BaseModel):
-    """Stores mappings between a non interactive run and the environment
+class PipelineRunStep(BaseModel):
+    __tablename__ = "pipeline_run_steps"
+
+    run_uuid = db.Column(
+        db.String(36),
+        db.ForeignKey("pipeline_runs.run_uuid", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    step_uuid = db.Column(db.String(36), primary_key=True)
+    status = db.Column(db.String(15), unique=False, nullable=True)
+    started_time = db.Column(db.DateTime, unique=False, nullable=True)
+    finished_time = db.Column(db.DateTime, unique=False, nullable=True)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.run_uuid}.{self.step_uuid}>"
+
+
+class NonInteractivePipelineRun(PipelineRun):
+    # https://docs.sqlalchemy.org/en/14/orm/inheritance.html
+    # sqlalchemy has 3 kinds of inheritance: joined table, single table,
+    # concrete.
+    #
+    # Concrete is, essentially, not recommended unsless you have a
+    # reason to use it. Will also lead to FKs issues if the base table
+    # is abstract.
+    #
+    # "ORM-enabled UPDATEs and DELETEs do not handle joined table
+    # inheritance automatically." This means that, for example, that
+    # updating a NonInteractivePipelineRun would not allow updating the
+    # columns that belong to the InteractiveRun. This means that, for
+    # for example, the update_status_db function from the utils module
+    # would not work when updating the status of a non interactive run.
+    # https://docs.sqlalchemy.org/en/14/orm/session_basics.html#update-and-delete-with-arbitrary-where-clause
+    #
+    # Single table inheritance is the inheritance of choice, mostly
+    # because of the drawbacks of joined table inheritance. Settng the
+    # tablename to None will result in using single table inheritance,
+    # setting it to a string will result in using joined table
+    # inheritance.
+    __tablename__ = None
+
+    # TODO: verify why the experiment_uuid should be part of the
+    # primary key
+    experiment_uuid = db.Column(
+        db.String(36),
+        db.ForeignKey("experiments.experiment_uuid", ondelete="CASCADE"),
+    )
+    # This run_id is used to identify the pipeline run within the
+    # experiment and maintain a consistent ordering.
+    pipeline_run_id = db.Column(
+        db.Integer,
+        unique=False,
+    )
+
+    # related to inheriting from PipelineRun
+    __mapper_args__ = {
+        "polymorphic_identity": "NonInteractivePipelineRun",
+    }
+
+
+class PipelineRunImageMapping(BaseModel):
+    """Stores mappings between a pipeline run and the environment
      images it uses.
 
     Used to understand if an image can be removed from the docker
@@ -289,14 +247,14 @@ class NonInteractiveRunImageMapping(BaseModel):
 
     """
 
-    __tablename__ = "non_interactive_pipeline_run_image_mapping"
+    __tablename__ = "pipeline_run_image_mappings"
     __table_args__ = (
         UniqueConstraint("run_uuid", "orchest_environment_uuid"),
         UniqueConstraint("run_uuid", "docker_img_id"),
     )
 
     run_uuid = db.Column(
-        db.ForeignKey(NonInteractiveRun.run_uuid, ondelete="CASCADE"),
+        db.ForeignKey(PipelineRun.run_uuid, ondelete="CASCADE"),
         unique=False,
         nullable=False,
         index=True,
@@ -311,7 +269,7 @@ class NonInteractiveRunImageMapping(BaseModel):
 
     def __repr__(self):
         return (
-            f"<NonInteractiveRunImageMapping: {self.run_uuid} | "
+            f"<PipelineRunImageMapping: {self.run_uuid} | "
             f"{self.orchest_environment_uuid} | "
             f"{self.docker_img_id}>"
         )

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -238,6 +238,19 @@ class NonInteractivePipelineRun(PipelineRun):
     }
 
 
+class InteractivePipelineRun(PipelineRun):
+    # Just a wrapper around PipelineRun so that we can selectively
+    # reference InteractivePipelineRun(s) without filtering by the type
+    # column, which would be error prone.
+    # PipelineRun.query.filter_by(type="PipelineRun").all() becomes
+    # InteractivePipelineRun.query.all()
+    __tablename__ = None
+
+    __mapper_args__ = {
+        "polymorphic_identity": "InteractivePipelineRun",
+    }
+
+
 class PipelineRunImageMapping(BaseModel):
     """Stores mappings between a pipeline run and the environment
      images it uses.

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -138,7 +138,7 @@ def get_env_uuids_to_docker_id_mappings(
 
 
 def lock_environment_images_for_run(
-    run_id: str, project_uuid: str, environment_uuids: Set[str], is_interactive: bool
+    run_id: str, project_uuid: str, environment_uuids: Set[str]
 ) -> Dict[str, str]:
     """Retrieve the docker ids to use for a pipeline run.
 
@@ -171,9 +171,6 @@ def lock_environment_images_for_run(
         run_id:
         project_uuid:
         environment_uuids:
-        is_interactive: True if this is an interactive run, false
-         otherwise. Simply affects to what table new records are written to,
-         i.e. interactive or non interactive.
 
     Returns:
         A dictionary mapping environment uuids to the docker id
@@ -182,11 +179,7 @@ def lock_environment_images_for_run(
         if they become outdated.
 
     """
-    model = (
-        models.InteractiveRunImageMapping
-        if is_interactive
-        else models.NonInteractiveRunImageMapping
-    )
+    model = models.PipelineRunImageMapping
 
     # read the current docker image ids of each env
     env_uuid_docker_id_mappings = get_env_uuids_to_docker_id_mappings(
@@ -255,10 +248,10 @@ def interactive_runs_using_environment(project_uuid: str, env_uuid: str):
 
     Returns:
     """
-    return models.InteractiveRun.query.filter(
-        models.InteractiveRun.project_uuid == project_uuid,
-        models.InteractiveRun.image_mappings.any(orchest_environment_uuid=env_uuid),
-        models.InteractiveRun.status.in_(["PENDING", "STARTED"]),
+    return models.PipelineRun.query.filter(
+        models.PipelineRun.project_uuid == project_uuid,
+        models.PipelineRun.image_mappings.any(orchest_environment_uuid=env_uuid),
+        models.PipelineRun.status.in_(["PENDING", "STARTED"]),
     ).all()
 
 
@@ -278,10 +271,10 @@ def experiments_using_environment(project_uuid: str, env_uuid: str):
         # and is or will make use of the environment (PENDING/STARTED)
         models.Experiment.pipeline_runs.any(
             and_(
-                models.NonInteractiveRun.image_mappings.any(
+                models.NonInteractivePipelineRun.image_mappings.any(
                     orchest_environment_uuid=env_uuid
                 ),
-                models.NonInteractiveRun.status.in_(["PENDING", "STARTED"]),
+                models.NonInteractivePipelineRun.status.in_(["PENDING", "STARTED"]),
             )
         ),
     ).all()
@@ -312,15 +305,11 @@ def is_docker_image_in_use(img_id: str) -> bool:
         bool:
     """
 
-    int_runs = models.InteractiveRun.query.filter(
-        models.InteractiveRun.image_mappings.any(docker_img_id=img_id),
-        models.InteractiveRun.status.in_(["PENDING", "STARTED"]),
+    runs = models.PipelineRun.query.filter(
+        models.PipelineRun.image_mappings.any(docker_img_id=img_id),
+        models.PipelineRun.status.in_(["PENDING", "STARTED"]),
     ).all()
-    non_int_runs = models.NonInteractiveRun.query.filter(
-        models.NonInteractiveRun.image_mappings.any(docker_img_id=img_id),
-        models.NonInteractiveRun.status.in_(["PENDING", "STARTED"]),
-    ).all()
-    return len(int_runs) > 0 or len(non_int_runs) > 0
+    return bool(runs)
 
 
 def remove_if_dangling(img) -> bool:

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -248,10 +248,12 @@ def interactive_runs_using_environment(project_uuid: str, env_uuid: str):
 
     Returns:
     """
-    return models.PipelineRun.query.filter(
-        models.PipelineRun.project_uuid == project_uuid,
-        models.PipelineRun.image_mappings.any(orchest_environment_uuid=env_uuid),
-        models.PipelineRun.status.in_(["PENDING", "STARTED"]),
+    return models.InteractivePipelineRun.query.filter(
+        models.InteractivePipelineRun.project_uuid == project_uuid,
+        models.InteractivePipelineRun.image_mappings.any(
+            orchest_environment_uuid=env_uuid
+        ),
+        models.InteractivePipelineRun.status.in_(["PENDING", "STARTED"]),
     ).all()
 
 

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -3,12 +3,7 @@ class Config:
     TESTING = False
 
     # must be uppercase
-    # https://flask-appbuilder.readthedocs.io/en/latest/multipledbs.html
-    SQLALCHEMY_DATABASE_URI = "sqlite:////tmp/resources.db"
-    SQLALCHEMY_BINDS = {
-        # /userdir works because it's mounted via docker
-        "persistent_db": "sqlite:////userdir/.orchest/orchest-api.db",
-    }
+    SQLALCHEMY_DATABASE_URI = "postgresql://postgres@orchest-database/orchest_api"
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
@@ -31,7 +26,12 @@ class Config:
     # For this reason no solution is provided for this, taking into account that we will eventually
     # implement cronjobs and such trimming might be an internal cronjob, or automatically managed
     # by celery if we end using "celery beat".
-    result_backend = "db+sqlite:////userdir/.orchest/celery_result_backend.db"
+    _result_backend_server = "postgres@orchest-database/celery_result_backend"
+    # used to create the db if it does not exist, the function needs
+    # this exact url format
+    result_backend_sqlalchemy_uri = f"postgresql://{_result_backend_server}"
+    # this format is used by celery
+    result_backend = f"db+postgresql+psycopg2://{_result_backend_server}"
 
     imports = ("app.core.tasks",)
     task_create_missing_queues = True

--- a/services/orchest-api/requirements-dev.txt
+++ b/services/orchest-api/requirements-dev.txt
@@ -12,4 +12,5 @@ Werkzeug==0.16.0
 python-engineio==3.14.2
 python-socketio[client]==4.6.1
 eventlet==0.29.1
+SQLAlchemy-Utils==0.36.8
 -e ../../lib/python/orchest-internals

--- a/services/orchest-api/requirements.txt
+++ b/services/orchest-api/requirements.txt
@@ -12,4 +12,6 @@ Werkzeug==0.16.0
 python-engineio==3.14.2
 python-socketio[client]==4.6.1
 eventlet==0.29.1
+SQLAlchemy-Utils==0.36.8
+psycopg2-binary==2.8.6
 -e ../../lib/python/orchest-internals

--- a/services/orchest-ctl/app/cmdline.py
+++ b/services/orchest-ctl/app/cmdline.py
@@ -132,9 +132,9 @@ def start():
         # TODO: should we have a generic abstraction when it comes to
         # dependencies among the services? I don't think it's needed.
         if container_image.startswith("postgres"):
-            exit_code, _ = container.exec_run("pg_isready")
+            exit_code, _ = container.exec_run("pg_isready --username postgres")
             while exit_code != 0:
-                exit_code, _ = container.exec_run("pg_isready")
+                exit_code, _ = container.exec_run("pg_isready --username postgres")
                 time.sleep(1)
 
     utils.log_server_url()

--- a/services/orchest-ctl/app/cmdline.py
+++ b/services/orchest-ctl/app/cmdline.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import time
 
 import typer
 
@@ -124,7 +125,17 @@ def start():
         run_config = utils.convert_to_run_config(container_image, container_spec)
 
         logging.info("Starting image %s" % container_image)
-        docker_client.containers.run(**run_config)
+        container = docker_client.containers.run(**run_config)
+
+        # wait for the db to be accepting connections before launching
+        # other containers, this will likely take 1 try or two.
+        # TODO: should we have a generic abstraction when it comes to
+        # dependencies among the services? I don't think it's needed.
+        if container_image.startswith("postgres"):
+            exit_code, _ = container.exec_run("pg_isready")
+            while exit_code != 0:
+                exit_code, _ = container.exec_run("pg_isready")
+                time.sleep(1)
 
     utils.log_server_url()
 

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -161,8 +161,8 @@ CONTAINER_MAPPING = {
         },
         "mounts": [
             {
-                "source": os.path.join(ENVS["HOST_USER_DIR"], ".orchest"),
-                "target": "/userdir/.orchest",
+                "source": os.path.join(ENVS["HOST_USER_DIR"], ".orchest", "database"),
+                "target": "/userdir/.orchest/database",
             },
         ],
     },

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -27,6 +27,7 @@ _orchest_images = [
     "orchest/file-manager:latest",
     "orchest/nginx-proxy:latest",
     "rabbitmq:3",
+    "postgres:13.1",
 ]
 LANGUAGE_IMAGES = {
     "none": _orchest_images,
@@ -56,6 +57,9 @@ LANGUAGE_IMAGES = {
 
 # Images to be run on start of Orchest.
 ON_START_IMAGES = [
+    # the database (postgres) needs to be started before the containers
+    # that depend on it are (webserver, api, auth)
+    "postgres:13.1",
     "orchest/orchest-api:latest",
     "orchest/orchest-webserver:latest",
     "orchest/celery-worker:latest",
@@ -148,6 +152,19 @@ CONTAINER_MAPPING = {
             "443/tcp": 443,
         },
         "mounts": [],  # dynamically added in start() based on presence of certs on host
+    },
+    "postgres:13.1": {
+        "name": "orchest-database",
+        "environment": {
+            "PGDATA": "/userdir/.orchest/database/data",
+            "POSTGRES_HOST_AUTH_METHOD": "trust",
+        },
+        "mounts": [
+            {
+                "source": os.path.join(ENVS["HOST_USER_DIR"], ".orchest"),
+                "target": "/userdir/.orchest",
+            },
+        ],
     },
     "orchest/update-server:latest": {
         "name": "update-server",

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -118,13 +118,16 @@ def create_app():
 
     logging.info("Flask CONFIG: %s" % app.config)
 
+    # Create the database if it does not exist yet. Roughly equal to a
+    # "CREATE DATABASE IF NOT EXISTS <db_name>" call.
     if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
         create_database(app.config["SQLALCHEMY_DATABASE_URI"])
     db.init_app(app)
     ma.init_app(app)
 
-    # according to SQLAlchemy will only create tables if they do not exist
     with app.app_context():
+        # This call will create tables if needed (the ones which do not
+        # exist in the database yet).
         db.create_all()
         # this class is only serialized on disk
         # see the Environment model

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -21,6 +21,8 @@ import base64
 
 from flask import Flask, send_from_directory
 from flask_socketio import SocketIO
+from sqlalchemy_utils import create_database, database_exists
+
 from app.config import CONFIG_CLASS
 from apscheduler.schedulers.background import BackgroundScheduler
 from app.analytics import analytics_ping
@@ -116,6 +118,8 @@ def create_app():
 
     logging.info("Flask CONFIG: %s" % app.config)
 
+    if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
+        create_database(app.config["SQLALCHEMY_DATABASE_URI"])
     db.init_app(app)
     ma.init_app(app)
 

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -8,7 +8,7 @@ class Config:
     DEBUG = False
     TESTING = False
 
-    SQLALCHEMY_DATABASE_URI = "sqlite:////userdir/.orchest/orchest-webserver.db"
+    SQLALCHEMY_DATABASE_URI = "postgresql://postgres@orchest-database/orchest_webserver"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/services/orchest-webserver/app/app/models.py
+++ b/services/orchest-webserver/app/app/models.py
@@ -105,7 +105,7 @@ class BackgroundTask(db.Model):
 
     task_uuid = db.Column(db.String(36), primary_key=True, unique=True, nullable=False)
     # see background_task_executor types
-    task_type = db.Column(db.String(15), unique=False, nullable=True)
+    task_type = db.Column(db.String(50), unique=False, nullable=True)
     status = db.Column(db.String(15), unique=False, nullable=False)
     code = db.Column(db.String(15), unique=False, nullable=True)
     result = db.Column(db.String(), unique=False, nullable=True)

--- a/services/orchest-webserver/app/scripts/file_permission_watcher.py
+++ b/services/orchest-webserver/app/scripts/file_permission_watcher.py
@@ -34,15 +34,27 @@ def fix_path_permission(path, is_dir):
             os.chmod(path, 0o646)
 
 
-def walk_dir(path):
+def walk_dir(path, ignored_paths):
 
     for dp, dirs, files in os.walk(path):
         for f in files:
             current_path = os.path.join(dp, f)
-            fix_path_permission(current_path, os.path.isdir(current_path))
+            if all(
+                [
+                    not current_path.startswith(ignored_path)
+                    for ignored_path in ignored_paths
+                ]
+            ):
+                fix_path_permission(current_path, os.path.isdir(current_path))
         for d in dirs:
             current_path = os.path.join(dp, d)
-            fix_path_permission(current_path, os.path.isdir(current_path))
+            if all(
+                [
+                    not current_path.startswith(ignored_path)
+                    for ignored_path in ignored_paths
+                ]
+            ):
+                fix_path_permission(current_path, os.path.isdir(current_path))
 
 
 def main():
@@ -60,8 +72,11 @@ def main():
 
     logger.info("Started permission logging")
 
+    ignored_paths = [os.path.join(".orchest", "database")]
+    ignored_paths = [os.path.join(sys.argv[1], path) for path in ignored_paths]
+
     while True:
-        walk_dir(sys.argv[1])
+        walk_dir(sys.argv[1], ignored_paths)
         time.sleep(1)
 
 

--- a/services/orchest-webserver/requirements.txt
+++ b/services/orchest-webserver/requirements.txt
@@ -15,5 +15,7 @@ docker>=4.3.0
 Werkzeug==0.16.0
 python-engineio==3.14.2
 python-socketio==4.6.1
+SQLAlchemy-Utils==0.36.8
 posthog==1.1.3
+psycopg2-binary==2.8.6
 -e ../../lib/python/orchest-internals

--- a/userdir/.orchest/database/.gitignore
+++ b/userdir/.orchest/database/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This PR changes the database backend of Orchest from `sqllite` to `postgres`. A new service, `orchest-database`, is launched on start.

The PR affects `orchest-ctl` and services that were persisting their data: the `auth-server`, `orchest-webserver`, `orchest-api`, `celery-worker`.