### PR TITLE
Fix selection behavior in pipeline editor

### DIFF
--- a/services/orchest-webserver/client/src/views/PipelineView.jsx
+++ b/services/orchest-webserver/client/src/views/PipelineView.jsx
@@ -971,12 +971,12 @@ class PipelineView extends React.Component {
         let step = this.state.steps[this.selectedItem];
 
         if (!step.meta_data._dragged) {
+          if (this.selectedConnection) {
+            this.deselectConnection();
+          }
+
           if (!e.ctrlKey) {
             stepClicked = true;
-
-            if (this.selectedConnection) {
-              this.deselectConnection();
-            }
 
             if (this.doubleClickFirstClick) {
               this.refManager.refs[this.selectedItem].props.onDoubleClick(
@@ -1025,6 +1025,10 @@ class PipelineView extends React.Component {
 
       // check if step needs to be selected based on selectedSteps
       if (this.state.stepSelector.active || this.selectedItem !== undefined) {
+        if (this.selectedConnection) {
+          this.deselectConnection();
+        }
+
         if (
           this.state.selectedSteps.length == 1 &&
           !stepClicked &&
@@ -1104,9 +1108,7 @@ class PipelineView extends React.Component {
             _this.selectedConnection.deselectState();
           }
 
-          if (!e.ctrlKey) {
-            _this.deselectSteps();
-          }
+          _this.deselectSteps();
 
           let connection = $(this).parents("svg").parents(".connection");
           let startNodeUUID = connection.attr("data-start-uuid");

--- a/services/orchest-webserver/client/src/views/PipelineView.jsx
+++ b/services/orchest-webserver/client/src/views/PipelineView.jsx
@@ -974,6 +974,10 @@ class PipelineView extends React.Component {
           if (!e.ctrlKey) {
             stepClicked = true;
 
+            if (this.selectedConnection) {
+              this.deselectConnection();
+            }
+
             if (this.doubleClickFirstClick) {
               this.refManager.refs[this.selectedItem].props.onDoubleClick(
                 this.selectedItem
@@ -1098,6 +1102,10 @@ class PipelineView extends React.Component {
         if (e.button === 0 && !_this.keysDown[32]) {
           if (_this.selectedConnection) {
             _this.selectedConnection.deselectState();
+          }
+
+          if (!e.ctrlKey) {
+            _this.deselectSteps();
           }
 
           let connection = $(this).parents("svg").parents(".connection");


### PR DESCRIPTION
## Description
Fix selection behavior in pipeline editor.

More precisely, connections should behave similar to steps:
* Whenever selected, deselect other connections and steps.
* Whenever something else is selected, deselect itself.

## Old behavior
* Selecting a connection would not deselect an already select step.
* Selecting a step would not deselect a selected connection.

For example (without using the Ctrl + click feature):
![image](https://user-images.githubusercontent.com/26223174/120512318-89a4fa00-c3cb-11eb-8300-430b4f051cc8.png)
