### PR TITLE
Use a different logger when running as celery

### DIFF
--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -237,6 +237,7 @@ class Session:
 
 
         """
+        logger = utils.get_logger()
 
         # TODO: make convert this "pipeline" uuid into a "session" uuid.
         orchest_services = _get_orchest_services_specs(
@@ -251,9 +252,7 @@ class Session:
                 container = self.client.containers.run(**orchest_services[resource])
                 self._containers[resource] = container
             except Exception as e:
-                current_app.logger.error(
-                    "Failed to start container %s [%s]." % (e, type(e))
-                )
+                logger.error("Failed to start container %s [%s]." % (e, type(e)))
                 raise errors.SessionContainerError(
                     "Could not start required containers."
                 )
@@ -292,16 +291,14 @@ class Session:
                 container = self.client.containers.run(**service_spec)
                 self._containers[service_name] = container
             except Exception as e:
-                current_app.logger.error(
+                logger.error(
                     "Failed to start user service container %s [%s]." % (e, type(e))
                 )
                 try:
                     container = self.client.containers.get(service_spec["name"])
                     container.remove(force=True)
                 except NotFound:
-                    current_app.logger.warning(
-                        "Did not find dangling user service container."
-                    )
+                    logger.warning("Did not find dangling user service container.")
 
                 # Necessary because the docker container won't emit any
                 # logs for SDK level errors.
@@ -325,6 +322,7 @@ class Session:
             successful.
 
         """
+        logger = utils.get_logger()
 
         session_identity_uuid = None
         project_uuid = None
@@ -353,7 +351,7 @@ class Session:
                 APIError,
                 ContainerError,
             ) as e:
-                current_app.logger.error(
+                logger.error(
                     "Failed to kill/remove session container %s [%s]" % (e, type(e))
                 )
 
@@ -789,7 +787,7 @@ def _get_user_services_specs(
                 )
         except Exception as e:
 
-            current_app.logger.error(
+            utils.get_logger().error(
                 "Failed to fetch user_env_variables: %s [%s]" % (e, type(e))
             )
 

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -1,8 +1,10 @@
+import logging
 import time
 from datetime import datetime
 from typing import Dict, List, Set
 
 import requests
+from celery.utils.log import get_task_logger
 from docker import errors
 from flask import current_app
 from flask_restx import Model, Namespace
@@ -545,3 +547,11 @@ def get_proj_pip_env_variables(project_uuid: str, pipeline_uuid: str) -> Dict[st
         .env_variables
     )
     return {**project_env_vars, **pipeline_env_vars}
+
+
+def get_logger() -> logging.Logger:
+    try:
+        return current_app.logger
+    except Exception:
+        pass
+    return get_task_logger(__name__)


### PR DESCRIPTION
## Description
Fixes an issue where code shared by the `orchest-api` and `celery-worker` would fail because it contained a resource that was not available to the `celery-worker`, the app logger.

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
