### PR TITLE
Stop Orchest on CLI update

### DIFF
--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -360,7 +360,8 @@ class OrchestApp:
         if mode == "web":
             utils.echo("Update completed.")
         else:
-            utils.echo("Update completed. Run ./orchest start to start Orchest.")
+            utils.echo("Update completed. To start Orchest again, run:")
+            utils.echo("\torchest start")
 
     def version(self, ext=False):
         """Returns the version of Orchest.

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -296,6 +296,7 @@ class OrchestApp:
         utils.echo("Updating...")
 
         _, running_containers = self.resource_manager.get_containers(state="running")
+
         if utils.is_orchest_running(running_containers):
             utils.echo(
                 "Using Orchest whilst updating is NOT supported and will be shut"
@@ -307,16 +308,19 @@ class OrchestApp:
             # using a keyboard interrupt.
             time.sleep(2)
 
-            # It is possible to pull new image whilst the older versions
-            # of those images are running.
-            self.stop(
-                skip_containers=[
+            skip_containers = []
+            if mode == "web":
+                # It is possible to pull new images whilst the older
+                # versions of those images are running. We will invoke
+                # Orchest restart from the webserver ui-updater.
+                skip_containers = [
                     "orchest/update-server:latest",
                     "orchest/auth-server:latest",
                     "orchest/nginx-proxy:latest",
                     "postgres:13.1",
                 ]
-            )
+
+            self.stop(skip_containers=skip_containers)
 
         # Update the Orchest git repo to get the latest changes to the
         # "userdir/" structure.
@@ -353,19 +357,7 @@ class OrchestApp:
         # Delete Orchest dangling images.
         self.resource_manager.remove_orchest_dangling_imgs()
 
-        # We invoke the Orchest restart from the webserver ui-updater.
-        # Hence we do not show the message to restart manually.
-        if mode == "web":
-            utils.echo("Update completed.")
-        else:
-            # Let the user know they need to restart the application
-            # for the changes to take effect. NOTE: otherwise Orchest
-            # might also be running a mix of containers on different
-            # versions.
-            utils.echo(
-                "Don't forget to restart Orchest for the changes to take effect:"
-            )
-            utils.echo("\torchest restart")
+        utils.echo("Update completed.")
 
     def version(self, ext=False):
         """Returns the version of Orchest.

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -357,7 +357,10 @@ class OrchestApp:
         # Delete Orchest dangling images.
         self.resource_manager.remove_orchest_dangling_imgs()
 
-        utils.echo("Update completed.")
+        if mode == "web":
+            utils.echo("Update completed.")
+        else:
+            utils.echo("Update completed. Run ./orchest start to start Orchest.")
 
     def version(self, ext=False):
         """Returns the version of Orchest.

--- a/services/orchest-ctl/tests/test_orchestapp.py
+++ b/services/orchest-ctl/tests/test_orchestapp.py
@@ -143,8 +143,8 @@ def test_version(extensive, exec_stdout, expected_stdout, capsys, monkeypatch):
 @pytest.mark.parametrize(
     ("installed_images", "update_exit_code", "mode", "expected_stdout"),
     [
-        (["A", "B"], 0, None, "Don't forget to restart Orchest"),
-        (["A"], 0, None, "Don't forget to restart Orchest"),
+        (["A", "B"], 0, None, "Update completed."),
+        (["A"], 0, None, "Update completed."),
         (["A"], 1, None, "Cancelling update..."),
         (["A"], 0, "web", "Update completed."),
     ],

--- a/services/orchest-ctl/tests/test_orchestapp.py
+++ b/services/orchest-ctl/tests/test_orchestapp.py
@@ -143,13 +143,8 @@ def test_version(extensive, exec_stdout, expected_stdout, capsys, monkeypatch):
 @pytest.mark.parametrize(
     ("installed_images", "update_exit_code", "mode", "expected_stdout"),
     [
-        (
-            ["A", "B"],
-            0,
-            None,
-            "Update completed. Run ./orchest start to start Orchest.",
-        ),
-        (["A"], 0, None, "Update completed. Run ./orchest start to start Orchest."),
+        (["A", "B"], 0, None, "Update completed. To start Orchest again, run:"),
+        (["A"], 0, None, "Update completed. To start Orchest again, run:"),
         (["A"], 1, None, "Cancelling update..."),
         (["A"], 0, "web", "Update completed."),
     ],

--- a/services/orchest-ctl/tests/test_orchestapp.py
+++ b/services/orchest-ctl/tests/test_orchestapp.py
@@ -143,8 +143,13 @@ def test_version(extensive, exec_stdout, expected_stdout, capsys, monkeypatch):
 @pytest.mark.parametrize(
     ("installed_images", "update_exit_code", "mode", "expected_stdout"),
     [
-        (["A", "B"], 0, None, "Update completed."),
-        (["A"], 0, None, "Update completed."),
+        (
+            ["A", "B"],
+            0,
+            None,
+            "Update completed. Run ./orchest start to start Orchest.",
+        ),
+        (["A"], 0, None, "Update completed. Run ./orchest start to start Orchest."),
         (["A"], 1, None, "Cancelling update..."),
         (["A"], 0, "web", "Update completed."),
     ],


### PR DESCRIPTION
This PR makes it so that `./orchest update` will lead to a full stop of Orchest if Orchest is running when not called with `--mode=web`.

### Checklist

- [X] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
