### PR TITLE
Include JS files in type checks

### DIFF
--- a/services/auth-server/client/tsconfig.json
+++ b/services/auth-server/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "exclude": ["node_modules"],
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "compilerOptions": {
     "types": ["vite/client"]
   }

--- a/services/orchest-webserver/client/tsconfig.json
+++ b/services/orchest-webserver/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "exclude": ["node_modules"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "compilerOptions": {
     "types": ["vite/client", "node"],
     "baseUrl": ".",


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

As of now, our `lint` step hasn't actually been catching type errors via `// @ts-check` 🥴

### Checklist

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
