### PR TITLE
Fixes #279

### DIFF
--- a/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
+++ b/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
@@ -148,8 +148,17 @@ class EnvironmentEditView extends React.Component {
   }
 
   onSave(e) {
-    e.preventDefault();
-    this.save();
+    // Negative lookbehind. Check that every " is escaped with \
+    const regex = new RegExp(/(?<!\\)"/);
+    if (regex.test(this.state.environment.name)) {
+      orchest.alert(
+        "Error",
+        'Double quotation marks in the "Environment name" have to be escaped using a backslash.'
+      );
+    } else {
+      e.preventDefault();
+      this.save();
+    }
   }
 
   returnToEnvironments() {


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

 Fixes: #279 

### Reasoning

By default JupyterLab and the Enterprise Gateway allow all kernel names. The problem was that double quotation marks `"` need to be escaped, e.g. `\"`. Otherwise the `kernel.json` would be invalid as the value could look like `"value"more"`, which is invalid JSON.