### PR TITLE
Memory size changes to take effect on memory-server restart

### DIFF
--- a/services/memory-server/app/config.py
+++ b/services/memory-server/app/config.py
@@ -1,7 +1,5 @@
 import os
 
-import utils
-
 from _orchest.internals import config as _config
 
 # Default location where the socket is created.
@@ -11,5 +9,3 @@ STORE_SOCKET_NAME = os.path.join(_config.MEMORY_SERVER_SOCK_PATH, "plasma.sock")
 PIPELINE_FNAME = os.path.join(
     _config.PROJECT_DIR, os.environ.get("ORCHEST_PIPELINE_PATH", "")
 )
-
-STORE_MEMORY = utils.get_store_memory_size(PIPELINE_FNAME)

--- a/services/memory-server/app/config.py
+++ b/services/memory-server/app/config.py
@@ -1,10 +1,15 @@
 import os
 
+import utils
+
 from _orchest.internals import config as _config
 
 # Default location where the socket is created.
 STORE_SOCKET_NAME = os.path.join(_config.MEMORY_SERVER_SOCK_PATH, "plasma.sock")
 
-STORE_MEMORY = os.getenv("ORCHEST_MEMORY_SIZE", 1024 ** 3)
-# "System memory request exceeds memory available in /dev/shm."
-# STORE_MEMORY = 60397977  # default max by docker
+# Used to determine whether objects need to be evicted.
+PIPELINE_FNAME = os.path.join(
+    _config.PROJECT_DIR, os.environ.get("ORCHEST_PIPELINE_PATH", "")
+)
+
+STORE_MEMORY = utils.get_store_memory_size(PIPELINE_FNAME)

--- a/services/memory-server/app/main.py
+++ b/services/memory-server/app/main.py
@@ -9,8 +9,6 @@ import config
 import pyarrow as pa
 from manager import start_manager
 
-from _orchest.internals import config as _config
-
 
 def get_command_line_args():
     parser = argparse.ArgumentParser(description="Start plasma store and manager.")
@@ -33,9 +31,7 @@ def get_command_line_args():
         "-p",
         "--pipeline_fname",
         required=False,
-        default=os.path.join(
-            _config.PROJECT_DIR, os.environ.get("ORCHEST_PIPELINE_PATH", "")
-        ),
+        default=config.PIPELINE_FNAME,
         help="file containing pipeline definition",
     )
 

--- a/services/memory-server/app/utils.py
+++ b/services/memory-server/app/utils.py
@@ -1,0 +1,29 @@
+import json
+from typing import Union
+
+
+def _parse_string_memory_size(memory_size: Union[str, int]) -> int:
+    """Converts string description of memory size to number of bytes
+
+    Allowable inputs are: [\\d]+\\s*(KB|MB|GB)+
+    """
+    # If an integer is given, then it is assumed to be the number of
+    # bytes.
+    if isinstance(memory_size, int):
+        return memory_size
+
+    conversion = {"KB": 1000, "MB": 1000 ** 2, "GB": 1000 ** 3}
+    size, unit = memory_size[:-2], memory_size[-2:]
+    size = int(float(size) * conversion[unit])
+
+    return size
+
+
+def get_store_memory_size(pipeline_definition_path: str):
+    """Gets the specified memory size from the pipeline definition."""
+    with open(pipeline_definition_path, "r") as f:
+        description = json.load(f)
+
+    mem_size = description["settings"].get("data_passing_memory_size", 1000 ** 3)
+
+    return _parse_string_memory_size(mem_size)

--- a/services/orchest-api/app/app/apis/namespace_sessions.py
+++ b/services/orchest-api/app/app/apis/namespace_sessions.py
@@ -49,7 +49,6 @@ class SessionList(Resource):
                     post_data["pipeline_path"],
                     post_data["project_dir"],
                     post_data["host_userdir"],
-                    post_data["settings"]["data_passing_memory_size"],
                 )
         except Exception as e:
             return {"message": str(e)}, 500
@@ -132,7 +131,6 @@ class CreateInteractiveSession(TwoPhaseFunction):
         pipeline_path: str,
         project_dir: str,
         host_userdir: str,
