### PR TITLE
Fix user configuration migration on JupyterLab upgrade

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -35,7 +35,8 @@ KERNEL_NAME = "orchest-kernel-{environment_uuid}"
 PIPELINE_STEP_CONTAINER_NAME = "orchest-step-{run_uuid}-{step_uuid}"
 JUPYTER_SERVER_NAME = "jupyter-server-{project_uuid}-{pipeline_uuid}"
 JUPYTER_EG_SERVER_NAME = "jupyter-EG-{project_uuid}-{pipeline_uuid}"
-JUPYTER_SETUP_SCRIPT = ".orchest/user-configurations/jupyterlab/setup_script.sh"
+JUPYTER_USER_CONFIG = ".orchest/user-configurations/jupyterlab"
+JUPYTER_SETUP_SCRIPT = f"{JUPYTER_USER_CONFIG}/setup_script.sh"
 JUPYTER_IMAGE_NAME = "orchest-jupyter-server-user-configured"
 
 # Whenever UUIDs take up too much space in an identifier the UUIDs are

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -26,27 +26,27 @@ build_path=/jupyterlab-orchest-build
 userdir_path=/usr/local/share/jupyter/lab
 
 ###
-# The lockfile is used to make sure
+# The lockdir is used to make sure
 # that this JupyterLab start script
 # is only executed for one instance
 # at a time.
 ###
-lockfile=$userdir_path/.bootlock
+lockdir=$userdir_path/.bootlock
 
