### PR TITLE
[documentation update] fix get_params example

### DIFF
--- a/docs/source/user_guide/sdk/python.rst
+++ b/docs/source/user_guide/sdk/python.rst
@@ -76,7 +76,7 @@ Parameters
    import orchest
 
    # Get the parameters of the current step and the pipeline.
-   step_params, pipeline_params = orchest.get_params()  # e.g. ({"vegetable": "carrot"}, {})
+   step_params, pipeline_params = orchest.parameters.get_params()  # e.g. ({"vegetable": "carrot"}, {})
 
    # Update both the step parameters and the pipeline parameters. The
    # updated parameters will be visible in the GUI, in the properties


### PR DESCRIPTION
A single grain of contribution to an exiting project I discovered just today! 🤩  
Important to keep examples up to date and copy/paste ready for newcomers~

## Description
It looks like `orchest.get_params()` is now `orchest.parameters.get_params()`

### Checklist

- [x] The documentation reflects the changes.
