### PR TITLE
Revert JupyterLab 3.1 due to stability issues.

### DIFF
--- a/services/jupyter-server/requirements.txt
+++ b/services/jupyter-server/requirements.txt
@@ -1,1 +1,1 @@
-jupyterlab==3.1.0a9
+jupyterlab==3.0.16

--- a/services/jupyter-server/start.sh
+++ b/services/jupyter-server/start.sh
@@ -53,7 +53,7 @@ start_jupyterlab(){
     release_lock
     # Don't release the lock again on exit.
     trap - EXIT
-    jupyter lab --LabApp.app_dir="$userdir_path" "$@" --collaborative
+    jupyter lab --LabApp.app_dir="$userdir_path" "$@"
 }
 
 acquire_lock


### PR DESCRIPTION
For the time being we're reverting back to JupyterLab 3.0.X as the 3.1 version has too many stability issues at the moment.