### PR TITLE
Invalidate user environment on update

### DIFF
--- a/services/orchest-ctl/app/cmdline.py
+++ b/services/orchest-ctl/app/cmdline.py
@@ -236,6 +236,21 @@ def update(language):
         # during the update to support _updateserver
         stop(skip_names=["nginx-proxy", "update-server"])
 
+    # Delete all user built environments. This is to avoid the issue of
+    # having environments with mismatching Orchest SDK versions.
+    # TODO: once/if we have GPU and Language labels then we might be
+    # more selective on the way we delete such environments.
+    filters = {
+        "label": [
+            "_orchest_project_uuid",
+        ]
+    }
+    filters = {"label": ["_orchest_project_uuid"]}
+    # Can't use docker_client.images.prune because such filtering is not
+    # supported.
+    for img in docker_client.images.list(filters=filters):
+        docker_client.images.remove(img.id)
+
     # Update git repository to get the latest changes to the ``userdir``
     # structure.
     logging.info("Updating repo ...")

--- a/services/orchest-ctl/app/cmdline.py
+++ b/services/orchest-ctl/app/cmdline.py
@@ -220,6 +220,22 @@ def _updateserver():
     docker_client.containers.run(**run_config)
 
 
+def clear_environment_images():
+    """Delete all user built environments.
+
+    This is to avoid the issue of having environments with mismatching
+    Orchest SDK versions.
+    """
+
+    # TODO: once/if we have GPU and Language labels then we might be
+    # more selective on the way we delete such environments.
+    filters = {"label": ["_orchest_project_uuid"]}
+    # Can't use docker_client.images.prune because such filtering is not
+    # supported.
+    for img in docker_client.images.list(filters=filters):
+        docker_client.images.remove(img.id)
+
+
 def update(language):
     typer.echo("[Update]: ...")
 
@@ -236,20 +252,7 @@ def update(language):
         # during the update to support _updateserver
         stop(skip_names=["nginx-proxy", "update-server"])
 
-    # Delete all user built environments. This is to avoid the issue of
-    # having environments with mismatching Orchest SDK versions.
-    # TODO: once/if we have GPU and Language labels then we might be
-    # more selective on the way we delete such environments.
-    filters = {
-        "label": [
-            "_orchest_project_uuid",
-        ]
-    }
-    filters = {"label": ["_orchest_project_uuid"]}
-    # Can't use docker_client.images.prune because such filtering is not
-    # supported.
-    for img in docker_client.images.list(filters=filters):
-        docker_client.images.remove(img.id)
+    clear_environment_images()
 
     # Update git repository to get the latest changes to the ``userdir``
     # structure.

--- a/services/orchest-ctl/app/cmdline.py
+++ b/services/orchest-ctl/app/cmdline.py
@@ -220,22 +220,6 @@ def _updateserver():
     docker_client.containers.run(**run_config)
 
 
-def clear_environment_images():
-    """Delete all user built environments.
-
-    This is to avoid the issue of having environments with mismatching
-    Orchest SDK versions.
-    """
-
-    # TODO: once/if we have GPU and Language labels then we might be
-    # more selective on the way we delete such environments.
-    filters = {"label": ["_orchest_project_uuid"]}
-    # Can't use docker_client.images.prune because such filtering is not
-    # supported.
-    for img in docker_client.images.list(filters=filters):
-        docker_client.images.remove(img.id)
-
-
 def update(language):
     typer.echo("[Update]: ...")
 
@@ -252,7 +236,7 @@ def update(language):
         # during the update to support _updateserver
         stop(skip_names=["nginx-proxy", "update-server"])
 
-    clear_environment_images()
+    utils.clear_environment_images()
 
     # Update git repository to get the latest changes to the ``userdir``
     # structure.

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -198,7 +198,7 @@ def fix_userdir_permissions():
     """setgid on all directories in userdir to make sure new files
     created by containers are read/write for sibling containers
     and the host user"""
-    
+
     try:
         os.system("find /orchest-host/userdir -type d -exec chmod g+s {} \;")
     except Exception as e:
@@ -313,3 +313,19 @@ def convert_to_run_config(image_name, container_spec):
         run_config["group_add"] = container_spec.get("group_add")
 
     return run_config
+
+
+def clear_environment_images():
+    """Delete all user built environments.
+
+    This is to avoid the issue of having environments with mismatching
+    Orchest SDK versions.
+    """
+
+    # TODO: once/if we have GPU and Language labels then we might be
+    # more selective on the way we delete such environments.
+    filters = {"label": ["_orchest_project_uuid"]}
+    # Can't use docker_client.images.prune because such filtering is not
+    # supported.
+    for img in docker_client.images.list(filters=filters):
+        docker_client.images.remove(img.id)


### PR DESCRIPTION
This PR makes it so that user environments are invalidated when Orchest updates, to avoid issues related to mismatching versions of the `Orchest SDK` in different environments.