### PR TITLE
Add import url support, and post-login redirect.

### DIFF
--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -124,8 +124,10 @@ def register_views(app):
                     db.session.add(token)
                     db.session.commit()
 
+                    redirect_url = request.args.get("redirect_url", "/")
+
                     resp = make_response(
-                        render_template("client_side_redirect.html", url="/")
+                        render_template("client_side_redirect.html", url=redirect_url)
                     )
                     resp.set_cookie("auth_token", token.token)
                     resp.set_cookie("auth_username", username)

--- a/services/orchest-webserver/app/static/css/main.scss
+++ b/services/orchest-webserver/app/static/css/main.scss
@@ -882,12 +882,16 @@ span.floating-button {
 }
 
 .warning {
-  color: orangered;
+  padding: $generalPadding/2;
+  border-radius: 3px;
+  color: #fff;
+  background: #b00020;
+  font-size: 15px;
 
   .material-icons {
     float: left;
     margin-right: 10px;
-    margin-top: -2px;
+    margin-top: -4px;
   }
 }
 
@@ -1055,7 +1059,7 @@ button.themed-secondary {
 
 span.code {
   font-family: monospace;
-  background: #eee;
+  background: rgba(0, 0, 0, 0.1);
   border-radius: 3px;
   padding: 2px 4px;
   display: inline-block;
@@ -1647,6 +1651,21 @@ table {
 }
 
 @media only screen and (max-width: 1200px) {
+  .view-page {
+    &.global-settings {
+      .columns {
+        .column {
+          &:nth-child(2n) {
+            padding-left: 0;
+          }
+          &:nth-child(2n + 1) {
+            padding-right: 0;
+          }
+        }
+      }
+    }
+  }
+
   .columns {
     .column {
       width: 100%;

--- a/services/orchest-webserver/app/static/js/src/views/ProjectsView.js
+++ b/services/orchest-webserver/app/static/js/src/views/ProjectsView.js
@@ -361,9 +361,9 @@ class ProjectsView extends React.Component {
                         <div className="push-down warning">
                           <p>
                             <i className="material-icons">warning</i> The import
-                            URL was pre-filled using the URL. Make sure you
-                            trust the <span className="code">git</span>{" "}
-                            repository you're importing.
+                            URL was pre-filled. Make sure you trust the{" "}
+                            <span className="code">git</span> repository you're
+                            importing.
                           </p>
                         </div>
                       )}


### PR DESCRIPTION
## Description

This PR adds the possibility to add an `import_url` query argument to the `/projects` page. It will make it easier to directly import a project from a `git` supported URL.

It comes with a warning to make sure the user knows what they're doing:

![image](https://user-images.githubusercontent.com/1309307/112037821-6dbae780-8b42-11eb-8e38-8ff17aad1bf0.png)

In addition, this PR adds the ability to have login a redirect to a specific page by using the `redirect_url` query argument.


<!--
Please provide a summary of what this PR adds or changes together with relevant motivation and context.
-->

<!-- Fixes: #issue -->

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
