### PR TITLE
Use subprocess for non blocking FS copy and removal in webserver

### DIFF
--- a/services/orchest-webserver/app/app/core/projects.py
+++ b/services/orchest-webserver/app/app/core/projects.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 import uuid
 from typing import Optional
@@ -18,6 +17,7 @@ from app.utils import (
     populate_default_environments,
     project_uuid_to_path,
     remove_project_jobs_directories,
+    rmtree,
 )
 from app.views.orchest_api import api_proxy_environment_builds
 
@@ -153,18 +153,11 @@ class DeleteProject(TwoPhaseFunction):
         """Remove a project from the fs and the orchest-api"""
 
         # Delete the project directory.
-        try:
-            project_path = project_uuid_to_path(project_uuid)
-            full_project_path = os.path.join(
-                current_app.config["PROJECTS_DIR"], project_path
-            )
-            shutil.rmtree(full_project_path)
-        except FileNotFoundError:
-            # If the `full_project_path` is not found, it means that the
-            # user has already performed the deletion operation. So we
-            # need to catch and then ignore this error, otherwise the DB
-            # deletion operation will not continue.
-            pass
+        project_path = project_uuid_to_path(project_uuid)
+        full_project_path = os.path.join(
+            current_app.config["PROJECTS_DIR"], project_path
+        )
+        rmtree(full_project_path)
 
         # Remove jobs directories related to project.
         remove_project_jobs_directories(project_uuid)


### PR DESCRIPTION
## Description

This PR alters the way the `orchest-webserver` is doing most of its file system operations by replacing calls to `shutil` with `subprocess`. The reason is that `shutil`  (and os.system) is not monkey patched by eventlet while subprocess is. This makes it so that the webserver won't be blocked while, for example, taking a snapshot of a project for a job.


Fixes #304 

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

