### PR TITLE
Fix: "Text is hard to read in the 'environments' tab"

### DIFF
--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -30,7 +30,6 @@
 @import "ansi";
 @import "themes/jupyter";
 
-$generalPadding: 20px;
 $mdcComponentPadding: 16px;
 $codeSize: 14px;
 $defaultFontSize: 15px;
@@ -57,10 +56,10 @@ body {
 
 p {
   &.padding-top {
-    padding-top: $generalPadding;
+    padding-top: var(--space-5);
   }
   &.padding-bottom {
-    padding-bottom: $generalPadding;
+    padding-bottom: var(--space-5);
   }
 }
 
@@ -105,13 +104,13 @@ h2 {
 
 .create-job-modal {
   .mdc-linear-progress {
-    margin: $generalPadding 0;
+    margin: var(--space-5) 0;
   }
 }
 
 header {
   height: 80px;
-  padding: $generalPadding/2;
+  padding: calc(var(--space-5) / 2);
   border-bottom: 1px solid $borderColor;
   position: relative;
 
@@ -123,7 +122,7 @@ header {
 
   .header-actions {
     button {
-      margin-left: $generalPadding/2;
+      margin-left: calc(var(--space-5) / 2);
       &:first-child {
         margin-left: 0;
       }
@@ -141,7 +140,7 @@ header {
     height: auto;
     box-sizing: content-box;
     width: 50px;
-    padding-right: $generalPadding;
+    padding-right: var(--space-5);
     padding-left: 10px;
     display: inline-block;
   }
@@ -181,7 +180,7 @@ header {
 
     button {
       position: absolute;
-      right: $generalPadding;
+      right: var(--space-5);
       top: 50%;
       transform: translateY(-50%);
     }
@@ -239,7 +238,7 @@ a.button {
 }
 
 .view-page {
-  padding: $generalPadding;
+  padding: var(--space-5);
   overflow-y: auto;
   height: 100%;
 
@@ -249,8 +248,8 @@ a.button {
 
   &.orchest-settings {
     h3 {
-      margin-top: $generalPadding * 2;
-      margin-bottom: $generalPadding/2;
+      margin-top: var(--space-10);
+      margin-bottom: calc(var(--space-5) / 2);
     }
     .columns {
       .column {
@@ -280,7 +279,7 @@ a.button {
         max-width: 400px;
 
         h2 {
-          margin-bottom: $generalPadding;
+          margin-bottom: var(--space-5);
           text-align: center;
         }
       }
@@ -292,7 +291,7 @@ a.button {
   }
 
   h2 {
-    padding-bottom: $generalPadding;
+    padding-bottom: var(--space-5);
   }
 
   &.update-page {
@@ -308,11 +307,11 @@ a.button {
     }
 
     .mdc-text-field--outlined.search {
-      margin-bottom: $generalPadding;
+      margin-bottom: var(--space-5);
     }
 
     .job-actions {
-      margin-bottom: $generalPadding;
+      margin-bottom: var(--space-5);
     }
   }
 }
@@ -374,7 +373,7 @@ p > i.material-icons.float-left {
 
 .datetime-input {
   > div {
-    margin-bottom: $generalPadding;
+    margin-bottom: var(--space-5);
   }
 }
 
@@ -518,21 +517,27 @@ p > i.material-icons.float-left {
     margin-right: 0;
   }
   > * {
-    margin-right: $generalPadding;
+    margin-right: var(--space-5);
   }
 }
 
 .push-down {
-  margin-bottom: $generalPadding;
+  margin-bottom: var(--space-5);
 }
+
+// vars driven by Stitches
+.push-down-7 {
+  margin-bottom: var(--space-7);
+}
+
 .push-up {
-  margin-top: $generalPadding;
+  margin-top: var(--space-5);
 }
 .push-left {
-  margin-left: $generalPadding;
+  margin-left: var(--space-5);
 }
 .push-right {
-  margin-right: $generalPadding;
+  margin-right: var(--space-5);
 }
 
 .persistent-view {
@@ -559,7 +564,7 @@ p > i.material-icons.float-left {
 .file-viewer {
   .file-description,
   p {
-    padding: $generalPadding;
+    padding: var(--space-5);
 
     h3 {
       font-weight: 500;
@@ -572,7 +577,7 @@ p > i.material-icons.float-left {
 
     .step-navigation {
       overflow: auto;
-      padding-top: $generalPadding;
+      padding-top: var(--space-5);
 
       .parents {
         float: left;
@@ -611,7 +616,7 @@ p > i.material-icons.float-left {
   }
 
   .react-codemirror2 {
-    padding: $generalPadding;
+    padding: var(--space-5);
 
     .CodeMirror {
       width: 100%;
@@ -648,8 +653,8 @@ button.text-button {
 
 .top-buttons {
   position: absolute;
-  top: $generalPadding;
-  right: $generalPadding;
+  top: var(--space-5);
+  right: var(--space-5);
   z-index: 99;
 
   button {
@@ -663,9 +668,9 @@ button.text-button {
 .bottom-buttons {
   background: #fff;
   width: 100%;
-  margin-left: -$generalPadding;
-  padding-left: $generalPadding;
-  padding-right: $generalPadding;
+  margin-left: -var(--space-5);
+  padding-left: var(--space-5);
+  padding-right: var(--space-5);
   box-sizing: content-box;
 
   &.overflowing {
@@ -673,8 +678,8 @@ button.text-button {
   }
 
   button {
-    margin-right: $generalPadding;
-    margin-top: $generalPadding;
+    margin-right: var(--space-5);
+    margin-top: var(--space-5);
 
     &:last-of-type {
       margin-right: 0;
@@ -707,7 +712,7 @@ button.text-button {
 
 .pipeline-settings-view {
   .tab-content {
-    padding: $generalPadding 0;
+    padding: var(--space-5) 0;
   }
 
   ul {
@@ -720,7 +725,7 @@ button.text-button {
 
   form {
     button {
-      margin-top: $generalPadding;
+      margin-top: var(--space-5);
     }
   }
 }
@@ -740,7 +745,7 @@ button.text-button {
 }
 
 h2.header {
-  padding: $generalPadding;
+  padding: var(--space-5);
   background: #f5f5f5;
   font-weight: normal;
 }
@@ -751,11 +756,11 @@ h2.header {
   }
 
   .steps {
-    padding: $generalPadding;
+    padding: var(--space-5);
   }
 
   .step {
-    margin-bottom: $generalPadding;
+    margin-bottom: var(--space-5);
   }
 
   .argument-set {
@@ -810,7 +815,7 @@ span.floating-button {
 
   .pipeline-tab-view {
     .search {
-      margin-bottom: $generalPadding;
+      margin-bottom: var(--space-5);
     }
   }
 
@@ -818,7 +823,7 @@ span.floating-button {
     background: #fff;
 
     button {
-      margin-right: $generalPadding;
+      margin-right: var(--space-5);
 
       &:last-of-type {
         margin-right: 0;
@@ -850,7 +855,7 @@ span.floating-button {
 
       .pipeline-run-detail {
         button {
-          margin-top: $generalPadding;
+          margin-top: var(--space-5);
         }
       }
 
@@ -870,18 +875,18 @@ span.floating-button {
     }
 
     button {
-      margin-top: $generalPadding;
+      margin-top: var(--space-5);
     }
   }
 
   .tab-view {
-    padding: $generalPadding 0;
+    padding: var(--space-5) 0;
     flex: 1;
     overflow: auto;
   }
 
   .top-labels {
-    padding-bottom: $generalPadding;
+    padding-bottom: var(--space-5);
     font-size: 14px;
 
     h3 {
@@ -890,12 +895,12 @@ span.floating-button {
   }
 
   .mdc-tab-bar {
-    margin-top: $generalPadding;
+    margin-top: var(--space-5);
   }
 }
 
 .warning {
-  padding: $generalPadding/2;
+  padding: calc(var(--space-5) / 2);
   border-radius: 3px;
   color: #fff;
   background: #b00020;
@@ -998,7 +1003,7 @@ span.floating-button {
     .column:nth-child(1) {
       width: 30%;
     }
-    margin-bottom: $generalPadding;
+    margin-bottom: var(--space-5);
   }
 }
 
@@ -1025,7 +1030,7 @@ span.floating-button {
   font-size: 13px;
   background: #000;
   color: #fff;
-  padding: $generalPadding / 2;
+  padding: calc(var(--space-5) / 2);
   white-space: pre-line;
   overflow-x: auto;
 }
@@ -1104,7 +1109,7 @@ span.code {
     right: 0;
     top: 0;
     z-index: 9;
-    padding: $generalPadding;
+    padding: var(--space-5);
 
     &.bottom-right {
       top: auto;
@@ -1132,7 +1137,7 @@ span.code {
 
       button {
         margin-bottom: 0;
-        margin-top: $generalPadding;
+        margin-top: var(--space-5);
       }
 
       .navigation-buttons {
@@ -1141,7 +1146,7 @@ span.code {
 
       .selection-buttons {
         display: inline-block;
-        padding-left: $generalPadding;
+        padding-left: var(--space-5);
       }
     }
 
@@ -1150,8 +1155,8 @@ span.code {
         margin-right: 0;
       }
 
-      margin-right: $generalPadding;
-      margin-bottom: $generalPadding;
+      margin-right: var(--space-5);
+      margin-bottom: var(--space-5);
       min-width: 0;
     }
   }
@@ -1245,7 +1250,7 @@ span.code {
     .pipeline-step {
       position: absolute;
       background: #fff;
-      padding: $generalPadding/2 $generalPadding;
+      padding: calc(var(--space-5) / 2) var(--space-5);
       border: 1px solid $borderColor;
       border-radius: $stepBorderRadius;
       cursor: pointer;
@@ -1316,10 +1321,10 @@ span.code {
 
       .step-label {
         text-overflow: ellipsis;
-        height: $pipelineStepHeight - $generalPadding;
-        max-height: $pipelineStepHeight - $generalPadding;
-        width: $pipelineStepWidth - $generalPadding * 2;
-        max-width: $pipelineStepWidth - $generalPadding * 2;
+        height: calc(#{$pipelineStepHeight} - var(--space-5));
+        max-height: calc(#{$pipelineStepHeight} - var(--space-5));
+        width: calc(#{$pipelineStepWidth} - var(--space-5) * 2);
+        max-width: calc(#{$pipelineStepWidth} - var(--space-5) * 2);
         display: table-cell;
         vertical-align: middle;
         overflow: hidden;
@@ -1389,7 +1394,7 @@ span.code {
 
   .pipeline-details {
     height: 100%;
-    padding: $generalPadding 0;
+    padding: var(--space-5) 0;
     background: #fff;
     border-left: 1px solid $borderColor;
     z-index: 12;
@@ -1400,7 +1405,7 @@ span.code {
     }
 
     .overflowable {
-      padding: 0 $generalPadding;
+      padding: 0 var(--space-5);
     }
 
     .mdc-select__anchor {
@@ -1423,7 +1428,7 @@ span.code {
     }
 
     .input-group {
-      margin-bottom: $generalPadding;
+      margin-bottom: var(--space-5);
     }
 
     .connection-list {
@@ -1483,21 +1488,21 @@ span.code {
       flex-direction: column;
 
       &.overflown {
-        padding-right: $generalPadding;
+        padding-right: var(--space-5);
       }
     }
 
     .action-buttons-bottom {
-      padding: $generalPadding;
+      padding: var(--space-5);
       padding-bottom: 0;
 
       .file-actions {
-        margin-bottom: $generalPadding;
+        margin-bottom: var(--space-5);
 
         button {
           display: block;
 
-          margin-bottom: $generalPadding;
+          margin-bottom: var(--space-5);
           &:last-child {
             margin-bottom: 0;
           }
@@ -1505,7 +1510,7 @@ span.code {
       }
 
       button {
-        margin-right: $generalPadding;
+        margin-right: var(--space-5);
       }
     }
 
@@ -1546,7 +1551,7 @@ table {
   overflow: visible;
 
   .mdc-dialog__actions {
-    padding: $generalPadding;
+    padding: var(--space-5);
     padding-top: 0;
   }
 
@@ -1632,10 +1637,10 @@ table {
   .columns {
     &.inner-padded {
       .column:nth-child(1) {
-        padding-right: $generalPadding;
+        padding-right: var(--space-5);
       }
       .column:nth-child(2) {
-        padding-left: $generalPadding;
+        padding-left: var(--space-5);
       }
     }
   }
@@ -1661,7 +1666,7 @@ table {
     .column {
       width: 100%;
       padding: 0;
-      margin-bottom: $generalPadding;
+      margin-bottom: var(--space-5);
     }
     margin-bottom: 0;
   }

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -444,7 +444,6 @@ p > i.material-icons.float-left {
 .form-helper-text {
   font-size: $codeSize;
   margin-top: 10px;
-  color: rgba(0, 0, 0, 0.6);
 }
 
 .CodeMirror {

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -525,7 +525,6 @@ p > i.material-icons.float-left {
   margin-bottom: var(--space-5);
 }
 
-// vars driven by Stitches
 .push-down-7 {
   margin-bottom: var(--space-7);
 }

--- a/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
+++ b/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
@@ -570,7 +570,7 @@ class EnvironmentEditView extends React.Component {
                   }
                 })()}
 
-                <div className="push-down-7">
+                <div className="push-down">
                   <MDCButtonReact
                     label="Back to environments"
                     icon="arrow_back"

--- a/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
+++ b/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
@@ -381,7 +381,7 @@ class EnvironmentEditView extends React.Component {
                   <Fragment>
                     <div className="environment-properties">
                       <MDCTextFieldReact
-                        classNames={["fullwidth", "push-down"]}
+                        classNames={["fullwidth", "push-down-7"]}
                         label="Environment name"
                         onChange={this.onChangeName.bind(this)}
                         value={this.state.environment.name}
@@ -403,7 +403,7 @@ class EnvironmentEditView extends React.Component {
                         />
                         <div className="clear"></div>
                       </div>
-                      <div className="form-helper-text push-down">
+                      <div className="form-helper-text push-down-7">
                         The base image will be the starting point from which the
                         environment will be built.
                       </div>
@@ -421,7 +421,7 @@ class EnvironmentEditView extends React.Component {
                         ]}
                         value={this.state.environment.language}
                       />
-                      <div className="form-helper-text push-down">
+                      <div className="form-helper-text push-down-7">
                         The language determines for which kernel language this
                         environment can be used. This only affects pipeline
                         steps that point to a Notebook.
@@ -430,7 +430,7 @@ class EnvironmentEditView extends React.Component {
                       {(() => {
                         if (this.state.languageDocsNotice === true) {
                           return (
-                            <div className="docs-notice push-down">
+                            <div className="docs-notice push-down-7">
                               Language explanation
                             </div>
                           );
@@ -440,7 +440,7 @@ class EnvironmentEditView extends React.Component {
                       <MDCCheckboxReact
                         onChange={this.onGPUChange.bind(this)}
                         label="GPU support"
-                        classNames={["push-down"]}
+                        classNames={["push-down-7"]}
                         value={this.state.environment.gpu_support}
                         ref={this.refManager.nrefs.environmentGPUSupport}
                       />
@@ -448,7 +448,7 @@ class EnvironmentEditView extends React.Component {
                       {(() => {
                         if (this.state.environment.gpu_support === true) {
                           let enabledBlock = (
-                            <p className="push-down">
+                            <p className="push-down-7">
                               If enabled, the environment will request GPU
                               capabilities when in use.
                             </p>
@@ -456,7 +456,7 @@ class EnvironmentEditView extends React.Component {
                           if (orchest.config["GPU_ENABLED_INSTANCE"] !== true) {
                             if (orchest.config["CLOUD"] === true) {
                               return (
-                                <div className="docs-notice push-down">
+                                <div className="docs-notice push-down-7">
                                   <p>
                                     This instance is not configured with a GPU.
                                     To request a GPU instance please fill out
@@ -473,7 +473,7 @@ class EnvironmentEditView extends React.Component {
                               );
                             } else {
                               return (
-                                <div className="docs-notice push-down">
+                                <div className="docs-notice push-down-7">
                                   {enabledBlock}
                                   <p>
                                     Check out{" "}
@@ -497,7 +497,7 @@ class EnvironmentEditView extends React.Component {
                             }
                           } else {
                             return (
-                              <div className="docs-notice push-down">
+                              <div className="docs-notice push-down-7">
                                 {enabledBlock}
                               </div>
                             );
@@ -512,11 +512,11 @@ class EnvironmentEditView extends React.Component {
                 subview = (
                   <>
                     <h3>Environment set-up script</h3>
-                    <div className="form-helper-text push-down">
+                    <div className="form-helper-text push-down-7">
                       This will execute when you build the environment. Use it
                       to include your dependencies.
                     </div>
-                    <div className="push-down">
+                    <div className="push-down-7">
                       <CodeMirror
                         value={this.state.environment.setup_script}
                         options={{
@@ -570,7 +570,7 @@ class EnvironmentEditView extends React.Component {
                   }
                 })()}
 
-                <div className="push-down">
+                <div className="push-down-7">
                   <MDCButtonReact
                     label="Back to environments"
                     icon="arrow_back"
@@ -578,7 +578,7 @@ class EnvironmentEditView extends React.Component {
                   />
                 </div>
 
-                <div className="push-down">
+                <div className="push-down-7">
                   <MDCTabBarReact
                     ref={this.refManager.nrefs.tabBar}
                     selectedIndex={this.state.subviewIndex}


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

- Slightly increases spacing between form fields (I tried making it larger but it was just too much)
- Uses Stitches-driven vars to help migrate styles slowly over to Stitches (and at least align our use-case styles in the meantime)

It's important to know that this is really just something to improve short-term, long-term as we migrate to Stitches we can look into improving our overall forms design and structure

|Before|After|
|--|--|
| <img width="1259" alt="Screenshot 2021-05-21 at 14 05 35" src="https://user-images.githubusercontent.com/7349341/119127970-b527fc00-ba3d-11eb-938c-a62c43c97ac1.png"> | <img width="1259" alt="Screenshot 2021-05-21 at 14 03 05" src="https://user-images.githubusercontent.com/7349341/119127961-b22d0b80-ba3d-11eb-903c-076188e56d01.png"> | 

| Diff |
| --|
| ![image](https://user-images.githubusercontent.com/7349341/119128197-02a46900-ba3e-11eb-8a40-7229fee8d421.png) |


<!-- Fixes: #issue -->

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
