### PR TITLE
Produce JSONDecodeError to remove default kernel

### DIFF
--- a/services/jupyter-enterprise-gateway/kernel-override/kernel.json
+++ b/services/jupyter-enterprise-gateway/kernel-override/kernel.json
@@ -1,15 +1,1 @@
-{
-    "argv": [
-        "/opt/conda/bin/python",
-        "-m",
-        "ipykernel_launcher",
-        "-f",
-        "{connection_file}"
-    ],
-    "display_name": "Disabled",
-    "language": "python",
-    "resources": {
-        "logo-32x32": "logo-32x32.png",
-        "logo-64x64": "logo-64x64.png"
-    }
-}
+SOME INVALID JSON SO THE KERNEL DOES NOT SHOW UP IN JUPYTERLAB


### PR DESCRIPTION
<!--
Thank you for your contribution, you rock! 💪
-->

## Description

Closes: #204 

## Implementation details

As stated in the issue, the default kernel seems to be baked into certain Jupyter parts. Without digging into this I realized there is another solution: overwriting the `kernel.json` with invalid JSON. This will throw the following error (in the EG) every time the kernels are loaded:
```text
[W 2021-06-03 12:25:22.558 EnterpriseGatewayApp] Error loading kernelspec 'python3'
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.7/site-packages/jupyter_client/kernelspec.py", line 257, in get_all_specs
        spec = self._get_kernel_spec_by_name(kname, resource_dir)
      File "/opt/conda/lib/python3.7/site-packages/jupyter_client/kernelspec.py", line 200, in _get_kernel_spec_by_name
        return self.kernel_spec_class.from_resource_dir(resource_dir)
      File "/opt/conda/lib/python3.7/site-packages/jupyter_client/kernelspec.py", line 46, in from_resource_dir
        kernel_dict = json.load(f)
      File "/opt/conda/lib/python3.7/json/__init__.py", line 296, in load
        parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
      File "/opt/conda/lib/python3.7/json/__init__.py", line 348, in loads
        return _default_decoder.decode(s)
      File "/opt/conda/lib/python3.7/json/decoder.py", line 337, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/opt/conda/lib/python3.7/json/decoder.py", line 355, in raw_decode
        raise JSONDecodeError("Expecting value", s, err.value) from None
    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
[I 210603 12:25:22 web:2250] 200 GET /api/kernelspecs (172.18.0.12) 1.51ms
```
The EG continues to work without any problems.

## Screenshot (to show that it works)
![image](https://user-images.githubusercontent.com/26223174/120646011-5f117a80-c479-11eb-892a-74ad13991f19.png)
