### PR TITLE
Upgrade Orchest SDK and memory server to pyarrow 4.0.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ exclude_patterns = [""]
 
 # Autodoc configurations.
 # Mock dependencies that are not available at build time.
-autodoc_mock_imports = ["boto3", "pyarrow", "sqlalchemy"]
+autodoc_mock_imports = ["pyarrow"]
 # The first line of the docstring can be considered to be the function's
 # signature (if it looks like one).
 autodoc_docstring_signature = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,14 +1,15 @@
 # Configuration file for the Sphinx documentation builder.
 #
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
+# This file only contains a selection of the most common options. For a
+# full list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
+# -- Path setup --------------------------------------------------------
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
+# If extensions (or modules to document with autodoc) are in another
+# directory, add these directories to sys.path here. If the directory is
+# relative to the documentation root, use os.path.abspath to make it
+# absolute, like shown here.
 #
 import os
 import sys
@@ -16,21 +17,21 @@ import sys
 sys.path.insert(0, os.path.abspath("../../orchest-sdk/python"))
 
 
-# -- Project information -----------------------------------------------------
+# -- Project information -----------------------------------------------
 
 project = "Orchest"
 copyright = "2020, Orchest Software B.V."
 author = "Rick Lamers, Yannick Perrenet"
 
 # The full version, including alpha/beta/rc tags
-# We exclude the exact release because that is error prone when having to
-# update it on every release.
+# We exclude the exact release because that is error prone when having
+# to update it on every release.
 # release = "0.3.0"
 version = "alpha"
 html_title = "Orchest documentation"
 
 
-# -- General configuration ---------------------------------------------------
+# -- General configuration ---------------------------------------------
 
 master_doc = "index"
 
@@ -58,16 +59,17 @@ autodoc_mock_imports = ["pyarrow"]
 autodoc_docstring_signature = True
 
 
-# -- Options for HTML output -------------------------------------------------
+# -- Options for HTML output -------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
+# The theme to use for HTML and HTML Help pages.  See the documentation
+# for a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {"display_version": True}
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
+# Add any paths that contain custom static files (such as style sheets)
+# here, relative to this directory. They are copied after the builtin
+# static files, so a file named "default.css" will overwrite the builtin
+# "default.css".
 # html_static_path = ['_static']
 html_static_path = []

--- a/orchest-sdk/python/requirements-dev.txt
+++ b/orchest-sdk/python/requirements-dev.txt
@@ -1,0 +1,2 @@
+pandas
+pyarrow==4.0.0

--- a/orchest-sdk/python/requirements.txt
+++ b/orchest-sdk/python/requirements.txt
@@ -1,5 +1,1 @@
-SQLAlchemy
-boto3
-pandas 
-pyarrow>=2.0.0,<3.0.0
-requests
+pyarrow==4.0.0

--- a/orchest-sdk/python/setup.py
+++ b/orchest-sdk/python/setup.py
@@ -10,13 +10,7 @@ setuptools.setup(
     version="0.2.0",
     packages=setuptools.find_packages(),
     install_requires=[
-        "pyarrow>=2.0.0,<3.0.0",
-        "boto3>=1.13.26",
-        "requests>=2.23.0",
-        "SQLAlchemy>=1.3.18",
-        "mysqlclient>=2.0.1",
-        "psycopg2-binary>=2.8.6",
-        "sqlalchemy-redshift>=0.8.1",
+        "pyarrow>=1.0.0,<=4.0.0",
     ],
     # Metadata to display on PyPI.
     author="Rick Lamers",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -149,7 +149,7 @@ do
     if [ $SERVICE == "orchest-sdk" ]; then
         TEST_DIR=$DIR/../orchest-sdk/python
         REQ_DIR=$TEST_DIR
-        REQ_FILE=$REQ_DIR/requirements.txt
+        REQ_FILE=$REQ_DIR/requirements-dev.txt
     fi
     if [ $SERVICE == "orchest-ctl" ]; then
         TEST_DIR=$DIR/../services/orchest-ctl

--- a/services/memory-server/requirements-dev.txt
+++ b/services/memory-server/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements.txt
 networkx==2.4
-pyarrow>=2.0.0,<3.0.0
+pyarrow==4.0.0
 -e ../../orchest-sdk/python
 -e ../../lib/python/orchest-internals

--- a/services/memory-server/requirements.txt
+++ b/services/memory-server/requirements.txt
@@ -1,5 +1,5 @@
 # Make sure hardcoded version here are equal to the versions in the
 # requirements-dev.txt
 networkx==2.4
-pyarrow>=2.0.0,<3.0.0
+pyarrow==4.0.0
 -e ../../lib/python/orchest-internals


### PR DESCRIPTION
## Description
This PR upgrades the Orchest SDK and memory server service to `pyarrow` 4.0.0. The Orchest SDK requirements have intentionally been set with `pyarrow>=1.0.0,<=4.0.0` since testing has shown that the SDK would not break if a user was to install `pyarrow` release 1/2/3 when building an environment.
Some unused packages have also been removed from the SDK.

### Checklist

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
