### PR TITLE
Minimally change pipeline definition for diffs

### DIFF
--- a/orchest-sdk/python/orchest/parameters.py
+++ b/orchest-sdk/python/orchest/parameters.py
@@ -61,4 +61,4 @@ def update_params(params: Dict[str, Any]) -> None:
     step.update_params(params)
 
     with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
-        json.dump(pipeline.to_dict(), f)
+        json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -250,7 +250,7 @@ def start_non_interactive_pipeline_run(
     # every step.
     pipeline_json = os.path.join(run_dir, run_config["pipeline_path"])
     with open(pipeline_json, "w") as f:
-        json.dump(pipeline_definition, f)
+        json.dump(pipeline_definition, f, indent=4, sort_keys=True)
 
     with launch_noninteractive_session(
         docker_client,

--- a/services/orchest-webserver/app/app/core/pipelines.py
+++ b/services/orchest-webserver/app/app/core/pipelines.py
@@ -57,7 +57,7 @@ class CreatePipeline(TwoPhaseFunction):
         }
 
         with open(pipeline_json_path, "w") as pipeline_json_file:
-            pipeline_json_file.write(json.dumps(pipeline_json, indent=4))
+            json.dump(pipeline_json, pipeline_json_file, indent=4, sort_keys=True)
 
     def _revert(self):
         Pipeline.query.filter_by(
@@ -168,7 +168,7 @@ class AddPipelineFromFS(TwoPhaseFunction):
             )
             with open(pipeline_json_path, "w") as json_file:
                 pipeline_json["uuid"] = pipeline_uuid
-                json_file.write(json.dumps(pipeline_json, indent=4))
+                json.dump(pipeline_json, json_file, indent=4, sort_keys=True)
 
     def _revert(self):
         Pipeline.query.filter(

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -751,7 +751,7 @@ def register_views(app, db):
             )
 
             with open(pipeline_json_path, "w") as json_file:
-                json_file.write(json.dumps(pipeline_json, indent=4))
+                json.dump(pipeline_json, json_file, indent=4, sort_keys=True)
 
             # Analytics call.
             send_anonymized_pipeline_definition(app, pipeline_json)


### PR DESCRIPTION
Since the pipeline definition is stored in JSON and JSON is unordered, every change to the pipeline definition could end up in large diffs. Instead of relying on the implicit order of keys in dictionaries, especially since the pipeline definition is also interacted with in Javascript, explicitly sort the keys.

Caveat: The order given by the user of the defined parameters is now also automatically sorted.