### PR TITLE
Fix preserve port on restart

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -7,7 +7,7 @@ import typer
 
 from app.cli import start as cli_start
 from app.orchest import OrchestApp
-from app.spec import get_container_config, inject_dict
+from app.spec import get_container_config
 from app.utils import echo
 
 
@@ -238,17 +238,7 @@ def restart(
     """
 
     dev = dev or (mode == "dev")
-    container_config = get_container_config(cloud=cloud, dev=dev)
-    port_bind: dict = {
-        "nginx-proxy": {
-            "HostConfig": {
-                "PortBindings": {
-                    "80/tcp": [{"HostPort": f"{port}"}],
-                },
-            },
-        },
-    }
-    inject_dict(container_config, port_bind, overwrite=True)
+    container_config = get_container_config(port, cloud=cloud, dev=dev)
     app.restart(container_config)
 
 
@@ -256,6 +246,9 @@ def restart(
 def updateserver(
     # Necessary to make it so that the update server restarts Orchest
     # with the correct settings.
+    port: Optional[int] = typer.Option(
+        8000, help="The port the Orchest webserver will listen on."
+    ),
     cloud: bool = typer.Option(
         False,
         show_default="--no-cloud",
@@ -269,7 +262,7 @@ def updateserver(
     """
     Update Orchest through the update-server.
     """
-    app._updateserver(cloud, dev)
+    app._updateserver(port, cloud, dev)
 
 
 @typer_app.command(hidden=True)

--- a/services/orchest-ctl/app/cli/start.py
+++ b/services/orchest-ctl/app/cli/start.py
@@ -4,7 +4,7 @@ from typing import Optional
 import typer
 
 from app.orchest import OrchestApp
-from app.spec import LogLevel, get_container_config, inject_dict
+from app.spec import LogLevel, get_container_config
 
 logger = logging.getLogger(__name__)
 
@@ -88,18 +88,7 @@ def reg(
     \b
         orchest start [OPTIONS]
     """
-    container_config = get_container_config(cloud, dev, log_level)
-
-    port_bind: dict = {
-        "nginx-proxy": {
-            "HostConfig": {
-                "PortBindings": {
-                    "80/tcp": [{"HostPort": f"{port}"}],
-                },
-            },
-        },
-    }
-    inject_dict(container_config, port_bind, overwrite=True)
+    container_config = get_container_config(port, cloud, dev, log_level)
 
     if dev:
         logger.info(

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -209,12 +209,12 @@ class OrchestApp:
         self.stop()
         self.start(container_config)
 
-    def _updateserver(self, cloud: bool = False, dev: bool = False):
+    def _updateserver(self, port: int = 8000, cloud: bool = False, dev: bool = False):
         """Starts the update-server service."""
         logger.info("Starting Orchest update service...")
 
         config = {}
-        container_config = spec.get_container_config(cloud=cloud, dev=dev)
+        container_config = spec.get_container_config(port=port, cloud=cloud, dev=dev)
         config["update-server"] = container_config["update-server"]
 
         self.docker_client.run_containers(config, use_name=True, detach=True)

--- a/services/orchest-ctl/app/spec.py
+++ b/services/orchest-ctl/app/spec.py
@@ -97,6 +97,7 @@ def filter_container_config(
 
 
 def get_container_config(
+    port: int = 8000,
     cloud: bool = False,
     dev: bool = False,
     log_level: Optional[LogLevel] = None,
@@ -117,6 +118,7 @@ def get_container_config(
             * ``"ORCHEST_HOST_GID"``
 
     Args:
+        port: The port the Orchest webserver will listen on.
         cloud: If the configuration should be setup for running in the
             cloud.
         dev: If the configuration should be setup for running in dev
@@ -126,7 +128,7 @@ def get_container_config(
             construct the container configurations.
 
     """
-    config = get_reg_container_config(env)
+    config = get_reg_container_config(port, env)
 
     if cloud:
         update_container_config_with_cloud(config, env)
@@ -140,7 +142,7 @@ def get_container_config(
     return config
 
 
-def get_reg_container_config(env: Optional[dict] = None) -> dict:
+def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
     """Constructs the container config to run Orchest.
 
     Note:
@@ -153,6 +155,7 @@ def get_reg_container_config(env: Optional[dict] = None) -> dict:
         https://docs.docker.com/engine/api/v1.41/#operation/ContainerCreate
 
     Args:
+        port: The port the Orchest webserver will listen on.
         env: Refer to :meth:`get_container_config`.
 
     Returns:
@@ -184,6 +187,7 @@ def get_reg_container_config(env: Optional[dict] = None) -> dict:
         "orchest-webserver": {
             "Image": "orchest/orchest-webserver:latest",
             "Env": [
+                f"PORT={port}",
                 f'HOST_USER_DIR={env["HOST_USER_DIR"]}',
                 f'HOST_CONFIG_DIR={env["HOST_CONFIG_DIR"]}',
                 f'HOST_REPO_DIR={env["HOST_REPO_DIR"]}',
@@ -258,7 +262,7 @@ def get_reg_container_config(env: Optional[dict] = None) -> dict:
             "HostConfig": {
                 "PortBindings": {
                     # Exposure of 443 is injected based on certs.
-                    "80/tcp": [{"HostPort": "8000"}],
+                    "80/tcp": [{"HostPort": f"{port}"}],
                 },
                 # Injected based on presence of certs on host.
                 "Binds": [],
@@ -282,6 +286,7 @@ def get_reg_container_config(env: Optional[dict] = None) -> dict:
         "update-server": {
             "Image": "orchest/update-server:latest",
             "Env": [
+                f"PORT={port}",
                 f'HOST_USER_DIR={env["HOST_USER_DIR"]}',
                 f'HOST_CONFIG_DIR={env["HOST_CONFIG_DIR"]}',
                 f'HOST_REPO_DIR={env["HOST_REPO_DIR"]}',

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -53,6 +53,8 @@ class Config:
     TELEMETRY_DISABLED = False
     TELEMETRY_INTERVAL = 15  # in minutes
 
+    # The port nginx will listen on. Necessary for a proper restart.
+    PORT = os.environ["PORT"]
     CLOUD = _config.CLOUD
     GPU_REQUEST_URL = "https://www.orchest.io/redirect-request-gpu"
 

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -183,6 +183,8 @@ def register_views(app, db):
 
         cmd = ["updateserver"]
 
+        cmd.append(f"--port {StaticConfig.PORT}")
+
         if StaticConfig.FLASK_ENV == "development":
             cmd.append("--dev")
 
@@ -202,6 +204,8 @@ def register_views(app, db):
 
         client = docker.from_env()
         cmd = ["restart"]
+
+        cmd.append(f"--port {StaticConfig.PORT}")
 
         if StaticConfig.FLASK_ENV == "development":
             cmd.append("--dev")

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -183,7 +183,8 @@ def register_views(app, db):
 
         cmd = ["updateserver"]
 
-        cmd.append(f"--port {StaticConfig.PORT}")
+        # Note that it won't work as --port {port}.
+        cmd.append(f"--port={StaticConfig.PORT}")
 
         if StaticConfig.FLASK_ENV == "development":
             cmd.append("--dev")
@@ -205,7 +206,8 @@ def register_views(app, db):
         client = docker.from_env()
         cmd = ["restart"]
 
-        cmd.append(f"--port {StaticConfig.PORT}")
+        # Note that it won't work as --port {port}.
+        cmd.append(f"--port={StaticConfig.PORT}")
 
         if StaticConfig.FLASK_ENV == "development":
             cmd.append("--dev")

--- a/services/update-server/app/app/config.py
+++ b/services/update-server/app/app/config.py
@@ -7,6 +7,8 @@ class Config:
     DEBUG = False
     CLOUD = _config.CLOUD
     FLASK_ENV = os.environ.get("FLASK_ENV", "production")
+    # The port nginx will listen on. Necessary for a proper restart.
+    PORT = os.environ["PORT"]
 
 
 class DevelopmentConfig(Config):

--- a/services/update-server/app/app/views.py
+++ b/services/update-server/app/app/views.py
@@ -70,7 +70,8 @@ def background_task():
         # Restart Orchest given the flags.
         ctl_command = ["restart"]
 
-        ctl_command.append(f"--port {CONFIG_CLASS.PORT}")
+        # Note that it won't work as --port {port}.
+        ctl_command.append(f"--port={CONFIG_CLASS.PORT}")
 
         if CONFIG_CLASS.FLASK_ENV == "development":
             ctl_command.append("--dev")

--- a/services/update-server/app/app/views.py
+++ b/services/update-server/app/app/views.py
@@ -70,6 +70,8 @@ def background_task():
         # Restart Orchest given the flags.
         ctl_command = ["restart"]
 
+        ctl_command.append(f"--port {CONFIG_CLASS.PORT}")
+
         if CONFIG_CLASS.FLASK_ENV == "development":
             ctl_command.append("--dev")
 


### PR DESCRIPTION
## Description
Fixes the fact that the port which Orchest was started with was not preserved between restarts and updates.

### Checklist

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
