### PR TITLE
Inherited env vars have priority over service defined ones

### DIFF
--- a/docs/source/user_guide/services.rst
+++ b/docs/source/user_guide/services.rst
@@ -106,13 +106,13 @@ Non required fields:
 - **command**: Service start command, e.g. what process the service will run.
 - **entrypoint**: `command` and `entrypoint` are a 1:1 mapping to Docker, refer to the `Docker docs
   <https://docs.docker.com/engine/reference/builder/#cmd>`_ for their difference and gotchas.
+- **environment variables**: Key-value pairs of environment variables. While project and
+  pipeline environment variables are considered as `secrets`, services environment variables
+  aren't and will be persisted in the pipeline definition file.
 - **inherited environment variables**: A list of environment variable names that will be inherited
   from the project and pipeline environment variables, and from job environment variables when run
-  in a job.
-- **environment variables**: Key-value pairs of environment variables, which take priority over the
-  inherited environment variables. Note that, while project and pipeline environment variables are
-  considered as `secrets`, services environment variables aren't and will be persisted in the
-  pipeline definition file.
+  in a job. These variables take priority over the service environment variables in case of name
+  collisions.
 - **scope**: Specifies whether the service should be running in interactive mode, jobs, or both.
 - **project directory mount**: To bind a service file system path to the directory of the project.
   This will allow the service to read or write to the project directory. See the VS-Code template

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -795,14 +795,12 @@ def _get_user_services_specs(
 
             user_env_variables = {}
 
-        environment = {}
+        environment = service.get("env_variables", {})
 
+        # Inherited env vars supersede inherited ones.
         for inherited_key in service.get("env_variables_inherit", []):
             if inherited_key in user_env_variables:
                 environment[inherited_key] = user_env_variables[inherited_key]
-
-        # User defined env vars superse inherited ones.
-        environment.update(service.get("env_variables", {}))
 
         # These are all required for the Orchest SDK to work.
         environment["ORCHEST_PROJECT_UUID"] = project_uuid

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -87,16 +87,14 @@ service = Model(
         ),
         "env_variables": fields.Raw(
             required=False,
-            description=(
-                "Environment variables of the service, supersedes environment "
-                "inherited variables"
-            ),
+            description=("Environment variables of the service."),
         ),
         "env_variables_inherit": fields.List(
             fields.String,
             required=False,
             description=(
-                "List of env vars to inherit from project and pipeline env vars"
+                "List of env vars to inherit from project and pipeline env vars "
+                " or job env vars. These env vars supersede the service defined ones."
             ),
         ),
         "binds": fields.Raw(


### PR DESCRIPTION
Service inherited environment variables take priority over "in place" defined ones.

 - [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
