### PR TITLE
Move unsavedChanges/setUnsavedChanges to useOrchest

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -38,7 +38,7 @@ const App = () => {
     dynamicProps: null,
     TagName: null,
   });
-  const [unsavedChangesState, setUnsavedChangesState] = React.useState(null);
+
   const context = useOrchest();
 
   const jupyterRef = useRef(null);
@@ -89,14 +89,14 @@ const App = () => {
         );
       };
 
-      if (!unsavedChangesState) {
+      if (!context.state.unsavedChanges) {
         conditionalBody();
       } else {
         confirm(
           "Warning",
           "There are unsaved changes. Are you sure you want to navigate away?",
           () => {
-            setUnsavedChanges(false);
+            context.dispatch({ type: "setUnsavedChanges", payload: false });
             conditionalBody();
           }
         );
@@ -138,20 +138,6 @@ const App = () => {
     );
   };
 
-  const setUnsavedChanges = (unsavedChanges) => {
-    if (unsavedChanges) {
-      // Enable navigation prompt
-      window.onbeforeunload = function () {
-        return true;
-      };
-    } else {
-      // Remove navigation prompt
-      window.onbeforeunload = null;
-    }
-
-    setUnsavedChangesState(unsavedChanges);
-  };
-
   const loadView = (TagName, dynamicProps?, onCancelled?) => {
     // dynamicProps default
     if (!dynamicProps) {
@@ -184,14 +170,14 @@ const App = () => {
       _loadView(TagName, dynamicProps);
     };
 
-    if (!unsavedChangesState) {
+    if (!context.state.unsavedChanges) {
       conditionalBody();
     } else {
       confirm(
         "Warning",
         "There are unsaved changes. Are you sure you want to navigate away?",
         () => {
-          setUnsavedChanges(false);
+          context.dispatch({ type: "setUnsavedChanges", payload: false });
           conditionalBody();
         },
         onCancelled
@@ -286,14 +272,12 @@ const App = () => {
 
   React.useEffect(() => {
     setJupyter(new Jupyter(jupyterRef.current));
-    setUnsavedChanges(false);
     initializeFirstView();
     loadDefaultView();
   }, []);
 
   window.orchest = {
     config,
-    setUnsavedChanges,
     loadView,
     alert,
     confirm,

--- a/services/orchest-webserver/client/src/hooks/orchest/provider.jsx
+++ b/services/orchest-webserver/client/src/hooks/orchest/provider.jsx
@@ -56,6 +56,8 @@ const reducer = (state, action) => {
       return { ...state, sessionsKillAllInProgress: true };
     case "_sessionsKillAllClear":
       return { ...state, sessionsKillAllInProgress: false };
+    case "setUnsavedChanges":
+      return { ...state, unsavedChanges: action.payload };
     case "setView":
       return { ...state, view: action.payload };
     case "clearView":
@@ -77,6 +79,7 @@ const initialState = {
   sessions: [],
   sessionsIsLoading: true,
   sessionsKillAllInProgress: false,
+  unsavedChanges: false,
   view: "pipeline",
   _sessionsToFetch: [],
   _sessionsToggle: null,
@@ -141,6 +144,17 @@ export const OrchestProvider = ({ config, user_config, children }) => {
       orchest.alert(...state.alert);
     }
   }, [state.alert]);
+
+  /**
+   * Handle Unsaved Changes prompt
+   */
+  // React.useEffect(() => {
+  //   window.onbeforeunload = state.unsavedChanges
+  //     ? function () {
+  //         return true;
+  //       }
+  //     : null;
+  // }, [state.unsavedChanges]);
 
   if (process.env.NODE_ENV === "development")
     console.log("(Dev Mode) useOrchest: state updated", state);

--- a/services/orchest-webserver/client/src/hooks/orchest/provider.jsx
+++ b/services/orchest-webserver/client/src/hooks/orchest/provider.jsx
@@ -148,13 +148,13 @@ export const OrchestProvider = ({ config, user_config, children }) => {
   /**
    * Handle Unsaved Changes prompt
    */
-  // React.useEffect(() => {
-  //   window.onbeforeunload = state.unsavedChanges
-  //     ? function () {
-  //         return true;
-  //       }
-  //     : null;
-  // }, [state.unsavedChanges]);
+  React.useEffect(() => {
+    window.onbeforeunload = state.unsavedChanges
+      ? function () {
+          return true;
+        }
+      : null;
+  }, [state.unsavedChanges]);
 
   if (process.env.NODE_ENV === "development")
     console.log("(Dev Mode) useOrchest: state updated", state);

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -76,6 +76,7 @@ export interface IOrchestState
   sessionsKillAllInProgress?: boolean;
   config: IOrchestConfig;
   user_config: IOrchestUserConfig;
+  unsavedChanges: boolean;
   _sessionsToFetch?: IOrchestSessionUuid[] | [];
   _sessionsToggle?: IOrchestSessionUuid;
   _sessionsIsPolling?: boolean;
@@ -110,6 +111,7 @@ export type TOrchestAction =
       type: "sessionToggle";
       payload: IOrchestSessionUuid;
     }
+  | { type: "setUnsavedChanges"; payload: IOrchestState["unsavedChanges"] }
   | { type: "_sessionsToggleClear" }
   | {
       type: "_sessionsSet";

--- a/services/orchest-webserver/client/src/utils/webserver-utils.js
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.js
@@ -507,12 +507,6 @@ export function envVariablesDictToArray(envVariables) {
   return result;
 }
 
-export function updateGlobalUnsavedChanges(unsavedChanges) {
-  // NOTE: perhaps a more granular unsaved changes
-  // is necessary in the future
-  orchest.setUnsavedChanges(unsavedChanges);
-}
-
 /*
  Set of functions related to application routing.
 */

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.jsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.jsx
@@ -11,7 +11,6 @@ import {
 import { MDCButtonReact, MDCLinearProgressReact } from "@orchest/lib-mdc";
 import { OrchestContext, OrchestSessionsConsumer } from "@/hooks/orchest";
 import ImageBuildLog from "../components/ImageBuildLog";
-import { updateGlobalUnsavedChanges } from "../utils/webserver-utils";
 
 class ConfigureJupyterLabView extends React.Component {
   static contextType = OrchestContext;
@@ -43,9 +42,21 @@ class ConfigureJupyterLabView extends React.Component {
 
   componentDidMount() {
     this.getSetupScript();
+
+    this.context.dispatch({
+      type: "setUnsavedChanges",
+      payload: this.state.unsavedChanges,
+    });
   }
 
   componentDidUpdate() {
+    if (this.state.unsavedChanges !== prevState.unsavedChanges) {
+      this.context.dispatch({
+        type: "setUnsavedChanges",
+        payload: this.state.unsavedChanges,
+      });
+    }
+
     if (
       this.context.state.sessionsKillAllInProgress &&
       this.state.sessionKillStatus === "WAITING"
@@ -211,8 +222,6 @@ class ConfigureJupyterLabView extends React.Component {
   }
 
   render() {
-    updateGlobalUnsavedChanges(this.state.unsavedChanges);
-
     return (
       <OrchestSessionsConsumer>
         <div className={"view-page jupyterlab-config-page"}>

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.jsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.jsx
@@ -49,7 +49,7 @@ class ConfigureJupyterLabView extends React.Component {
     });
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(_, prevState) {
     if (this.state.unsavedChanges !== prevState.unsavedChanges) {
       this.context.dispatch({
         type: "setUnsavedChanges",

--- a/services/orchest-webserver/client/src/views/EditJobView.jsx
+++ b/services/orchest-webserver/client/src/views/EditJobView.jsx
@@ -26,7 +26,6 @@ import {
   getPipelineJSONEndpoint,
   envVariablesArrayToDict,
   envVariablesDictToArray,
-  updateGlobalUnsavedChanges,
 } from "../utils/webserver-utils";
 import JobView from "./JobView";
 
@@ -185,6 +184,20 @@ class EditJobView extends React.Component {
 
   componentDidMount() {
     this.fetchJob();
+
+    this.context.dispatch({
+      type: "setUnsavedChanges",
+      payload: this.state.unsavedChanges,
+    });
+  }
+
+  componentDidUpdate(_, prevState) {
+    if (this.state.unsavedChanges !== prevState.unsavedChanges) {
+      this.context.dispatch({
+        type: "setUnsavedChanges",
+        payload: this.state.unsavedChanges,
+      });
+    }
   }
 
   onParameterChange() {
@@ -565,8 +578,6 @@ class EditJobView extends React.Component {
   }
 
   render() {
-    updateGlobalUnsavedChanges(this.state.unsavedChanges);
-
     let rootView = undefined;
 
     if (this.state.job && this.state.pipeline) {

--- a/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
+++ b/services/orchest-webserver/client/src/views/EnvironmentEditView.jsx
@@ -20,7 +20,6 @@ import {
   DEFAULT_BASE_IMAGES,
 } from "@orchest/lib-utils";
 import { OrchestContext } from "@/hooks/orchest";
-import { updateGlobalUnsavedChanges } from "../utils/webserver-utils";
 import EnvironmentsView from "./EnvironmentsView";
 import ImageBuildLog from "../components/ImageBuildLog";
 
@@ -97,6 +96,20 @@ class EnvironmentEditView extends React.Component {
   componentDidMount() {
     if (this.props.queryArgs.environment_uuid) {
       this.fetchEnvironment();
+    }
+
+    this.context.dispatch({
+      type: "setUnsavedChanges",
+      payload: this.state.unsavedChanges,
+    });
+  }
+
+  componentDidUpdate(_, prevState) {
+    if (this.state.unsavedChanges !== prevState.unsavedChanges) {
+      this.context.dispatch({
+        type: "setUnsavedChanges",
+        payload: this.state.unsavedChanges,
+      });
     }
   }
 
@@ -386,8 +399,6 @@ class EnvironmentEditView extends React.Component {
   }
 
   render() {
-    updateGlobalUnsavedChanges(this.state.unsavedChanges);
-
     return (
       <div className={"view-page edit-environment"}>
         {(() => {

--- a/services/orchest-webserver/client/src/views/PipelineSettingsView.jsx
+++ b/services/orchest-webserver/client/src/views/PipelineSettingsView.jsx
@@ -42,7 +42,6 @@ import {
   envVariablesArrayToDict,
   envVariablesDictToArray,
   OverflowListener,
-  updateGlobalUnsavedChanges,
   validatePipeline,
 } from "@/utils/webserver-utils";
 import EnvVarList from "@/components/EnvVarList";
@@ -137,6 +136,14 @@ const PipelineSettingsView = (props) => {
   React.useEffect(() => {
     init();
   }, [props.queryArgs]);
+
+  /* sync local unsaved changes with global state */
+  React.useEffect(() => {
+    dispatch({
+      type: "setUnsavedChanges",
+      payload: state.unsavedChanges,
+    });
+  }, [state.unsavedChanges]);
 
   const setHeaderComponent = (pipelineName) =>
     dispatch({
@@ -616,8 +623,6 @@ const PipelineSettingsView = (props) => {
       );
     }
   };
-
-  updateGlobalUnsavedChanges(state.unsavedChanges);
 
   const sortService = (serviceA, serviceB) => serviceA.order - serviceB.order;
 

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.jsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.jsx
@@ -12,7 +12,6 @@ import {
   envVariablesArrayToDict,
   envVariablesDictToArray,
   OverflowListener,
-  updateGlobalUnsavedChanges,
 } from "../utils/webserver-utils";
 import PipelinesView from "./PipelinesView";
 import JobsView from "./JobsView";
@@ -42,10 +41,21 @@ class ProjectSettingsView extends React.Component {
   componentDidMount() {
     this.fetchSettings();
     this.attachResizeListener();
+    this.context.dispatch({
+      type: "setUnsavedChanges",
+      payload: this.state.unsavedChanges,
+    });
   }
 
   componentDidUpdate() {
     this.attachResizeListener();
+
+    if (this.state.unsavedChanges !== prevState.unsavedChanges) {
+      this.context.dispatch({
+        type: "setUnsavedChanges",
+        payload: this.state.unsavedChanges,
+      });
+    }
   }
 
   attachResizeListener() {
@@ -145,7 +155,6 @@ class ProjectSettingsView extends React.Component {
   }
 
   render() {
-    updateGlobalUnsavedChanges(this.state.unsavedChanges);
     return (
       <div className={"view-page view-project-settings"}>
         <form

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.jsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.jsx
@@ -47,7 +47,7 @@ class ProjectSettingsView extends React.Component {
     });
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(_, prevState) {
     this.attachResizeListener();
 
     if (this.state.unsavedChanges !== prevState.unsavedChanges) {

--- a/services/orchest-webserver/client/src/views/SettingsView.jsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.jsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from "react";
 import { MDCButtonReact, MDCLinearProgressReact } from "@orchest/lib-mdc";
-import { updateGlobalUnsavedChanges } from "../utils/webserver-utils";
 import {
   makeRequest,
   checkHeartbeat,
@@ -41,6 +40,19 @@ class SettingsView extends React.Component {
     this.checkOrchestStatus();
     this.getConfig();
     this.getVersion();
+    this.context.dispatch({
+      type: "setUnsavedChanges",
+      payload: this.state.unsavedChanges,
+    });
+  }
+
+  componentDidUpdate(_, prevState) {
+    if (this.state.unsavedChanges !== prevState.unsavedChanges) {
+      this.context.dispatch({
+        type: "setUnsavedChanges",
+        payload: this.state.unsavedChanges,
+      });
+    }
   }
 
   updateView() {
@@ -243,8 +255,6 @@ class SettingsView extends React.Component {
   }
 
   render() {
-    updateGlobalUnsavedChanges(this.state.unsavedChanges);
-
     return (
       <div className={"view-page orchest-settings"}>
         <h2>Orchest settings</h2>


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

As a side effect of #317, `setUnsavedChanges`'s logic was behaving incorrectly – firing again after first dismissal 

I started off by trying to debug this in the existing setup (with `window.orchest`) but it became incredibly tricky to find the root cause. 

Instead, I used this opportunity to remove further logic from `App.tsx`, moving all `setUnsavedChanges` functionality to the global context. Where needed, local `unsavedChanges` state has been updated to keep global state in sync.

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [x] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
