### PR TITLE
Fix abort run on session shutdown

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_sessions.py
+++ b/services/orchest-api/app/app/apis/namespace_sessions.py
@@ -346,10 +346,4 @@ class RestartMemoryServer(TwoPhaseFunction):
         # Note: The entry in the database does not have to be updated
         # since restarting the `memory-server` does not change its
         # Docker ID.
-        try:
-            session_obj.restart_resource(resource_name="memory-server")
-        except Exception as e:
-            current_app.logger.error(
-                "Failed to restart the memory server %s [%s]" % (e, type(e))
-            )
-            raise e
+        session_obj.restart_resource(resource_name="memory-server")

--- a/services/orchest-api/app/tests/namespaces/test_namespace_sessions.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_sessions.py
@@ -2,6 +2,7 @@ from _orchest.internals.test_utils import raise_exception_function
 from app.apis.namespace_sessions import (
     AbortPipelineRun,
     CreateInteractiveSession,
+    RestartMemoryServer,
     StopInteractiveSession,
 )
 from app.core.sessions import InteractiveSession
@@ -101,9 +102,36 @@ def test_session_put(client, pipeline, monkeypatch_interactive_session, monkeypa
     assert r.restarted
 
 
+def test_session_put_aborts_interactive_run(
+    client, interactive_run, monkeypatch_interactive_session, monkeypatch
+):
+    pr_uuid = interactive_run.project.uuid
+    pl_uuid = interactive_run.pipeline.uuid
+    pipeline_spec = {
+        "project_uuid": pr_uuid,
+        "pipeline_uuid": pl_uuid,
+        "pipeline_path": "pip_path",
+        "project_dir": "project_dir",
+        "host_userdir": "host_userdir",
+    }
+
+    client.post("/api/sessions/", json=pipeline_spec)
+
+    monkeypatch.setattr(
+        RestartMemoryServer, "_collateral", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(AbortPipelineRun, "_collateral", lambda *args, **kwargs: None)
+    resp = client.put(f"/api/sessions/{pr_uuid}/{pl_uuid}")
+    assert resp.status_code == 200
+
+    query = {"project_uuid": pr_uuid, "pipeline_uuid": pl_uuid}
+    data = client.get("/api/runs/", query_string=query).get_json()
+    assert data["runs"][0]["status"] == "ABORTED"
+
+
 def test_session_put_non_existent(client):
     resp = client.put("/api/sessions/hello/world")
-    assert resp.status_code == 404
+    assert resp.status_code == 500
 
 
 def test_session_delete_is_stopping(

--- a/services/orchest-api/app/tests/namespaces/test_namespace_sessions.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_sessions.py
@@ -1,5 +1,9 @@
 from _orchest.internals.test_utils import raise_exception_function
-from app.apis.namespace_sessions import CreateInteractiveSession, StopInteractiveSession
+from app.apis.namespace_sessions import (
+    AbortPipelineRun,
+    CreateInteractiveSession,
+    StopInteractiveSession,
+)
 from app.core.sessions import InteractiveSession
 
 
@@ -126,6 +130,33 @@ def test_session_delete_is_stopping(
 
     assert resp.status_code == 200
     assert data["status"] == "STOPPING"
+
+
+def test_session_delete_aborts_interactive_run(
+    client, interactive_run, monkeypatch_interactive_session, monkeypatch
+):
+    pr_uuid = interactive_run.project.uuid
+    pl_uuid = interactive_run.pipeline.uuid
+    pipeline_spec = {
+        "project_uuid": pr_uuid,
+        "pipeline_uuid": pl_uuid,
+        "pipeline_path": "pip_path",
+        "project_dir": "project_dir",
+        "host_userdir": "host_userdir",
+    }
+
+    client.post("/api/sessions/", json=pipeline_spec)
+
+    monkeypatch.setattr(
+        StopInteractiveSession, "_collateral", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(AbortPipelineRun, "_collateral", lambda *args, **kwargs: None)
+    resp = client.delete(f"/api/sessions/{pr_uuid}/{pl_uuid}")
+    assert resp.status_code == 200
+
+    query = {"project_uuid": pr_uuid, "pipeline_uuid": pl_uuid}
+    data = client.get("/api/runs/", query_string=query).get_json()
+    assert data["runs"][0]["status"] == "ABORTED"
 
 
 def test_session_delete(client, pipeline, monkeypatch_interactive_session, monkeypatch):


### PR DESCRIPTION
## Description
This PR makes it so that an ongoing interactive run will be aborted if the session is shut down or the memory server is restarted through the API, note that, as it stands, the GUI will not allow a user to restart the memory server if an interactive run is ongoing, but the session stop and memory server restart behaviours have been made consistent.

Fixes: #226 

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