-        data_passing_memory_size: str,
     ):
         interactive_session = {
             "project_uuid": project_uuid,
@@ -146,7 +144,6 @@ class CreateInteractiveSession(TwoPhaseFunction):
         self.collateral_kwargs["pipeline_path"] = pipeline_path
         self.collateral_kwargs["project_dir"] = project_dir
         self.collateral_kwargs["host_userdir"] = host_userdir
-        self.collateral_kwargs["data_passing_memory_size"] = data_passing_memory_size
 
     def _collateral(
         self,
@@ -155,7 +152,6 @@ class CreateInteractiveSession(TwoPhaseFunction):
         pipeline_path: str,
         project_dir: str,
         host_userdir: str,
-        data_passing_memory_size: str,
     ):
         session = InteractiveSession(docker_client, network="orchest")
         session.launch(
@@ -163,7 +159,6 @@ class CreateInteractiveSession(TwoPhaseFunction):
             project_uuid,
             pipeline_path,
             project_dir,
-            data_passing_memory_size,
             host_userdir,
         )
 

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -569,7 +569,8 @@ def _get_container_specs(
         "network": network,
         # Set a ridiculous shm size and let plasma determine how much
         # it wants to consume (according to the setting in the pipeline
-        # definition).
+        # definition). Mounting `/dev/shm` directly is not supported on
+        # Mac.
         "shm_size": "1000G",
         "environment": [
             f"ORCHEST_PIPELINE_PATH={pipeline_path}",

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -125,7 +125,6 @@ class Session:
         project_uuid: str,
         pipeline_path: str,
         project_dir: str,
-        data_passing_memory_size: int,
         host_userdir: Optional[str] = None,
     ) -> None:
         """Launches pre-configured resources.
@@ -142,7 +141,6 @@ class Session:
                 project_dir).
             project_dir: Path to project directory.
             host_userdir: Path to the userdir on the host
-            data_passing_memory_size: Size for the "memory-server".
 
         """
         # TODO: make convert this "pipeline" uuid into a "session" uuid.
@@ -153,7 +151,6 @@ class Session:
             project_dir,
             host_userdir,
             self.network,
-            data_passing_memory_size,
         )
         for resource in self._resources:
             container = self.client.containers.run(**container_specs[resource])
@@ -292,7 +289,6 @@ class InteractiveSession(Session):
         project_uuid: str,
         pipeline_path: str,
         project_dir: str,
-        data_passing_memory_size: int,
         host_userdir: str,
     ) -> None:
         """Launches the interactive session.
@@ -309,7 +305,6 @@ class InteractiveSession(Session):
             project_uuid,
             pipeline_path,
             project_dir,
-            data_passing_memory_size,
             host_userdir,
         )
 
@@ -404,7 +399,6 @@ class NonInteractiveSession(Session):
         project_uuid: str,
         pipeline_path: str,
         project_dir: str,
-        data_passing_memory_size: int,
     ) -> None:
         """
 
@@ -427,9 +421,7 @@ class NonInteractiveSession(Session):
         if uuid is None:
             uuid = self._session_uuid
 
-        return super().launch(
-            uuid, project_uuid, pipeline_path, project_dir, data_passing_memory_size
-        )
+        return super().launch(uuid, project_uuid, pipeline_path, project_dir)
 
 
 @contextmanager
@@ -439,7 +431,6 @@ def launch_noninteractive_session(
     project_uuid: str,
     pipeline_path: str,
     project_dir: str,
-    data_passing_memory_size: int,
 ) -> NonInteractiveSession:
     """Launches a non-interactive session for a particular pipeline.
 
@@ -450,7 +441,6 @@ def launch_noninteractive_session(
         project_dir: Path to the `project_dir`, which has to be
             mounted into the containers so that the user can interact
             with the files.
-        data_passing_memory_size: Size for the "memory-server".
 
     Yields:
         A Session object that has already launched its resources.
@@ -462,7 +452,6 @@ def launch_noninteractive_session(
         project_uuid,
         pipeline_path,
         project_dir,
-        data_passing_memory_size,
     )
     try:
         yield session
@@ -540,7 +529,6 @@ def _get_container_specs(
     project_dir: str,
     host_userdir: str,
     network: str,
-    data_passing_memory_size: int,
 ) -> Dict[str, dict]:
     """Constructs the container specifications for all resources.
 
