### PR TITLE
Fix Alert pagination

### DIFF
--- a/lib/design-system/package/CHANGELOG.md
+++ b/lib/design-system/package/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file
 
+# 0.0.3 (2021-05-20)
+
+## Bug Fixes
+
+- `Alert` backwards pagination goes to the previous item, rather than the next.
+
 # 0.0.2 (2021-05-12)
 
 ## Bug Fixes

--- a/lib/design-system/package/package.json
+++ b/lib/design-system/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchest/design-system",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Orchest B.V.",
   "license": "AGPL-3.0-only",
   "main": "dist/index.cjs",

--- a/lib/design-system/package/src/components/alert.tsx
+++ b/lib/design-system/package/src/components/alert.tsx
@@ -118,7 +118,7 @@ export const Alert = React.forwardRef<IAlertRef, IAlertProps>(
                     label="Back"
                     variant="ghost"
                     bleed="bottom"
-                    onClick={() => cycleDescriptionIndex("forwards")}
+                    onClick={() => cycleDescriptionIndex("backwards")}
                   >
                     <IconChevronLeft />
                   </IconButton>


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

Adds the "backwards" direction to the previous button (which was missed off in the implementation)

<!-- Fixes: #issue -->

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
