### PR TITLE
Rabbitmq to be ready before continuing with start

### DIFF
--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -153,6 +153,12 @@ class OrchestApp:
                     "pg_isready --username postgres",
                 )
 
+                utils.wait_for_zero_exitcode(
+                    self.docker_client,
+                    stdouts["rabbitmq-server"]["id"],
+                    "rabbitmqctl node_health_check",
+                )
+
         # Get the port on which Orchest is running.
         nginx_proxy = container_config.get("nginx-proxy")
         if nginx_proxy is not None:

--- a/services/orchest-ctl/tests/test_orchestapp.py
+++ b/services/orchest-ctl/tests/test_orchestapp.py
@@ -261,6 +261,7 @@ def test_start(
     docker_client.run_containers = MagicMock(
         return_value={
             "orchest-database": {"id": None},
+            "rabbitmq-server": {"id": None},
         }
     )
     docker_client.is_network_installed = MagicMock(return_value=True)


### PR DESCRIPTION
A small PR to require `rabbitmq` to be ready before moving on with starting other services during the start of Orchest.


### Checklist

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
