### PR TITLE
Add single param get/update for step, pipeline

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,9 @@ ignore =
     # Ignore invalid escape sequences.
     W605
 
+per-file-ignores =
+    orchest-sdk/python/orchest/__init__.py: F401
+
 # black is set to 88
 max-line-length = 88
 

--- a/orchest-sdk/python/orchest/__init__.py
+++ b/orchest-sdk/python/orchest/__init__.py
@@ -1,9 +1,7 @@
 from orchest.config import Config
 from orchest.parameters import (
-    get_params,
     get_pipeline_param,
     get_step_param,
-    update_params,
     update_pipeline_param,
     update_step_param,
 )

--- a/orchest-sdk/python/orchest/__init__.py
+++ b/orchest-sdk/python/orchest/__init__.py
@@ -1,3 +1,10 @@
 from orchest.config import Config
-from orchest.parameters import get_params, update_params
+from orchest.parameters import (
+    get_params,
+    get_pipeline_param,
+    get_step_param,
+    update_params,
+    update_pipeline_param,
+    update_step_param,
+)
 from orchest.transfer import get_inputs, output

--- a/orchest-sdk/python/orchest/parameters.py
+++ b/orchest-sdk/python/orchest/parameters.py
@@ -13,13 +13,13 @@ from orchest.pipeline import Pipeline, PipelineStep
 from orchest.utils import get_step_uuid
 
 
-def __get_pipeline() -> Pipeline:
+def _get_pipeline() -> Pipeline:
     with open(Config.PIPELINE_DEFINITION_PATH, "r") as f:
         pipeline_definition = json.load(f)
     return Pipeline.from_json(pipeline_definition)
 
 
-def __get_current_step(pipeline: Pipeline) -> PipelineStep:
+def _get_current_step(pipeline: Pipeline) -> PipelineStep:
     try:
         step_uuid = get_step_uuid(pipeline)
     except StepUUIDResolveError:
@@ -34,8 +34,8 @@ def get_params() -> Tuple[dict, dict]:
         A tuple of two elements, where the first is the parameters of
         the current step, the second is the parameters of the pipeline.
     """
-    pipeline = __get_pipeline()
-    step = __get_current_step(pipeline)
+    pipeline = _get_pipeline()
+    step = _get_current_step(pipeline)
     return step.get_params(), pipeline.get_params()
 
 
@@ -62,73 +62,69 @@ def update_params(
         since different steps could be updating them at the same time.
 
     """
-    pipeline = __get_pipeline()
+    pipeline = _get_pipeline()
 
     if pipeline_params is not None:
         pipeline.update_params(pipeline_params)
 
     if step_params is not None:
-        step = __get_current_step(pipeline)
+        step = _get_current_step(pipeline)
         step.update_params(step_params)
 
     with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
         json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)
 
 
-def get_step_param(key: str) -> Any:
+def get_step_param(name: str) -> Any:
     """Gets a parameter of the current step by name.
 
     Args:
-        key: The step parameter to get.
+        name: The step parameter to get.
 
     Returns:
         The value that was mapped to the step parameter name.
     """
-    pipeline = __get_pipeline()
-    step = __get_current_step(pipeline)
+    pipeline = _get_pipeline()
+    step = _get_current_step(pipeline)
     params = step.get_params()
-    return params[key]
+    return params[name]
 
 
-def get_pipeline_param(key: str) -> Any:
+def get_pipeline_param(name: str) -> Any:
     """Gets a pipeline parameter by name.
 
     Args:
-        key: The pipeline parameter to get.
+        name: The pipeline parameter to get.
 
     Returns:
         The value that was mapped to the pipeline parameter name.
     """
-    pipeline = __get_pipeline()
+    pipeline = _get_pipeline()
     params = pipeline.get_params()
-    return params[key]
+    return params[name]
 
 
-def update_step_param(key: str, value: Any) -> None:
+def update_step_param(name: str, value: Any) -> None:
     """Updates or sets a step parameter.
 
     Internally the updating is done by calling the ``dict.update``
     method. This further explains the behavior of this method.
 
     Args:
-        key: The step parameter to update/set.
+        name: The step parameter to update/set.
         value: The value that will be set.
     """
