### PR TITLE
Add watch scripts to lib packages

### DIFF
--- a/lib/javascript/mdc/package.json
+++ b/lib/javascript/mdc/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently -n w: npm:*:watch",
     "lint": "concurrently -n w: npm:*:check",
     "es:build": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:@orchest/lib-utils --external:react* --external:@material/* --define:process.env.NODE_ENV=\\\"production\\\"",
-    "es:watch": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:@orchest/lib-utils --external:react* --external:@material/* --define:process.env.NODE_ENV=\\\"development\\\" --sourcemap",
+    "es:watch": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:@orchest/lib-utils --external:react* --external:@material/* --define:process.env.NODE_ENV=\\\"development\\\" --watch --log-level=error --sourcemap",
     "ts:build": "tsc --emitDeclarationOnly --outDir dist",
     "ts:watch": "tsc --emitDeclarationOnly --outDir dist -w",
     "ts:check": "tsc --noEmit"

--- a/lib/javascript/utils/package.json
+++ b/lib/javascript/utils/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently -n w: npm:*:watch",
     "lint": "concurrently -n w: npm:*:check",
     "es:build": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:react* --define:process.env.NODE_ENV=\\\"production\\\"",
-    "es:watch": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:react* --define:process.env.NODE_ENV=\\\"development\\\" --sourcemap",
+    "es:watch": "esbuild src/index.ts --bundle --outdir=dist --format=esm --loader:.js=jsx --external:react* --define:process.env.NODE_ENV=\\\"development\\\" --sourcemap --watch --log-level=error",
     "ts:build": "tsc --emitDeclarationOnly --outDir dist",
     "ts:watch": "tsc --emitDeclarationOnly --outDir dist -w",
     "ts:check": "tsc --noEmit"


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

Adds `esbuild --watch` flags to `lib` packages to enable hot-reloading

(in the same manner that [`design-system` watches](https://github.com/orchest/orchest/blob/master/lib/design-system/package/package.json#L21) for changes)

<!-- Fixes: #issue -->

### Checklist

<!--
Feel free to add additional items to the checklist :)
You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR.
-->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
