### PR TITLE
Fix orchest update mechanism

### DIFF
--- a/services/orchest-ctl/app/scripts/git-update.sh
+++ b/services/orchest-ctl/app/scripts/git-update.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-[ $(git branch --show-current) != "master" ] && exit 21
+[ "$(git branch --show-current)" != "master" ] && exit 21
 
 # Get the user and group of the "orchest" shell script as this is most
 # likely also the user that should own the files in the repository.
-FILE_USER=$(ls -n /orchest-host/orchest | awk '{print $3}')
-FILE_GROUP=$(ls -n /orchest-host/orchest | awk '{print $4}')
+FILE_USER="$(ls -n /orchest-host/orchest | awk '{print $3}')"
+FILE_GROUP="$(ls -n /orchest-host/orchest | awk '{print $4}')"
 
 # Explicitely use HTTPS so that we do not get the error:
 # "error: cannot run ssh: No such file or directory"
@@ -17,4 +17,4 @@ git fetch https://github.com/orchest/orchest.git --tags
 
 # Change the user and group of all the files in the repository, except
 # for the userdir.
-chown -R $FILE_USER:$FILE_GROUP $(ls -I userdir /orchest-host)
+chown -R "$FILE_USER":"$FILE_GROUP" "$(ls -I userdir /orchest-host)"

--- a/services/orchest-ctl/app/scripts/git-update.sh
+++ b/services/orchest-ctl/app/scripts/git-update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-[ "$(git branch --show-current)" != "master" ] && exit 21
+[ "$(git rev-parse --abbrev-ref HEAD)" != "master" ] && exit 21
 
 # Get the user and group of the "orchest" shell script as this is most
 # likely also the user that should own the files in the repository.


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Fixes the `git-update.sh` script by not using `--show-current` as it is a new feature of git, which is not run in the `orchest-ctl` that executes the `git` command. (For reference the `orchest-ctl` runs `git version 2.20.1` whilst for `--show-current` version `2.22.0` is required.)