-    pipeline = __get_pipeline()
-    step = __get_current_step(pipeline)
-    step.update_params({key: value})
-    with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
-        json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)
+    update_params(step_params={name: value})
 
 
-def update_pipeline_param(key: str, value: Any) -> None:
+def update_pipeline_param(name: str, value: Any) -> None:
     """Updates or sets a pipeline parameter.
 
     Internally the updating is done by calling the ``dict.update``
     method. This further explains the behavior of this method.
 
     Args:
-        key: The pipeline parameter to update/set.
+        name: The pipeline parameter to update/set.
         value: The value that will be set.
 
     Warning:
@@ -136,7 +132,4 @@ def update_pipeline_param(key: str, value: Any) -> None:
         since different steps could be updating pipeline parameters at
         the same time.
     """
-    pipeline = __get_pipeline()
-    pipeline.update_params({key: value})
-    with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
-        json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)
+    update_params(pipeline_params={name: value})

--- a/orchest-sdk/python/orchest/parameters.py
+++ b/orchest-sdk/python/orchest/parameters.py
@@ -5,12 +5,26 @@ e.g. ``pipeline.orchest``.
 
 """
 import json
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from orchest.config import Config
 from orchest.error import StepUUIDResolveError
-from orchest.pipeline import Pipeline
+from orchest.pipeline import Pipeline, PipelineStep
 from orchest.utils import get_step_uuid
+
+
+def __get_pipeline() -> Pipeline:
+    with open(Config.PIPELINE_DEFINITION_PATH, "r") as f:
+        pipeline_definition = json.load(f)
+    return Pipeline.from_json(pipeline_definition)
+
+
+def __get_current_step(pipeline: Pipeline) -> PipelineStep:
+    try:
+        step_uuid = get_step_uuid(pipeline)
+    except StepUUIDResolveError:
+        raise StepUUIDResolveError("Parameters could not be identified.")
+    return pipeline.get_step_by_uuid(step_uuid)
 
 
 def get_params() -> Tuple[dict, dict]:
@@ -20,19 +34,9 @@ def get_params() -> Tuple[dict, dict]:
         A tuple of two elements, where the first is the parameters of
         the current step, the second is the parameters of the pipeline.
     """
