### PR TITLE
Fix "Double Click" Behaviour

### DIFF
--- a/services/orchest-webserver/client/src/views/PipelineView.jsx
+++ b/services/orchest-webserver/client/src/views/PipelineView.jsx
@@ -1387,7 +1387,11 @@ class PipelineView extends React.Component {
   }
 
   onDoubleClickStepHandler(stepUUID) {
-    this.openNotebook(stepUUID);
+    if (this.props.queryArgs.read_only === "true") {
+      this.onOpenFilePreviewView(stepUUID);
+    } else {
+      this.openNotebook(stepUUID);
+    }
   }
 
   stepNameUpdate(pipelineStepUUID, title, file_path) {


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

When in "read only" mode, double-clicking on a pipeline step will now trigger the "view file" action rather than erroneously trying to open Jupyter.

<!-- Fixes: #issue -->

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
