### PR TITLE
Improve orchest api status updates race conditions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,8 @@ ignore =
     # Allow breaks before/after binary operators
     W503,
     W504,
+    # Ignore invalid escape sequence, see services/orchest-api/app/app/core/environment_builds.py:262:55
+    W605
 
 # black is set to 88
 max-line-length = 88

--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ ignore =
     # Allow breaks before/after binary operators
     W503,
     W504,
-    # Ignore invalid escape sequence, see services/orchest-api/app/app/core/environment_builds.py:262:55
+    # Ignore invalid escape sequences.
     W605
 
 # black is set to 88

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -1,9 +1,5 @@
-import logging
-
-from docker import errors
 from flask_restx import Namespace, Resource
 
-import app.models as models
 from _orchest.internals import config as _config
 from _orchest.internals.utils import docker_images_list_safe, docker_images_rm_safe
 from app.apis.namespace_environment_builds import (
@@ -33,7 +29,7 @@ api = register_schema(api)
 class EnvironmentImage(Resource):
     @api.doc("delete-environment-image")
     def delete(self, project_uuid, environment_uuid):
-        """Removes an environment image given project_uuid and image_uuid
+        """Removes an environment image given project and image uuids.
 
         Will stop any run or experiment making use of this environment.
         """
@@ -106,22 +102,21 @@ def delete_project_environment_images(project_uuid):
         project_uuid:
     """
 
-    # cleanup references to the builds and dangling images
-    # of all environments of this project
+    # Cleanup references to the builds and dangling images
+    # of all environments of this project.
     delete_project_builds(project_uuid)
     delete_project_dangling_images(project_uuid)
 
     filters = {
         "label": [
-            f"_orchest_env_build_is_intermediate=0",
+            "_orchest_env_build_is_intermediate=0",
             f"_orchest_project_uuid={project_uuid}",
         ]
     }
     images_to_remove = docker_images_list_safe(docker_client, filters=filters)
 
-    image_remove_exceptions = []
-    # try with repeat because there might be a race condition
-    # where the aborted runs are still using the image
+    # Try with repeat because there might be a race condition
+    # where the aborted runs are still using the image.
     for img in images_to_remove:
         docker_images_rm_safe(docker_client, img.id)
 
@@ -136,10 +131,10 @@ def delete_project_dangling_images(project_uuid):
     Args:
         project_uuid:
     """
-    # look only through runs belonging to the project
+    # Look only through runs belonging to the project.
     filters = {
         "label": [
-            f"_orchest_env_build_is_intermediate=0",
+            "_orchest_env_build_is_intermediate=0",
             f"_orchest_project_uuid={project_uuid}",
         ]
     }
@@ -165,7 +160,7 @@ def delete_project_environment_dangling_images(project_uuid, environment_uuid):
     # consider only docker ids related to the environment_uuid
     filters = {
         "label": [
-            f"_orchest_env_build_is_intermediate=0",
+            "_orchest_env_build_is_intermediate=0",
             f"_orchest_project_uuid={project_uuid}",
             f"_orchest_environment_uuid={environment_uuid}",
         ]

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -29,7 +29,7 @@ api = register_schema(api)
 class EnvironmentImage(Resource):
     @api.doc("delete-environment-image")
     def delete(self, project_uuid, environment_uuid):
-        """Removes an environment image given project and image uuids.
+        """Removes an environment image given project and env uuids.
 
         Will stop any run or experiment making use of this environment.
         """

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -254,6 +254,7 @@ def stop_pipeline_run(run_uuid) -> bool:
 
     filter_by = {"run_uuid": run_uuid}
     status_update = {"status": "ABORTED"}
+    update_status_db(status_update, model=models.PipelineRunStep, filter_by=filter_by)
     update_status_db(status_update, model=models.PipelineRun, filter_by=filter_by)
 
     return True

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -2,7 +2,6 @@
 
 Note: "run" is short for "interactive pipeline run".
 """
-import logging
 import uuid
 
 from celery.contrib.abortable import AbortableAsyncResult
@@ -35,8 +34,8 @@ class RunList(Resource):
 
         query = models.InteractivePipelineRun.query
 
-        # Ability to query a specific runs given the `pipeline_uuid` or `project_uuid`
-        # through the URL (using `request.args`).
+        # Ability to query a specific runs given the `pipeline_uuid` or
+        # `project_uuid` through the URL (using `request.args`).
         if "pipeline_uuid" in request.args and "project_uuid" in request.args:
             query = query.filter_by(
                 pipeline_uuid=request.args.get("pipeline_uuid")
@@ -123,7 +122,10 @@ class RunList(Resource):
             db.session.commit()
 
             return {
-                "message": "Failed to start interactive run because not all referenced environments are available."
+                "message": (
+                    "Failed to start interactive run because not all"
+                    "referenced environments are available."
+                )
             }, 500
 
         # Create Celery object with the Flask context and construct the
@@ -249,5 +251,9 @@ def stop_pipeline_run(run_uuid) -> bool:
     res.abort()
 
     celery_app.control.revoke(run_uuid)
+
+    filter_by = {"run_uuid": run_uuid}
+    status_update = {"status": "ABORTED"}
+    update_status_db(status_update, model=models.PipelineRun, filter_by=filter_by)
 
     return True

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -28,13 +28,15 @@ def cleanup_env_build_docker_artifacts(filters):
     Returns:
 
     """
-    # actually we are just looking for a single container, but the syntax is the same as looking for N
+    # Actually we are just looking for a single container, but the
+    # syntax is the same as looking for N.
     containers_to_prune = docker_client.containers.list(filters=filters, all=True)
     tries = 0
     while containers_to_prune:
         docker_client.containers.prune(filters=filters)
         containers_to_prune = docker_client.containers.list(filters=filters, all=True)
-        # be as responsive as possible, only sleep at the first iteration if necessary
+        # Be as responsive as possible, only sleep at the first
+        # iteration if necessary.
         if containers_to_prune:
             tries += 1
             if tries > 100:
@@ -45,18 +47,22 @@ def cleanup_env_build_docker_artifacts(filters):
                 break
             time.sleep(1)
 
-    # only get to this point once there are no depending containers
-    # we DO NOT use all=True as an argument here because it will also return intermediate layers, which will
-    # not be pruneable if the build is successful. Those layers will be automatically deleted when the env
-    # image is deleted. What we are actually doing here is getting the last image created by the build process
-    # by getting all the images created by the build process. Removing n-1 of them will result in a no op,
-    # but 1 of them will cause the "ancestor" images to be removed as well.
+    # Only get to this point once there are no depending containers>
+    # We DO NOT use all=True as an argument here because it will also
+    # return intermediate layers, which will not be pruneable if the
+    # build is successful. Those layers will be automatically deleted
+    # when the env image is deleted. What we are actually doing here
+    # is getting the last image created by the build process by getting
+    # all the images created by the build process. Removing n-1 of them
+    # will result in a no op, but 1 of them will cause the "ancestor
+    # images to be removed as well.
     images_to_prune = docker_images_list_safe(docker_client, filters=filters)
     tries = 0
     while images_to_prune:
         docker_client.images.prune(filters=filters)
         images_to_prune = docker_images_list_safe(docker_client, filters=filters)
-        # be as responsive as possible, only sleep at the first iteration if necessary
+        # Be as responsive as possible, only sleep at the first
+        # iteration if necessary.
         if images_to_prune:
             tries += 1
             if tries > 100:
@@ -80,7 +86,10 @@ def update_environment_build_status(
     elif data["status"] in ["SUCCESS", "FAILURE"]:
         data["finished_time"] = datetime.utcnow().isoformat()
 
-    url = f"{CONFIG_CLASS.ORCHEST_API_ADDRESS}/environment-builds/{environment_build_uuid}"
+    url = (
+        f"{CONFIG_CLASS.ORCHEST_API_ADDRESS}/environment-builds/"
+        "{environment_build_uuid}"
+    )
 
     with session.put(url, json=data) as response:
         return response.json()
@@ -93,14 +102,17 @@ def build_docker_image(
     user_logs_file_object,
     complete_logs_path,
 ):
-    """Build a docker image with the given tag, context_path and docker file.
+    """Build a docker image with the given tag, context_path and docker
+        file.
 
     Args:
         image_name:
         build_context:
         dockerfile_path:
-        user_logs_file_object: file object to which logs from the user script are written.
-        complete_logs_path: path to where to store the full logs are written
+        user_logs_file_object: file object to which logs from the user
+            script are written.
+        complete_logs_path: path to where to store the full logs are
+            written.
 
     Returns:
 
@@ -111,13 +123,19 @@ def build_docker_image(
             docker_client.images.get(build_context["base_image"])
         except docker.errors.ImageNotFound as e:
             complete_logs_file_object.write(
-                "Docker error ImageNotFound: need to pull image as part of the build. Error: %s"
+                (
+                    "Docker error ImageNotFound: need to pull image as "
+                    "part of the build. Error: %s"
+                )
                 % e
             )
             user_logs_file_object.write(
-                f'Base image `{build_context["base_image"]}` not found. Pulling image...\n'
+                (
+                    f'Base image `{build_context["base_image"]}` not found. '
+                    "Pulling image...\n"
+                )
             )
-        except Exception as e:
+        except Exception:
             complete_logs_file_object.write(
                 "docker_client.images.get() call to Docker API failed."
             )
@@ -139,9 +157,12 @@ def build_docker_image(
             try:
                 output = next(generator)
                 json_output = json.loads(output)
-                # Checking for logs. Even if we consider to be done with the logs (found_ending_flag == True) we do not
-                # break out of the while loop because the build needs to keep going, both for error reporting
-                # and for actually allowing the build to keep going, which would not happen if we process exits.
+                # Checking for logs. Even if we consider to be done with
+                # the logs (found_ending_flag == True) we do not break
+                # out of the while loop because the build needs to keep
+                # going, both for error reporting and for actually
+                # allowing the build to keep going, which would not
+                # happen if we process exits.
                 if "stream" in json_output:
                     stream = json_output["stream"]
 
@@ -149,8 +170,9 @@ def build_docker_image(
                     complete_logs_file_object.flush()
 
                     if not found_ending_flag:
-                        # beginning flag not found --> do not log
-                        # beginning flag found --> log until you find the ending flag
+                        # Beginning flag not found --> do not log.
+                        # Beginning flag found --> log until you find
+                        # the ending flag.
                         if not found_beginning_flag:
                             found_beginning_flag = stream.startswith(flag)
                             if found_beginning_flag:
@@ -168,12 +190,12 @@ def build_docker_image(
                     or ("errorDetail" in json_output)
                 )
 
-            # build is done
+            # Build is done.
             except StopIteration:
                 break
             except ValueError:
                 pass
-            # any other exception will lead to a fail of the build
+            # Any other exception will lead to a fail of the build.
             except Exception:
                 had_errors = True
 
@@ -195,10 +217,11 @@ def build_docker_image(
 def write_environment_dockerfile(
     base_image, task_uuid, project_uuid, env_uuid, work_dir, bash_script, flag, path
 ):
-    """Write a custom dockerfile with the given specifications. This dockerfile is built in an ad-hoc way
-     to later be able to only log stuff related to the user script.
+    """Write a custom dockerfile with the given specifications.
 
-    Note that the produced dockerfile will make it so that the entire context is copied.
+    This dockerfile is built in an ad-hoc way to later be able to only
+    log messages related to the user script. Note that the produced
+    dockerfile will make it so that the entire context is copied.
 
     Args:
         base_image: Base image of the docker file.
@@ -207,7 +230,8 @@ def write_environment_dockerfile(
         env_uuid:
         work_dir: Working directory.
         bash_script: Script to run in a RUN command.
-        flag: Flag to use to be able to differentiate between logs of the bash_script and logs to be ignored.
+        flag: Flag to use to be able to differentiate between logs of
+            the bash_script and logs to be ignored.
         path: Where to save the file.
 
     Returns:
@@ -221,15 +245,17 @@ def write_environment_dockerfile(
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
 
-    # copy the entire context, that is, given the current use case,
-    # that we are copying the project directory (from the snapshot) into the docker image that is to be built,
-    # this allows the user defined script defined through orchest to make use of files
-    # that are part of its project, e.g. a requirements.txt or other scripts.
+    # Copy the entire context, that is, given the current use case, that
+    # we are copying the project directory (from the snapshot) into the
+    # docker image that is to be built, this allows the user defined
+    # script defined through orchest to make use of files that are part
+    # of its project, e.g. a requirements.txt or other scripts.
     statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
 
-    # note: commands are concatenated with && because this way an exit_code != 0 will bubble up
-    # and cause the docker build to fail, as it should.
-    # the bash script is removed so that the user won't be able to see it after the build is done
+    # Note: commands are concatenated with && because this way an
+    # exit_code != 0 will bubble up and cause the docker build to fail,
+    # as it should. The bash script is removed so that the user won't
+    # be able to see it after the build is done.
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
         "&& sudo chown -R :$(id -g) . "
@@ -260,9 +286,12 @@ def check_environment_correctness(project_uuid, environment_uuid, project_path):
     Returns:
 
     Raises:
-        OSError if the project path is missing, if the environment within the project cannot be found, if the
-         environment properties.json cannot be found or if the user bash script cannot be found.
-        ValueError if project_uuid, environment_uuid, base_image are incorrect or missing.
+        OSError if the project path is missing, if the environment
+            within the project cannot be found, if the environment
+            properties.json cannot be found or if the user bash script
+            cannot be found.
+        ValueError if project_uuid, environment_uuid, base_image are
+            incorrect or missing.
 
     """
     if not os.path.exists(project_path):
@@ -305,10 +334,12 @@ def check_environment_correctness(project_uuid, environment_uuid, project_path):
 def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_path):
     """Prepares the docker build context for a given environment.
 
-    Prepares the docker build context by taking a snapshot of the project directory, and using this
-    snapshot as a context in which the ad-hoc docker file will be placed. This dockerfile is built in a way
-    to respect the environment properties (base image, user bash script, etc.) while also allowing to log
-    only the messages that are related to the user script while building the docker image.
+    Prepares the docker build context by taking a snapshot of the
+    project directory, and using this snapshot as a context in which the
+    ad-hoc docker file will be placed. This dockerfile is built in a way
+    to respect the environment properties (base image, user bash script,
+    etc.) while also allowing to log only the messages that are related
+    to the user script while building the docker image.
 
     Args:
         task_uuid:
@@ -380,8 +411,9 @@ def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_pat
 def build_environment_task(task_uuid, project_uuid, environment_uuid, project_path):
     """Function called by the celery task to build an environment.
 
-    Builds an environment (docker image) given the arguments, the logs produced by the user provided script
-    are forwarded to a SocketIO server and namespace defined in the orchest internals config.
+    Builds an environment (docker image) given the arguments, the logs
+    produced by the user provided script are forwarded to a SocketIO
+    server and namespace defined in the orchest internals config.
 
     Args:
         task_uuid:
@@ -397,12 +429,13 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
         try:
             update_environment_build_status("STARTED", session, task_uuid)
 
-            # prepare the project snapshot with the correctly placed dockerfile, scripts, etc.
+            # Prepare the project snapshot with the correctly placed
+            # dockerfile, scripts, etc.
             build_context = prepare_build_context(
                 task_uuid, project_uuid, environment_uuid, project_path
             )
 
-            # use the agreed upon pattern for the docker image name
+            # Use the agreed upon pattern for the docker image name.
             docker_image_name = _config.ENVIRONMENT_IMAGE_NAME.format(
                 project_uuid=project_uuid, environment_uuid=environment_uuid
             )
@@ -415,7 +448,7 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
             )
 
             status = SioStreamedTask.run(
-                # what we are actually running/doing in this task
+                # What we are actually running/doing in this task,
                 task_lambda=lambda user_logs_fo: build_docker_image(
                     docker_image_name,
                     build_context,
@@ -427,10 +460,10 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
                 server=_config.ORCHEST_SOCKETIO_SERVER_ADDRESS,
                 namespace=_config.ORCHEST_SOCKETIO_ENV_BUILDING_NAMESPACE,
                 # note: using task.is_aborted() could be an option but
-                # it was giving some issues related
-                # to multithreading/processing, moreover,
-                # also just passing the task_uuid to this function is less information
-                # to rely on, which is good
+                # it was giving some issues related to
+                # multithreading/processing, moreover, also just passing
+                # the task_uuid to this function is less information to
+                # rely on, which is good.
                 abort_lambda=lambda: AbortableAsyncResult(task_uuid).is_aborted(),
             )
 
@@ -439,7 +472,8 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
 
             update_environment_build_status(status, session, task_uuid)
 
-        # catch all exceptions because we need to make sure to set the build state to failed
+        # Catch all exceptions because we need to make sure to set the
+        # build state to failed.
         except Exception as e:
             update_environment_build_status("FAILURE", session, task_uuid)
             raise e
@@ -451,10 +485,12 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
                 ]
             }
 
-            # artifacts of this build (intermediate containers, images, etc.)
+            # Artifacts of this build (intermediate containers, images,
+            # etc.)
             cleanup_env_build_docker_artifacts(filters)
 
-            # see if outdated images of this environment can be cleaned up
+            # See if outdated images of this environment can be cleaned
+            # up.
             url = (
                 f"{CONFIG_CLASS.ORCHEST_API_ADDRESS}"
                 f"/environment-images/dangling/{project_uuid}/{environment_uuid}"

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -497,4 +497,7 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
             )
             session.delete(url)
 
-    return status
+    # The status of the Celery task is SUCCESS since it has finished
+    # running. Not related to the actual state of the build, e.g.
+    # FAILURE.
+    return "SUCCESS"

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -88,7 +88,7 @@ def update_environment_build_status(
 
     url = (
         f"{CONFIG_CLASS.ORCHEST_API_ADDRESS}/environment-builds/"
-        "{environment_build_uuid}"
+        f"{environment_build_uuid}"
     )
 
     with session.put(url, json=data) as response:

--- a/services/orchest-api/app/app/core/pipelines.py
+++ b/services/orchest-api/app/app/core/pipelines.py
@@ -822,11 +822,8 @@ class Pipeline:
                 compute_backend=compute_backend,
             )
 
-            # NOTE: the status of a pipeline is always success once it
-            # is done executing. Errors in steps are reflected by the
-            # status of the respective steps.
             await update_status(
-                "SUCCESS",
+                status,
                 task_id,
                 session,
                 type="pipeline",
@@ -838,10 +835,6 @@ class Pipeline:
         # Reset the execution environment of the Pipeline.
         for step in self.steps:
             step._status = "PENDING"
-
-        # Status will contain whether any failures occured during
-        # execution of the pipeline.
-        return status
 
     def __repr__(self) -> str:
         return f"Pipeline({self.steps!r})"

--- a/services/orchest-api/app/app/core/pipelines.py
+++ b/services/orchest-api/app/app/core/pipelines.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 import aiodocker
 import aiohttp
 from config import CONFIG_CLASS
-from docker.types import Mount
 
 from _orchest.internals import config as _config
 from _orchest.internals.utils import get_device_requests, get_orchest_mounts
@@ -58,8 +57,8 @@ def construct_pipeline(
         All options for the config should be documented somewhere.
 
     Args:
-        uuids: a selection/sequence of pipeline step UUIDs. If `run_type`
-            equals "full", then this argument is ignored.
+        uuids: a selection/sequence of pipeline step UUIDs. If
+            `run_type` equals "full", then this argument is ignored.
         run_type: one of ("full", "selection", "incoming").
         pipeline_definition: a json description of the pipeline.
         config: configuration for the `run_type`.
@@ -70,8 +69,9 @@ def construct_pipeline(
         `pipeline_definition`:
             * "full" -> entire pipeline from description
             * "selection" -> induced subgraph based on selection.
-            * "incoming" -> all incoming steps of the selection. In other
-                words: all ancestors of the steps of the selection.
+            * "incoming" -> all incoming steps of the selection. In
+                other words: all ancestors of the steps of the
+                selection.
 
         As of now, the selection itself is NOT included in the Pipeline
         if `run_type` equals "incoming".
@@ -122,9 +122,9 @@ async def update_status(
     elif type == "pipeline":
         url = base_url
 
-    # Just await the response.
-    # The proposed fix on the aiohttp GitHub to do
-    # `response.json(content_type=None)` still results in parsing issues.
+    # Just await the response. The proposed fix on the aiohttp GitHub to
+    # do `response.json(content_type=None)` still results in parsing
+    # issues.
     await session.put(url, json=data)
 
 
@@ -133,8 +133,10 @@ def get_volume_mounts(run_config, task_id):
     # Determine the appropriate name for the volume that shares
     # temporary data amongst containers.
 
-    # This branching logic is because the volume is shared with Jupyter kernels
-    # for the InteractiveRuns, while for NonInteractiveRuns it's unique to the task.
+    # This branching logic is because the volume is shared with Jupyter
+    # kernels.
+    # For the InteractiveRuns, while for NonInteractiveRuns it's unique
+    # to the task.
     if run_config["run_endpoint"] == "runs":
         volume_uuid = run_config["pipeline_uuid"]
     elif run_config["run_endpoint"].startswith("experiments"):
@@ -206,10 +208,11 @@ class PipelineStepRunner:
         if self._status != "PENDING":
             # The step has already been started.
 
-            # Each parent attempts to start their children when they finish.
-            # When all parents finish simultaneously (with all their _status'es being
-            # "SUCCESS") not checking whether the child has started or not would lead
-            # to multiple start attempts of the child, resulting in errors.
+            # Each parent attempts to start their children when they
+            # finish. When all parents finish simultaneously (with all
+            # their _status'es being "SUCCESS") not checking whether
+            # the child has started or not would lead to multiple start
+            # attempts of the child, resulting in errors.
             return self._status
 
         # TODO: better error handling?
@@ -238,10 +241,10 @@ class PipelineStepRunner:
             form="docker-engine",
         )
 
-        # the working directory relative to the project directory is based on the location of the pipeline
-        # e.g. if the pipeline is in
-        #   /project-dir/my/project/path/mypipeline.orchest the working directory will be
-        #   my/project/path/
+        # The working directory relative to the project directory is
+        # based on the location of the pipeline, e.g. if the pipeline is
+        # in /project-dir/my/project/path/mypipeline.orchest the working
+        # directory will be my/project/path/.
         working_dir = os.path.split(run_config["pipeline_path"])[0]
 
         config = {
@@ -278,7 +281,8 @@ class PipelineStepRunner:
                 self.properties["file_path"],
             ],
             "NetworkingConfig": {
-                "EndpointsConfig": {"orchest": {}}  # TODO: should not be hardcoded.
+                # TODO: should not be hardcoded.
+                "EndpointsConfig": {"orchest": {}}
             },
             # NOTE: the `'tests-uuid'` key is only used for tests and
             # gets ignored by the `docker_client`.
@@ -299,9 +303,9 @@ class PipelineStepRunner:
 
             data = await container.wait()
 
-            # The status code will be 0 for "SUCCESS" and -N otherwise. A
-            # negative value -N indicates that the child was terminated
-            # by signal N (POSIX only).
+            # The status code will be 0 for "SUCCESS" and -N otherwise.
+            # A negative value -N indicates that the child was
+            # terminated by signal N (POSIX only).
             if data.get("StatusCode") != 0:
                 self._status = "FAILURE"
                 logging.error(
@@ -367,9 +371,10 @@ class PipelineStepRunner:
 
             res = await asyncio.gather(*tasks)
 
-            # If one of the children turns out to fail, then we say the step
-            # itself has failed. Because we start by calling the sentinel node
-            # which is placed at the start of the pipeline.
+            # If one of the children turns out to fail, then we say the
+            # step itself has failed. Because we start by calling the
+            # sentinel node which is placed at the start of
+            # thepipeline.
             if "FAILURE" in res:
                 return "FAILURE"
 
@@ -398,8 +403,8 @@ class PipelineStepRunner:
 
             return "FAILURE"
         else:
-            # The status could be STARTED, which means a parent tried to invoke
-            # run_on_docker for a child that was already running.
+            # The status could be STARTED, which means a parent tried to
+            # invoke run_on_docker for a child that was already running.
             # We don't have to do anything in that case.
             pass
 
@@ -449,14 +454,15 @@ class PipelineStep(PipelineStepRunner):
             runner_client: client to manage the compute backend.
             compute_backend: one of ("docker", "kubernetes").
         """
-        # run_func = getattr(self, f'run_ancestors_on_{compute_backend}')
+        # run_func =
+        # getattr(self, f'run_ancestors_on_{compute_backend}')
         run_func = getattr(self, f"run_children_on_{compute_backend}")
         return await run_func(runner_client, session, task_id, run_config=run_config)
 
     def __eq__(self, other) -> bool:
-        # NOTE: steps get a UUID and are always only identified with the
-        # UUID. Thus if they get additional parents and/or children, then
-        # they will stay the same. I think this is fine though.
+        # NOTE: steps get a UUID and are always only identified with
+        # the UUID. Thus if they get additional parents and/or children,
+        # then they will stay the same. I think this is fine though.
         return self.properties["uuid"] == other.properties["uuid"]
 
     def __hash__(self) -> int:
@@ -466,25 +472,26 @@ class PipelineStep(PipelineStepRunner):
         if self.properties:
             return f'<PipelineStep: {self.properties["name"]}>'
 
-        return f"<Pipelinestep: None>"
+        return "<Pipelinestep: None>"
 
     def __repr__(self) -> str:
-        # TODO: This is actually not correct: it should be self.properties.
-        #       But this just look ugly as hell (so maybe for later). And
-        #       strictly, should also include its parents.
+        # TODO: This is actually not correct: it should be
+        #       self.properties. But this just look ugly as hell
+        #       (so maybe for later). And strictly, should also include
+        #       its parents.
         if self.properties:
             return f'PipelineStep({self.properties["name"]!r})'
 
-        return f"Pipelinestep(None)"
+        return "Pipelinestep(None)"
 
 
 class Pipeline:
     def __init__(self, steps: List[PipelineStep], properties: Dict[str, str]) -> None:
         self.steps = steps
 
-        # TODO: we want to be able to serialize a Pipeline back to a json
-        #       file. Therefore we would need to store the Pipeline name
-        #       and UUID from the json first.
+        # TODO: we want to be able to serialize a Pipeline back to a
+        #       json file. Therefore we would need to store the Pipeline
+        #       name and UUID from the json first.
         # self.properties: Dict[str, str] = {}
         self.properties = properties
 
@@ -563,27 +570,28 @@ class Pipeline:
         its steps given by the selection (of UUIDs).
 
         Example:
-            When the selection consists of: a --> b. Then it is important
-            that "a" is run before "b". Therefore the induced subgraph
-            has to be taken to ensure the correct ordering, instead of
-            executing the steps independently (and in parallel).
+            When the selection consists of: a --> b. Then it is
+            important that "a" is run before "b". Therefore the induced
+            subgraph has to be taken to ensure the correct ordering,
+            instead of executing the steps independently (and in
+            parallel).
 
         Args:
             selection: list of UUIDs representing `PipelineStep`s.
 
         Returns:
-            An induced pipeline by the set of steps (defined by the given
-            selection).
+            An induced pipeline by the set of steps (defined by the
+            given selection).
         """
         keep_steps = [
             step for step in self.steps if step.properties["uuid"] in selection
         ]
 
-        # Only keep connection to parents and children if these steps are
-        # also included in the selection. In addition, to keep consistency
-        # of the properties attributes of the steps, we update the
-        # "incoming_connections" to be representative of the new pipeline
-        # structure.
+        # Only keep connection to parents and children if these steps
+        # are also included in the selection. In addition, to keep
+        # consistency of the properties attributes of the steps, we
+        # update the "incoming_connections" to be representative of the
+        # new pipeline structure.
         new_steps = []
         for step in keep_steps:
             # Take a deepcopy such that the properties of the new and
@@ -636,17 +644,17 @@ class Pipeline:
                 be included.
 
         Returns:
-            An induced pipeline by the set of steps (defined by the given
-            selection).
+            An induced pipeline by the set of steps (defined by the
+            given selection).
         """
-        # This set will be populated with all the steps that are ancestors
-        # of the sets given by the selection. Depending on the kwarg
-        # `inclusive` the steps from the selection itself will either be
-        # included or excluded.
+        # This set will be populated with all the steps that are
+        # ancestors of the sets given by the selection. Depending on the
+        # kwarg `inclusive` the steps from the selection itself will
+        # either be included or excluded.
         steps = set()
 
-        # Essentially a BFS where its stack gets initialized with multiple
-        # root nodes.
+        # Essentially a BFS where its stack gets initialized with
+        # multiple root nodes.
         stack = [step for step in self.steps if step.properties["uuid"] in selection]
 
         while stack:
@@ -675,8 +683,8 @@ class Pipeline:
             steps.add(new_step)
             stack.extend(new_step.parents)
 
-        # Remove steps if the selection should not be included in the new
-        # pipeline.
+        # Remove steps if the selection should not be included in the
+        # new pipeline.
         if inclusive:
             steps_to_be_included = steps
         elif not inclusive:
@@ -754,12 +762,15 @@ class Pipeline:
             if container.name in container_names_to_remove:
                 try:
                     logging.info("removing container %s" % container.name)
-                    # force=False so we log if a container happened to be still running while we expected it to
-                    # not be
-                    # v=True does not actually do anything because, given the docker docs:
+                    # force=False so we log if a container happened to
+                    # be still running while we expected it to not be
+                    # v=True does not actually do anything because,
+                    # given the docker docs:
                     # https://docs.docker.com/engine/reference/commandline/rm/
-                    # "This command removes the container and any volumes associated with it.
-                    # Note that if a volume was specified with a name, it will not be removed."
+                    # "This command removes the container and any
+                    # volumes associated with it. Note that if a volume
+                    # was specified with a name, it will not be removed.
+                    # "
                     container.remove(force=False, v=True)
                 except Exception as e:
                     logging.error(
@@ -776,7 +787,8 @@ class Pipeline:
             run_config: Configuration of the run. Example
                 {
                     'run_endpoint': 'runs',
-                    'project_dir': '/home/.../userdir/projects/<project_path>',
+                    'project_dir':
+                        '/home/.../userdir/projects/<project_path>',
                     'pipeline_uuid': 'some-uuid',
                 }
 
@@ -810,9 +822,9 @@ class Pipeline:
                 compute_backend=compute_backend,
             )
 
-            # NOTE: the status of a pipeline is always success once it is
-            # done executing. Errors in steps are reflected by the status
-            # of the respective steps.
+            # NOTE: the status of a pipeline is always success once it
+            # is done executing. Errors in steps are reflected by the
+            # status of the respective steps.
             await update_status(
                 "SUCCESS",
                 task_id,
@@ -827,8 +839,8 @@ class Pipeline:
         for step in self.steps:
             step._status = "PENDING"
 
-        # Status will contain whether any failures occured during execution
-        # of the pipeline.
+        # Status will contain whether any failures occured during
+        # execution of the pipeline.
         return status
 
     def __repr__(self) -> str:

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -127,6 +127,9 @@ async def run_pipeline_async(run_config, pipeline, task_id):
     # in check_pipeline_run_task_status
     run_config["docker_client"] = docker_client
     pipeline.remove_containerization_resources(task_id, "docker", run_config)
+    # The celery task has completed successfully. This is not related to
+    # the success or failure of the pipeline itself.
+    return "SUCCESS"
 
 
 @celery.task(bind=True, base=AbortableTask)

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -83,8 +83,8 @@ async def get_run_status(
             return await response.json()
 
 
-# Periodically check whether task has been aborted, if it has been, kill all
-# running containers to short-circuit pipeline run.
+# Periodically check whether task has been aborted, if it has been, kill
+# all running containers to short-circuit pipeline run.
 async def check_pipeline_run_task_status(run_config, pipeline, task_id):
 
     while True:
@@ -258,7 +258,7 @@ def start_non_interactive_pipeline_run(
         run_config["pipeline_path"],
         run_config["project_dir"],
         pipeline_definition["settings"]["data_passing_memory_size"],
-    ) as session:
+    ):
         status = run_pipeline(
             pipeline_definition, project_uuid, run_config, task_id=self.request.id
         )
@@ -276,7 +276,7 @@ def build_environment(
     environment_uuid,
     project_path,
 ) -> str:
-    """Builds an environment, resulting in a new image in the docker environment.
+    """Builds an environment, producing a new image in the docker env.
 
     Args:
         project_uuid: UUID of the project.

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -7,7 +7,7 @@ TODO:
     * Possibly add `pipeline_uuid` to the primary key.
 
 """
-from sqlalchemy import ForeignKeyConstraint, Index, UniqueConstraint, text
+from sqlalchemy import Index, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import JSONB
 
 from app.connections import db

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -8,8 +8,6 @@ TODO:
 """
 from flask_restx import Model, fields
 
-from _orchest.internals import config as _config
-
 # Namespace: Sessions
 server = Model(
     "Server",
@@ -104,7 +102,7 @@ pipeline_run_pipeline_step = Model(
         "status": fields.String(
             required=True,
             description="Status of the step",
-            enum=["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORTED", "REVOKED"],
+            enum=["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORTED"],
         ),
         "started_time": fields.String(
             required=True, description="Time at which the step started executing"
@@ -169,7 +167,7 @@ status_update = Model(
         "status": fields.String(
             required=True,
             description="New status of executable, e.g. pipeline or step",
-            enum=["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORTED", "REVOKED"],
+            enum=["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORTED"],
         ),
     },
 )
@@ -241,7 +239,9 @@ experiment_spec = Model(
         "pipeline_run_spec": fields.Nested(
             non_interactive_run_spec,
             required=True,
-            description='Specification of the pipeline runs, e.g. "full", "incoming" etc',
+            description=(
+                'Specification of the pipeline runs, e.g. "full",' ' "incoming" etc',
+            ),
         ),
         "scheduled_start": fields.String(
             required=True,

--- a/services/orchest-webserver/app/static/js/views/PipelineView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineView.js
@@ -1419,7 +1419,7 @@ class PipelineView extends React.Component {
           });
         }
 
-        if (result.status === "SUCCESS") {
+        if (["SUCCESS", "ABORTED", "FAILURE"].includes(result.status)) {
           // make sure stale opened files are reloaded in active
           // Jupyter instance
 


### PR DESCRIPTION
This PR makes it so that the status of an entity, such as a pipeline run or pipeline step, cannot be updated anymore once it has reached the state of ABORTED, FAILURE, or SUCCESS. This is to solve consistency and/or race conditions issues given by the fact that both the `orchest-api` and a celery task might be trying to PUT the status of an entity.