-    with open(Config.PIPELINE_DEFINITION_PATH, "r") as f:
-        pipeline_definition = json.load(f)
-
-    pipeline = Pipeline.from_json(pipeline_definition)
-    try:
-        step_uuid = get_step_uuid(pipeline)
-    except StepUUIDResolveError:
-        raise StepUUIDResolveError("Parameters could not be identified.")
-
-    step = pipeline.get_step_by_uuid(step_uuid)
-    params = step.get_params()
-
-    return params, pipeline.get_params()
+    pipeline = __get_pipeline()
+    step = __get_current_step(pipeline)
+    return step.get_params(), pipeline.get_params()
 
 
 def update_params(
@@ -54,26 +58,85 @@ def update_params(
             updating their values or adding new parameter keys.
 
     Warning:
-        Updating the `pipeline_params` can lead to read conditions,
+        Updating the `pipeline_params` can lead to race conditions,
         since different steps could be updating them at the same time.
 
     """
-    with open(Config.PIPELINE_DEFINITION_PATH, "r") as f:
-        pipeline_definition = json.load(f)
-
-    pipeline = Pipeline.from_json(pipeline_definition)
+    pipeline = __get_pipeline()
 
     if pipeline_params is not None:
         pipeline.update_params(pipeline_params)
 
     if step_params is not None:
-        try:
-            step_uuid = get_step_uuid(pipeline)
-        except StepUUIDResolveError:
-            raise StepUUIDResolveError("Parameters could not be identified.")
-
-        step = pipeline.get_step_by_uuid(step_uuid)
+        step = __get_current_step(pipeline)
         step.update_params(step_params)
 
+    with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
+        json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)
+
+
+def get_step_param(key: str) -> Any:
+    """Gets a parameter of the current step by name.
+
+    Args:
+        key: The step parameter to get.
+
+    Returns:
+        The value that was mapped to the step parameter name.
+    """
+    pipeline = __get_pipeline()
+    step = __get_current_step(pipeline)
+    params = step.get_params()
+    return params[key]
+
+
+def get_pipeline_param(key: str) -> Any:
+    """Gets a pipeline parameter by name.
+
+    Args:
+        key: The pipeline parameter to get.
+
+    Returns:
+        The value that was mapped to the pipeline parameter name.
+    """
+    pipeline = __get_pipeline()
+    params = pipeline.get_params()
+    return params[key]
+
+
+def update_step_param(key: str, value: Any) -> None:
+    """Updates or sets a step parameter.
+
+    Internally the updating is done by calling the ``dict.update``
+    method. This further explains the behavior of this method.
+
+    Args:
+        key: The step parameter to update/set.
+        value: The value that will be set.
+    """
+    pipeline = __get_pipeline()
+    step = __get_current_step(pipeline)
+    step.update_params({key: value})
+    with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
+        json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)
+
+
+def update_pipeline_param(key: str, value: Any) -> None:
+    """Updates or sets a pipeline parameter.
+
+    Internally the updating is done by calling the ``dict.update``
+    method. This further explains the behavior of this method.
+
+    Args:
+        key: The pipeline parameter to update/set.
+        value: The value that will be set.
+
+    Warning:
+        Updating a pipeline parameter can lead to race conditions,
+        since different steps could be updating pipeline parameters at
+        the same time.
+    """
+    pipeline = __get_pipeline()
+    pipeline.update_params({key: value})
     with open(Config.PIPELINE_DEFINITION_PATH, "w") as f:
         json.dump(pipeline.to_dict(), f, indent=4, sort_keys=True)

--- a/orchest-sdk/python/orchest/pipeline.py
+++ b/orchest-sdk/python/orchest/pipeline.py
@@ -56,7 +56,12 @@ class PipelineStep:
     def update_params(self, params) -> None:
         for param in params:
             if not isinstance(param, str):
-                raise TypeError("Parameter keys can only be of type string.")
+                raise TypeError(
+                    (
+                        f"Parameter keys can only be of type string. Key {param} "
+                        f"of type {type(param)} is invalid."
+                    )
+                )
         try:
             self.properties["parameters"].update(params)
         except KeyError:
@@ -148,8 +153,12 @@ class Pipeline:
     def update_params(self, params) -> None:
         for param in params:
             if not isinstance(param, str):
-                raise TypeError("Parameter keys can only be of type string.")
-
+                raise TypeError(
+                    (
+                        f"Parameter keys can only be of type string. Key {param} "
+                        f"of type {type(param)} is invalid."
+                    )
+                )
         try:
             self.properties["parameters"].update(params)
         except KeyError:

--- a/orchest-sdk/python/orchest/pipeline.py
+++ b/orchest-sdk/python/orchest/pipeline.py
@@ -54,6 +54,9 @@ class PipelineStep:
         return self.properties.get("parameters", {})
 
     def update_params(self, params) -> None:
+        for param in params:
+            if not isinstance(param, str):
+                raise TypeError("Parameter keys can only be of type string.")
         try:
             self.properties["parameters"].update(params)
         except KeyError:
@@ -143,6 +146,10 @@ class Pipeline:
         return self.properties.get("parameters", {})
 
     def update_params(self, params) -> None:
+        for param in params:
+            if not isinstance(param, str):
+                raise TypeError("Parameter keys can only be of type string.")
+
         try:
             self.properties["parameters"].update(params)
         except KeyError:


### PR DESCRIPTION
## Description
This PR expands the Orchest SDK to add single parameter `get` and `update` operations for both step and pipeline parameters.
It's still possible to `get` or `update` parameters in a batched manner by using the `get_params` and `update_params` functions.

Signatures:
`def get_step_param(key: str) -> Any:`
`def get_pipeline_param(key: str) -> Any:`
`def update_step_param(key: str, value: Any) -> None:`
`def update_pipeline_param(key: str, value: Any) -> None:`

### Checklist
- [x] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
