### PR TITLE
Do not use sudo if it's not necessary

### DIFF
--- a/docs/source/user_guide/environments.rst
+++ b/docs/source/user_guide/environments.rst
@@ -34,6 +34,7 @@ Build an environment
 2. Create a new *Environment*. *Environments* are part of a single project.
 3. Choose an *Environment name*.
 4. Choose a base image. This image will be extended through your setup bash script.
+   Custom images must have USER `root` or ``sudo`` must be installed, ``find`` must also be installed.
 5. To keep environment image sizes to a minimal, each environment is tied to a specific programming
    language. Choose one of the supported languages for your environment.
 6. Go to the *BUILD* tab to install additional packages by adding their installation steps to the *Environment set-up

--- a/services/orchest-api/app/app/core/docker_utils.py
+++ b/services/orchest-api/app/app/core/docker_utils.py
@@ -77,7 +77,7 @@ def build_docker_image(
                 # out of the while loop because the build needs to keep
                 # going, both for error reporting and for actually
                 # allowing the build to keep going, which would not
-                # happen if we process exits.
+                # happen if the process exits.
                 if "stream" in json_output:
                     stream = json_output["stream"]
 


### PR DESCRIPTION
## Description
This PR makes it so that building an environment with a custom base image uses `sudo` only if necessary, moreover, a help message is injected into the log stream if `find` is not installed in the base image, or if the base image does not have USER root while also not having `sudo` installed.

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