@@ -557,7 +545,6 @@ def _get_container_specs(
         host_userdir: Path to the userdir on the host
         network: Docker network. This is put directly into the specs, so
             that the containers are started on the specified network.
-        data_passing_memory_size: Size for the "memory-server".
 
     Returns:
         Mapping from container name to container specification for the
@@ -573,7 +560,6 @@ def _get_container_specs(
     container_specs = {}
     mounts = _get_mounts(uuid, project_uuid, project_dir, host_userdir)
 
-    # TODO: remove data_passing_memory_size
     container_specs["memory-server"] = {
         "image": "orchest/memory-server:latest",
         "detach": True,

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -258,7 +258,6 @@ def start_non_interactive_pipeline_run(
         project_uuid,
         run_config["pipeline_path"],
         run_config["project_dir"],
-        pipeline_definition["settings"]["data_passing_memory_size"],
     ):
         status = run_pipeline(
             pipeline_definition, project_uuid, run_config, task_id=self.request.id

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -57,9 +57,6 @@ pipeline = Model(
         "host_userdir": fields.String(
             required=True, description="Host path to userdir"
         ),
-        "settings": fields.Raw(
-            required=True, description="Settings from the pipeline definition"
-        ),
     },
 )
 

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-from typing import Dict, Set, Union
+from typing import Dict, Set
 
 import requests
 from docker import errors
@@ -386,44 +386,3 @@ def remove_if_dangling(img) -> bool:
             time.sleep(1)
             tries -= 1
     return False
-
-
-def parse_string_memory_size(memory_size: Union[str, int]) -> int:
-    """Converts string description of memory size to number of bytes
-
-    Allowable inputs are: [\\d]+\\s*(KB|MB|GB)+
-    """
-
-    # seems like this is already int (assumed to be number of bytes)
-    if isinstance(memory_size, int):
-        return memory_size
-
-    conversion = {"KB": 1000, "MB": 1000 ** 2, "GB": 1000 ** 3}
-    size, unit = memory_size[:-2], memory_size[-2:]
-    size = int(float(size) * conversion[unit])
-
-    return size
-
-
-def calculate_shm_size(data_passing_memory_size: int) -> int:
-    """Calculates the shm-size for the Docker container.
-
-    Given a size for the memory-server we need to do a certain
-    allocation to get to that size. In other words, the `shm-size` for
-    the Docker container is not equal to the request size for the
-    memory-server.
-
-    If the Plasma server tries to allocate more than is available in
-    /dev/shm it will not fail but issue a warning. However, the full
-    amount requested will not be available to the user.
-
-    Args:
-        data_passing_memory_size: Requested size for the memory-server.
-
-    Returns:
-        The shm-size for the Docker container.
-
-    """
-    # We need to overallocate by a fraction to make /dev/shm large
-    # enough for the request amount in `data_passing_memory_size`
-    return int(data_passing_memory_size * 1.2)

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -5,7 +5,6 @@ from app.analytics import send_pipeline_run
 from app.models import Job, PipelineRun
 from app.utils import (
     get_environments,
-    get_pipeline_json,
     get_project_directory,
     pipeline_uuid_to_path,
     project_uuid_to_path,
@@ -169,11 +168,6 @@ def register_orchest_api_views(app, db):
         )
 
         json_obj["host_userdir"] = app.config["HOST_USER_DIR"]
-
-        pipeline_json = get_pipeline_json(
-            json_obj["pipeline_uuid"], json_obj["project_uuid"]
-        )
-        json_obj["settings"] = pipeline_json.get("settings", {})
 
         resp = requests.post(
             "http://" + app.config["ORCHEST_API_ADDRESS"] + "/api/sessions/",

--- a/services/orchest-webserver/app/static/js/views/PipelineSettingsView.js
+++ b/services/orchest-webserver/app/static/js/views/PipelineSettingsView.js
@@ -214,6 +214,12 @@ class PipelineSettingsView extends React.Component {
                     )}
 
                     <h3>Data passing</h3>
+                    <p className="push-up">
+                      <i>
+                        For these changing to take effect you have to restart
+                        the memory-server (see button below).
+                      </i>
+                    </p>
 
                     <MDCCheckboxReact
                       value={this.state.pipelineJson.settings.auto_eviction}
@@ -224,12 +230,8 @@ class PipelineSettingsView extends React.Component {
 
                     <p className="push-down">
                       Change the size of the memory server for data passing. For
-                      units use KB, MB, or GB. E.g.{" "}
+                      units use KB, MB, or GB, e.g.{" "}
                       <span className="code">1GB</span>.{" "}
-                      <i>
-                        Changing this setting requires you to restart the
-                        session.
-                      </i>
                     </p>
                     <MDCTextFieldReact
                       ref={
@@ -255,12 +257,12 @@ class PipelineSettingsView extends React.Component {
                 <h3 className="push-up push-down">Actions</h3>
 
                 <p className="push-down">
-                  Clear the memory of the pipeline to allow additional data to
-                  be passed between pipeline steps.
+                  Restarting the memory-server also clears the memory to allow
+                  additional data to be passed between pipeline steps.
                 </p>
                 <MDCButtonReact
                   disabled={this.state.restartingMemoryServer}
-                  label="Clear memory"
+                  label="Restart memory-server"
                   icon="memory"
                   classNames={["mdc-button--raised"]}
                   onClick={this.restartMemoryServer.bind(this)}


### PR DESCRIPTION
<!-- 
Thank you for your contribution, you rock! 💪
Don't forget to add yourself to the list of contributors at the bottom of the `README.md`.
-->

## Description
<!-- 
Please provide a summary of what this PR adds or changes together with relevant motivation and context. 
-->

Due to Docker not supporting passing environment variables when starting a container (https://github.com/moby/moby/issues/7561), the `memory-server` now reads the `pipeline-definition` to determine the memory size for the internal Plasma store. As a side-effect only the `memory-server` has to be restarted for changes in the _Data passing memory size_ pipeline setting to take effect.

As an additional note, when starting the `memory-server` the `shm-size` is set to a large value to solely let the `memory-server` determine how much memory to consume (based on the setting). Mounting `/dev/shm` directly to the container's `/dev/shm` is not out of the box supported on Mac (and neither are [tmpfs mounts](https://docs.docker.com/storage/tmpfs/)).

Resolves #127 

### Checklist
<!-- 
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->
- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations. <!-- See `scripts/migration_manager.sh` -->
