### PR TITLE
Add exit codes to CLI status

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -118,6 +118,17 @@ def status(
 ):
     """
     Get status of Orchest.
+
+    Exit codes:
+
+    - 0: Orchest is running and services are ready.
+
+    - 1: Orchest is not running.
+
+    - 2: Orchest is running, but some required service has shut down.
+
+    - 3: Orchest is running, but some required service is not passing an
+    health check.
     """
     app.status(ext=ext)
 

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -127,7 +127,7 @@ def status(
 
     - 2: Orchest is running, but some required service has shut down.
 
-    - 3: Orchest is running, but some required service is not passing an
+    - 3: Orchest is running, but some required service is not passing a
     health check.
     """
     app.status(ext=ext)

--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -16,7 +16,7 @@ health_check_command = {
     "orchest/orchest-webserver:latest": "wget localhost -T 2 -t 2 --spider",
     # Need to GET login/clear because this will work both when AUTH is
     # enabled and not.
-    "orchest/auth-server:latest": "wget localhost/login/clear -T 2 -t 2",
+    "orchest/auth-server:latest": "wget localhost/login/clear -T 2 -t 2 --spider",
     "orchest/celery-worker:latest": "celery inspect ping -A app.core.tasks",
     "orchest/file-manager:latest": "wget localhost -T 2 -t 2 --spider",
     "postgres:13.1": "pg_isready --username postgres",

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -227,7 +227,7 @@ class OrchestApp:
 
         if not self.is_running(running_containers_names):
             utils.echo("Orchest is not running.")
-            return
+            raise typer.Exit(code=1)
 
         # Minimal set of containers to be running for Orchest to be in
         # a valid state.
@@ -240,6 +240,7 @@ class OrchestApp:
                 "Orchest has reached an invalid state. Running containers:\n"
                 + "\n".join(running_containers_names)
             )
+            raise typer.Exit(code=2)
         else:
             utils.echo("Orchest is running.")
             if ext:
@@ -252,6 +253,8 @@ class OrchestApp:
 
                 if no_issues:
                     utils.echo("All services are ready.")
+                else:
+                    raise typer.Exit(code=3)
 
     def update(self, mode=None):
         """Update Orchest.


### PR DESCRIPTION
## Description

This PR adds an exit code to the `orchest-ctl` CLI `status` command. So that it can more easily be interacted with in an automated manner.

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
