### PR TITLE
Fix project detection failed: #116

### DIFF
--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -13,6 +13,7 @@ class Config:
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
     USER_DIR = os.path.join("/userdir")
+    PROJECTS_DIR = os.path.join(USER_DIR, "projects")
     HOST_USER_DIR = os.environ.get("HOST_USER_DIR")
     WEBSERVER_LOGS = _config.WEBSERVER_LOGS
     STATIC_DIR = os.path.join(dir_path, "..", "static")

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -473,9 +473,8 @@ def register_views(app, db):
     def discoverFSDeletedProjects():
         """Cleanup projects that were deleted from the filesystem."""
 
-        projects_dir = os.path.join(app.config["USER_DIR"], "projects")
         project_paths = [
-            entry.name for entry in os.scandir(projects_dir) if entry.is_dir()
+            entry.name for entry in os.scandir(app.config["PROJECTS_DIR"]) if entry.is_dir()
         ]
 
         fs_removed_projects = Project.query.filter(
@@ -505,10 +504,9 @@ def register_views(app, db):
 
         # Detect new projects by detecting directories that were not
         # registered in the db as projects.
-        projects_dir = os.path.join(app.config["USER_DIR"], "projects")
         existing_project_paths = [project.path for project in Project.query.all()]
         project_paths = [
-            entry.name for entry in os.scandir(projects_dir) if entry.is_dir()
+            entry.name for entry in os.scandir(app.config["PROJECTS_DIR"]) if entry.is_dir()
         ]
         new_project_paths = set(project_paths) - set(existing_project_paths)
 


### PR DESCRIPTION
This PR made the following changes:
  - About #116 , This bug is caused by not catching the FileNotFoundError error, see line 147 of the script services/orchest-webserver/app/app/core/projects.py. `  shutil.rmtree(full_project_path)`
  - Set `projects_dir` as a configuration property, such as: `app.config["USER_DIR"]`, because this variable is frequently combined in the code