-await_lock() {
-    until [ ! -f $lockfile ]
+acquire_lock() {
+    while :
     do
+        if mkdir $lockdir 2>/dev/null; then
+            break
+        fi
+
         echo "Awaiting boot lock..."
         sleep 1
     done
 }
 
-write_lock() {
-    touch $lockfile
-}
-
 release_lock() {
-    rm -f $lockfile
+    rm -rf $lockdir
 }
 
 start_jupyterlab(){
@@ -54,8 +54,7 @@ start_jupyterlab(){
     jupyter lab --LabApp.app_dir="$userdir_path" "$@" --collaborative
 }
 
-await_lock
-write_lock
+acquire_lock
 
 pre_installed_extensions=("orchest-integration" "visual-tags" "nbdime-jupyterlab")
 

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -89,8 +89,26 @@ if [ "$build_version" = "$userdir_version" ] && $equal_ext_versions; then
     exit 0
 fi
 
+# In case JupyterLab was upgraded we need to remove all files that
+# could potentially cause compatibility issues with the new version.
+find "$userdir_path" \
+    -maxdepth 1 \
+    ! \( \
+        -type d -a \( -name "extensions" -o -name "themes" \) \
+        -o -name ".gitignore" \
+        -o -wholename "$userdir_path" \
+    \) \
+    -exec rm -rf {} \;
+
 # Overwrite the static files from the userdir with the static files
 # from the build. Otherwise JupyterLab cannot start as part of Orchest.
-rm -rf "$userdir_path/static" && cp -r "$build_path/static" "$userdir_path/static"
+find "$build_path" \
+    -maxdepth 1 \
+    ! \( \
+        -type d -a \( -name "extensions" -o -name "themes" \) \
+        -o -name ".gitignore" \
+        -o -wholename "$build_path" \
+    \) \
+    -exec cp -r {} "$userdir_path" \;
 
 jupyter lab --LabApp.app_dir="$userdir_path" "$@" --collaborative

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -51,10 +51,15 @@ release_lock() {
 
 start_jupyterlab(){
     release_lock
+    # Don't release the lock again on exit.
+    trap - EXIT
     jupyter lab --LabApp.app_dir="$userdir_path" "$@" --collaborative
 }
 
 acquire_lock
+# Make sure the lock is released if, for some reason, the process does
+# not get to release the lock. Does not cover the case of SIGKILL.
+trap release_lock EXIT
 
 pre_installed_extensions=("orchest-integration" "visual-tags" "nbdime-jupyterlab")
 

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -89,6 +89,9 @@ if [ "$build_version" = "$userdir_version" ] && $equal_ext_versions; then
     exit 0
 fi
 
+echo "Pre installed extensions have changed, partially clearing \
+JupyterLab userdir config."
+
 # In case JupyterLab was upgraded we need to remove all files that
 # could potentially cause compatibility issues with the new version.
 find "$userdir_path" \

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -77,7 +77,7 @@ check_ext_versions() {
 userdir_version=$(jq .jupyterlab.version "$userdir_path/static/package.json" 2>/dev/null)
 if [ -z "$userdir_version" ]; then
     cp -rfT "$build_path" "$userdir_path"
-    start_jupyterlab
+    start_jupyterlab "$@"
     exit 0
 fi
 
@@ -117,7 +117,7 @@ cp -rnT "$build_path/extensions" "$userdir_path/extensions"
 
 if [ "$build_version" = "$userdir_version" ] && $equal_ext_versions; then
     # We don't have to do anything.
-    start_jupyterlab
+    start_jupyterlab "$@"
     exit 0
 fi
 
@@ -146,4 +146,4 @@ find "$build_path" \
     \) \
     -exec cp -r {} "$userdir_path" \;
 
-start_jupyterlab
+start_jupyterlab "$@"

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -131,6 +131,7 @@ find "$userdir_path" \
         -type d -a \( -name "extensions" -o -name "themes" \) \
         -o -name ".gitignore" \
         -o -wholename "$userdir_path" \
+        -o -wholename "$lockdir" \
     \) \
     -exec rm -rf {} \;
 

--- a/services/orchest-api/app/app/apis/namespace_sessions.py
+++ b/services/orchest-api/app/app/apis/namespace_sessions.py
@@ -295,6 +295,10 @@ class StopInteractiveSession(TwoPhaseFunction):
         notebook_server_info: Dict[str, str] = None,
     ):
 
+        # Note that a session that is still LAUNCHING should not be
+        # killed until it has done launching, because the jupyterlab
+        # user configuration is managed through a lock that is removed
+        # by the jupyterlab start script. See PR #254.
         with app.app_context():
             try:
                 session_obj = InteractiveSession.from_container_IDs(

--- a/services/orchest-api/requirements-dev.txt
+++ b/services/orchest-api/requirements-dev.txt
@@ -5,6 +5,7 @@ amqp==2.6.0
 celery==4.4.2
 croniter==1.0.2
 docker>=4.3.0
+six>=1.13.0
 Flask==1.1.1
 Flask-Cors==3.0.9
 flask-restx==0.2.0

--- a/services/orchest-api/requirements.txt
+++ b/services/orchest-api/requirements.txt
@@ -5,6 +5,7 @@ amqp==2.6.0
 celery==4.4.2
 croniter==1.0.2
 docker>=4.3.0
+six>=1.13.0
 Flask==1.1.1
 Flask-Cors==3.0.9
 flask-restx==0.2.0

--- a/services/orchest-ctl/requirements-dev.txt
+++ b/services/orchest-ctl/requirements-dev.txt
@@ -1,5 +1,6 @@
 typer
 docker
+six>=1.13.0
 aiodocker @ git+https://github.com/yannickperrenet/aiodocker.git
 tqdm==4.53.0
 -e ../../lib/python/orchest-internals

--- a/services/orchest-ctl/setup.py
+++ b/services/orchest-ctl/setup.py
@@ -7,6 +7,7 @@ setuptools.setup(
     install_requires=[
         "typer",
         "docker",
+        "six>=1.13.0",
         "aiodocker @ git+https://github.com/yannickperrenet/aiodocker.git",
         "tqdm==4.53.0",
         "orchest-internals @ file://localhost/orchest/lib/python/orchest-internals",

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -123,6 +123,22 @@ def create_app():
                         % (proj.uuid, e, type(e))
                     )
 
+        # To avoid multiple removals in case of a flask --reload, so
+        # that this code runs once per container.
+        try:
+            os.mkdir("/tmp/jupyter_lock_removed")
+            lock_path = os.path.join(
+                "/userdir", _config.JUPYTER_USER_CONFIG, "lab", ".bootlock"
+            )
+            if os.path.exists(lock_path):
+                app.logger.info("Removing dangling jupyter boot lock.")
+                os.remove(lock_path)
+
+        except FileExistsError:
+            app.logger.info(
+                "/tmp/jupyter_lock_removed exists. " " Not removing the lock again."
+            )
+
     # Telemetry
     if not app.config["TELEMETRY_DISABLED"]:
         # initialize posthog

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -132,7 +132,7 @@ def create_app():
             )
             if os.path.exists(lock_path):
                 app.logger.info("Removing dangling jupyter boot lock.")
-                os.remove(lock_path)
+                os.rmdir(lock_path)
 
         except FileExistsError:
             app.logger.info(

--- a/services/orchest-webserver/requirements.txt
+++ b/services/orchest-webserver/requirements.txt
@@ -13,6 +13,7 @@ requests==2.25.0
 APScheduler==3.6.3
 nbformat==5.0.8
 docker>=4.3.0
+six>=1.13.0
 Werkzeug==0.16.0
 python-engineio==3.14.2
 python-socketio==4.6.1

--- a/services/update-server/requirements.txt
+++ b/services/update-server/requirements.txt
@@ -1,4 +1,5 @@
 Flask==1.1.1
 docker
+six>=1.13.0
 requests
 -e ../../lib/python/orchest-internals


### PR DESCRIPTION
### Description
On JupyterLab upgrade its old build files will be removed, whilst trying to maintain the user configurations.

### How to test
I tested by swapping between commit `853809f2752c31f58528cc3a860bab9d5ca59003` (a commit before the JupyterLab upgrade) and rebuilding Orchest each time (which is quick due to Docker's caching system).

My flow:
* `sudo rm -rf lab && git checkout lab && ll lab` in `userdir/.orchest/user-configurations/jupyterlab`
* `git checkout 853809f2752c31f58528cc3a860bab9d5ca59003`
* `scripts/build_container.sh`
* Rebuilding the user configured JupyterLab (in which I put `pip show jupyterlab` to inspect that it is running on an older/newer version).
* This now populates the `lab` directory.
* Stop Orchest and rebuild master (after a `git checkout master`)
* Rebuild user configured JupyterLab
* Start a session (to trigger the changes in `start.sh`)
* See that the directory structure of the `lab` directory is updated.

### Checklist
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
