### PR TITLE
Improv remove orchest dangling images on update and start

### DIFF
--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -84,8 +84,6 @@ class OrchestApp:
                 on start.
 
         """
-        self.resource_manager.remove_orchest_dangling_imgs()
-
         # Check whether the minimal set of images is present for Orchest
         # to be started.
         pulled_images = self.resource_manager.get_images()

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -117,4 +117,4 @@ def update_git_repo():
 def is_dangling(image: Mapping) -> bool:
     """Checks whether the given image is to be considered dangling."""
     tags = image["RepoTags"]
-    return not tags or (len(tags) == 1 and tags[0] == "<none>:<none>")
+    return not tags or "<none>:<none>" in tags


### PR DESCRIPTION
## Description

<!--
Please provide a summary of what this PR adds or changes together with relevant motivation and context.
-->

Fixes issue #213

### Checklist

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
