### PR TITLE
Change working directory to be relative to the file being executed

### DIFF
--- a/services/base-images/runnable-shared/runner/run.py
+++ b/services/base-images/runnable-shared/runner/run.py
@@ -35,7 +35,7 @@ def main():
     working_dir = os.path.join(Config.PROJECT_DIR, sys.argv[1])
 
     # sys.argv[2] contains the relative file path
-    # (relative to the pipeline file)
+    # (relative to the project directory)
     filename = sys.argv[2]
     file_extension = get_filename_extension(filename)
     file_path = os.path.join(Config.PROJECT_DIR, filename)

--- a/services/base-images/runnable-shared/runner/run.py
+++ b/services/base-images/runnable-shared/runner/run.py
@@ -1,8 +1,5 @@
 import os
-import subprocess
 import sys
-
-import nbformat
 
 from runner.config import Config
 from runner.runners import NotebookRunner, ProcessRunner
@@ -26,19 +23,22 @@ def main():
     # index 1 contains filename
     if len(sys.argv) < 3:
         raise Exception(
-            "Should pass in the working directory (relative to the project dir) and filename (relative to the working directory) that you want to execute."
+            "Should pass in the working directory (relative to the project dir) and "
+            "filename (relative to the working directory) that you want to execute."
         )
 
     step_uuid = os.environ.get("ORCHEST_STEP_UUID")
     pipeline_uuid = os.environ.get("ORCHEST_PIPELINE_UUID")
 
-    # sys.argv[1] contains the working directory relative to the project dir
+    # sys.argv[1] contains the working directory relative to
+    # the project dir
     working_dir = os.path.join(Config.PROJECT_DIR, sys.argv[1])
 
-    # sys.argv[2] contains the relative file path (relative to the pipeline file)
+    # sys.argv[2] contains the relative file path
+    # (relative to the pipeline file)
     filename = sys.argv[2]
     file_extension = get_filename_extension(filename)
-    file_path = os.path.join(Config.PROJECT_DIR, working_dir, filename)
+    file_path = os.path.join(Config.PROJECT_DIR, filename)
 
     # check if file exists in working directory
     if not os.path.isfile(file_path):
@@ -60,7 +60,7 @@ def main():
         }
 
         pr = ProcessRunner(pipeline_uuid, step_uuid, working_dir)
-        sys.exit(pr.run(extension_script_mapping[file_extension], filename))
+        sys.exit(pr.run(extension_script_mapping[file_extension], file_path))
 
     else:
         raise Exception(

--- a/services/base-images/runnable-shared/runner/run.py
+++ b/services/base-images/runnable-shared/runner/run.py
@@ -24,7 +24,7 @@ def main():
     if len(sys.argv) < 3:
         raise Exception(
             "Should pass in the working directory (relative to the project dir) and "
-            "filename (relative to the working directory) that you want to execute."
+            "filename (relative to the project dir) that you want to execute."
         )
 
     step_uuid = os.environ.get("ORCHEST_STEP_UUID")

--- a/services/base-images/runnable-shared/runner/runner/runners.py
+++ b/services/base-images/runnable-shared/runner/runner/runners.py
@@ -32,7 +32,10 @@ class Runner:
             with open(log_file_path, "w") as file:
                 file.write("%s\n" % str(uuid.uuid4()))
         except IOError as e:
-            raise Exception("Could not write to log file %s" % log_file_path)
+            raise Exception(
+                "Could not write to log file %s. Error: %s [%s]"
+                % (log_file_path, e, type(e))
+            )
 
     def clear_pipeline_step_log(self):
 
@@ -67,7 +70,7 @@ class Runner:
 
 
 class ProcessRunner(Runner):
-    def run(self, command, filename):
+    def run(self, command, file_path):
 
         super().run()
 
@@ -75,7 +78,7 @@ class ProcessRunner(Runner):
 
         with open(log_file_path, "a") as f:
             process = subprocess.Popen(
-                [command, filename], cwd=self.working_dir, stdout=f, stderr=f
+                [command, file_path], cwd=self.working_dir, stdout=f, stderr=f
             )
             process.wait()
 

--- a/services/orchest-api/app/app/core/pipelines.py
+++ b/services/orchest-api/app/app/core/pipelines.py
@@ -239,11 +239,13 @@ class PipelineStepRunner:
             form="docker-engine",
         )
 
-        # The working directory relative to the project directory is
-        # based on the location of the pipeline, e.g. if the pipeline is
-        # in /project-dir/my/project/path/mypipeline.orchest the working
-        # directory will be my/project/path/.
-        working_dir = os.path.split(run_config["pipeline_path"])[0]
+        # The working directory is the location of the file being
+        # executed.
+        project_relative_file_path = os.path.join(
+            os.path.split(run_config["pipeline_path"])[0], self.properties["file_path"]
+        )
+
+        working_dir = os.path.split(project_relative_file_path)[0]
 
         user_env_variables = [
             f"{key}={value}" for key, value in run_config["user_env_variables"].items()
@@ -284,7 +286,7 @@ class PipelineStepRunner:
                 "/orchest/bootscript.sh",
                 "runnable",
                 working_dir,
-                self.properties["file_path"],
+                project_relative_file_path,
             ],
             "NetworkingConfig": {"EndpointsConfig": {_config.DOCKER_NETWORK: {}}},
             # NOTE: the `'tests-uuid'` key is only used for tests and


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

This changes the behavior of the default working directory to be more consistent throughout Orchest.

The change is: originally the working directory would always be the pipeline file directory. Now it's the directory in which the file lives that's being executed.

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

