### PR TITLE
Add warning when snapshot size exceeds 50MB

### DIFF
--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -7,7 +7,6 @@ import aiohttp
 from celery import Task
 from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 from celery.utils.log import get_task_logger
-from config import CONFIG_CLASS
 
 from app import create_app
 from app.celery_app import make_celery
@@ -16,6 +15,7 @@ from app.core.environment_builds import build_environment_task
 from app.core.jupyter_builds import build_jupyter_task
 from app.core.pipelines import Pipeline, PipelineDefinition
 from app.core.sessions import launch_noninteractive_session
+from config import CONFIG_CLASS
 
 logger = get_task_logger(__name__)
 
@@ -221,7 +221,6 @@ def start_non_interactive_pipeline_run(
     snapshot_dir = os.path.join(job_dir, "snapshot")
     run_dir = os.path.join(job_dir, self.request.id)
 
-    # TODO: It should not copy all directories, e.g. not "data".
     # Copy the contents of `snapshot_dir` to the new (not yet existing
     # folder) `run_dir` (that will then be created by `copytree`).
     # copytree(snapshot_dir, run_dir)

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -93,6 +93,29 @@ def get_project_directory(project_uuid, host_path=False):
     return os.path.join(USER_DIR, "projects", project_uuid_to_path(project_uuid))
 
 
+def get_project_snapshot_size(project_uuid, host_path=False):
+    """Returns the snapshot size for a project in MB."""
+
+    def get_size(path, skip_dir):
+        size = 0
+        for root, dirs, files in os.walk(path):
+            size += sum(os.path.getsize(os.path.join(root, name)) for name in files)
+            if skip_dir in dirs:
+                dirs.remove(skip_dir)
+
+        return size
+
+    project_dir = get_project_directory(project_uuid, host_path=host_path)
+
+    # TODO: This directory is not yet excluded when creating snapshots.
+    # This does not count towards size for snapshots.
+    # skip_dir = ".orchest"
+    skip_dir = None
+
+    # Convert bytes to megabytes.
+    return get_size(project_dir, skip_dir) / (1024 ** 2)
+
+
 def project_exists(project_uuid):
     return Project.query.filter(
         Project.uuid == project_uuid

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -96,24 +96,24 @@ def get_project_directory(project_uuid, host_path=False):
 def get_project_snapshot_size(project_uuid, host_path=False):
     """Returns the snapshot size for a project in MB."""
 
-    def get_size(path, skip_dir):
+    def get_size(path, skip_dirs):
         size = 0
         for root, dirs, files in os.walk(path):
             size += sum(os.path.getsize(os.path.join(root, name)) for name in files)
-            if skip_dir in dirs:
-                dirs.remove(skip_dir)
+
+            for skip_dir in skip_dirs:
+                if skip_dir in dirs:
+                    dirs.remove(skip_dir)
 
         return size
 
     project_dir = get_project_directory(project_uuid, host_path=host_path)
 
-    # TODO: This directory is not yet excluded when creating snapshots.
     # This does not count towards size for snapshots.
-    # skip_dir = ".orchest"
-    skip_dir = None
+    skip_dirs = [".orchest", ".git"]
 
     # Convert bytes to megabytes.
-    return get_size(project_dir, skip_dir) / (1024 ** 2)
+    return get_size(project_dir, skip_dirs) / (1024 ** 2)
 
 
 def project_exists(project_uuid):

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -110,7 +110,11 @@ def get_project_snapshot_size(project_uuid, host_path=False):
     project_dir = get_project_directory(project_uuid, host_path=host_path)
 
     # This does not count towards size for snapshots.
-    skip_dirs = [".orchest", ".git"]
+    # NOTE: For optimization purposes we might have to also ignore the
+    # `.git` directories. Although for large `.git` directories the
+    # approximation would be significantly different from the exact
+    # value.
+    skip_dirs = [".orchest"]
 
     # Convert bytes to megabytes.
     return get_size(project_dir, skip_dirs) / (1024 ** 2)

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -36,6 +36,7 @@ from app.utils import (
     get_pipeline_json,
     get_pipeline_path,
     get_project_directory,
+    get_project_snapshot_size,
     get_repo_tag,
     get_session_counts,
     get_user_conf,
@@ -407,7 +408,12 @@ def register_views(app, db):
         else:
             # Merge the project data coming from the orchest-api.
             counts = project_entity_counts(project_uuid, get_job_count=True)
-            project = {**project.as_dict(), **resp.json(), **counts}
+            project = {
+                **project.as_dict(),
+                **resp.json(),
+                **counts,
+                "project_snapshot_size": get_project_snapshot_size(project_uuid),
+            }
 
             return jsonify(project)
 

--- a/services/orchest-webserver/client/src/components/JobList.jsx
+++ b/services/orchest-webserver/client/src/components/JobList.jsx
@@ -323,7 +323,8 @@ class JobList extends React.Component {
                                   return (
                                     <div className="warning push-down">
                                       <i className="material-icons">warning</i>{" "}
-                                      Snapshot size exceeds 50MB. Refer to the{" "}
+                                      Snapshot size exceeds 50MB. Please refer
+                                      to the{" "}
                                       <a href="https://orchest.readthedocs.io/en/latest/user_guide/jobs.html">
                                         docs
                                       </a>

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -911,6 +911,10 @@ span.floating-button {
     margin-right: 10px;
     margin-top: -4px;
   }
+
+  a {
+    color: inherit;
+  }
 }
 
 .parameter-tree {
@@ -1557,6 +1561,7 @@ table {
 
   .mdc-dialog__content {
     overflow: visible;
+    line-height: inherit;
   }
 
   .mdc-select__menu {


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

Closes: #247

### Implementation details

The warning is added to the modal when creating a job (but only visible if the snapshot size would exceed the 50MB threshold):
![image](https://user-images.githubusercontent.com/26223174/120767881-ec0d1000-c51b-11eb-840b-2496c21ee174.png)

Note: This is the same style of warning when creating an invalid cron string.

### Todo

- [x] Fixing the styling
  - [x] The icon is misaligned (due to [this code](https://github.com/orchest/orchest/blob/master/services/orchest-webserver/client/src/styles/main.scss#L912) which is done to fix the alignment for the cron string warning.
  - [x] The hyperlink to the docs should probably be prettier.

