### PR TITLE
Run a pipeline through the CLI

### DIFF
--- a/orchest
+++ b/orchest
@@ -6,12 +6,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if ! docker ps >/dev/null 2>/dev/null ; then
     USERNAME=$(whoami)
 
-    ORCHEST_PATH=.
-    # Check if orchest is in PWD
-    if ! test -f "orchest"; then
-        ORCHEST_PATH=$DIR
-    fi
-
     # Automatically prepending with `sudo` makes sure this script does
     # not have to be run using `sudo`, which would overwrite the `$USER`
     # variable and thereby writing the `HOST_CONFIG_DIR` to the wrong
@@ -58,6 +52,11 @@ then
     OPTIONAL_IT="-it"
 fi
 
+# When Orchest is not yet installed then the Orchest does not yet exist,
+# however for certain features such as 'orchest run' we need the
+# ctl container to be launched within the network.
+OPTIONAL_NETWORK="--network=orchest"
+[ -z "$(docker network ls --filter="name=orchest" -q)" ] && OPTIONAL_NETWORK=""
 
 $SUDO_PREFIX docker run \
     --rm \
@@ -69,4 +68,5 @@ $SUDO_PREFIX docker run \
     -e HOST_REPO_DIR="${DIR}" \
     -e HOST_USER_DIR="${HOST_USER_DIR}" \
     -e HOST_OS="${HOST_OS}" \
+    ${OPTIONAL_NETWORK} \
     orchest/orchest-ctl:latest "$@"

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -10,7 +10,6 @@ class Config:
 
     # TODO: for now this is put here.
     ORCHEST_API_ADDRESS = "http://orchest-api:80/api"
-    ORCHEST_WEBSERVER_ADDRESS = "http://orchest-webserver:5000"
 
     # How often to run the scheduling logic when the process is running
     # as scheduler, in seconds.

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -353,5 +353,11 @@ def run(
     them directly through the CLI is a potential security risk.
 
     NOTE: Orchest has to be running for this to work.
+
+    Exit codes:
+
+    - 0: The job was successfully queued.
+
+    - 1: Something went wrong.
     """
     app.run(job_name, project_name, pipeline_name)

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -324,3 +324,30 @@ def adduser(
         raise typer.Exit(code=1)
 
     app.add_user(username, password, token, is_admin)
+
+
+# TODO: hidden=True
+@typer_app.command()
+def run(
+    job_name: str = typer.Option(
+        ...,  # required
+        "--job",
+        help="Name of job to create.",
+    ),
+    project_name: str = typer.Option(
+        ...,  # required
+        "--project",
+        help="Name of project containing pipeline.",
+    ),
+    pipeline_name: str = typer.Option(
+        ...,  # required
+        "--pipeline",
+        help="Name of pipeline to run.",
+    ),
+):
+    """
+    Queue a pipeline as a one-time job.
+
+    NOTE: Orchest has to be running for this to work.
+    """
+    app.run(job_name, project_name, pipeline_name)

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -348,6 +348,10 @@ def run(
     """
     Queue a pipeline as a one-time job.
 
+    In order to use environments variables, you can define them through
+    the UI as project or pipeline level environment variables. Passing
+    them directly through the CLI is a potential security risk.
+
     NOTE: Orchest has to be running for this to work.
     """
     app.run(job_name, project_name, pipeline_name)

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -61,3 +61,5 @@ ORCHEST_IMAGES = {
 }
 
 WRAP_LINES = 72
+
+ORCHEST_WEBSERVER_ADDRESS = "http://orchest-webserver:5000"

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -62,4 +62,4 @@ ORCHEST_IMAGES = {
 
 WRAP_LINES = 72
 
-ORCHEST_WEBSERVER_ADDRESS = "http://orchest-webserver:5000"
+ORCHEST_WEBSERVER_ADDRESS = "http://orchest-webserver:80"

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -483,8 +483,8 @@ class OrchestApp:
             url=base_url.format(path="/async/projects"),
         )
         for project in resp:
-            # NOTE: We use here that a project name is unique.
-            if project["name"] == project_name:
+            # NOTE: We use here that a project name/path is unique.
+            if project["path"] == project_name:
                 project_uuid = project["uuid"]
                 project_path = project["path"]
                 break
@@ -578,7 +578,9 @@ class OrchestApp:
             method="PUT",
         )
 
-        utils.echo("Successfully queued the quickstart pipeline as a one-time job.")
+        utils.echo(
+            f"Successfully queued the {pipeline_name} pipeline as a one-time job."
+        )
 
     def _is_restarting(self) -> bool:
         """Check if Orchest is restarting.

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -202,7 +202,7 @@ class OrchestApp:
         # Orchest is partially running and thus in an inconsistent
         # state. Possibly the start command was issued whilst Orchest
         # is still shutting down.
-        if running_containers:
+        if utils.is_orchest_running(running_containers):
             utils.echo(
                 "Orchest seems to be partially running. Before attempting to start"
                 " Orchest, shut the application down first:",

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -9,6 +9,7 @@ TODO:
       functionality. See: https://www.python.org/dev/peps/pep-0585/
 
 """
+import json
 import logging
 import os
 import re
@@ -19,7 +20,7 @@ from typing import List, Optional, Set, Tuple
 import typer
 
 from app import spec, utils
-from app.config import ORCHEST_IMAGES, _on_start_images
+from app.config import ORCHEST_IMAGES, ORCHEST_WEBSERVER_ADDRESS, _on_start_images
 from app.debug import debug_dump, health_check
 from app.docker_wrapper import DockerWrapper, OrchestResourceManager
 
@@ -61,6 +62,105 @@ class OrchestApp:
         )
         self.version(ext=True)
 
+    def update(self, mode=None, dev: bool = False):
+        """Update Orchest.
+
+        Args:
+            mode: The mode in which to update Orchest. This is either
+                ``None`` or ``"web"``, where the latter is used when
+                update is invoked through the update-server.
+
+        """
+        utils.echo("Updating...")
+
+        _, running_containers = self.resource_manager.get_containers(state="running")
+
+        if utils.is_orchest_running(running_containers):
+            if mode != "web":
+                # In the web updater it is not possible to cancel the
+                # update once started. So there is no value in showing
+                # this message or sleeping.
+                utils.echo(
+                    "Using Orchest whilst updating is NOT supported and will be shut"
+                    " down, killing all active pipeline runs and session. You have 2s"
+                    " to cancel the update operation."
+                )
+
+                # Give the user the option to cancel the update
+                # operation using a keyboard interrupt.
+                time.sleep(2)
+
+            skip_containers = []
+            if mode == "web":
+                # It is possible to pull new images whilst the older
+                # versions of those images are running. We will invoke
+                # Orchest restart from the webserver ui-updater.
+                skip_containers = [
+                    "orchest/update-server:latest",
+                    "orchest/auth-server:latest",
+                    "orchest/nginx-proxy:latest",
+                    "postgres:13.1",
+                ]
+
+            self.stop(skip_containers=skip_containers)
+
+        # Update the Orchest git repo to get the latest changes to the
+        # "userdir/" structure.
+        if not dev:
+            exit_code = utils.update_git_repo()
+            if exit_code == 0:
+                logger.info("Successfully updated git repo during update.")
+            elif exit_code == 21:
+                utils.echo("Cancelling update...")
+                utils.echo(
+                    "Make sure you have the master branch checked out before updating."
+                )
+                logger.error(
+                    "Failed update due to master branch not being checked out."
+                )
+                return
+            else:
+                utils.echo("Cancelling update...")
+                utils.echo(
+                    "It seems like you have unstaged changes in the 'orchest'"
+                    " repository. Please commit or stash them as 'orchest update'"
+                    " pulls the newest changes to the 'userdir/' using a rebase.",
+                )
+                logger.error("Failed update due to unstaged changes.")
+                return
+
+        # Get all installed images and pull new versions. The pulled
+        # images are checked to make sure optional images, e.g. lang
+        # specific images, are updated as well.
+        pulled_images = self.resource_manager.get_images()
+        to_pull_images = set(ORCHEST_IMAGES["minimal"]) | set(pulled_images)
+        logger.info("Updating images:\n" + "\n".join(to_pull_images))
+        self.docker_client.pull_images(to_pull_images, prog_bar=True, force=True)
+
+        # Delete user-built environment images to avoid the issue of
+        # having environments with mismatching Orchest SDK versions.
+        logger.info("Deleting user-built environment images.")
+        self.resource_manager.remove_env_build_imgs()
+
+        # Delete user-built Jupyter image to make sure the Jupyter
+        # server is updated to the latest version of Orchest.
+        logger.info("Deleting user-built Jupyter image.")
+        self.resource_manager.remove_jupyter_build_imgs()
+
+        # Delete Orchest dangling images.
+        self.resource_manager.remove_orchest_dangling_imgs()
+
+        if mode == "web":
+            utils.echo("Update completed.")
+        else:
+            utils.echo("Update completed. To start Orchest again, run:")
+            utils.echo("\torchest start")
+
+        utils.echo(
+            "Checking whether all containers are running the same version of Orchest."
+        )
+        self.version(ext=True)
+
     def start(self, container_config: dict):
         """Starts Orchest.
 
@@ -96,9 +196,6 @@ class OrchestApp:
         # Orchest is already running
         ids, running_containers = self.resource_manager.get_containers(state="running")
         if not (start_req_images - set(running_containers)):
-            # TODO: Ideally this would print the port on which Orchest
-            #       is running. (Was started before and so we do not
-            #       simply know.)
             utils.echo("Orchest is already running...")
             return
 
@@ -237,7 +334,6 @@ class OrchestApp:
         self.docker_client.run_containers(config_, use_name=True, detach=True)
 
     def status(self, ext=False):
-
         if self._is_restarting():
             utils.echo("Orchest is currently restarting.")
             raise typer.Exit(code=4)
@@ -280,105 +376,6 @@ class OrchestApp:
                     utils.echo("All services are ready.")
                 else:
                     raise typer.Exit(code=3)
-
-    def update(self, mode=None, dev: bool = False):
-        """Update Orchest.
-
-        Args:
-            mode: The mode in which to update Orchest. This is either
-                ``None`` or ``"web"``, where the latter is used when
-                update is invoked through the update-server.
-
-        """
-        utils.echo("Updating...")
-
-        _, running_containers = self.resource_manager.get_containers(state="running")
-
-        if utils.is_orchest_running(running_containers):
-            if mode != "web":
-                # In the web updater it is not possible to cancel the
-                # update once started. So there is no value in showing
-                # this message or sleeping.
-                utils.echo(
-                    "Using Orchest whilst updating is NOT supported and will be shut"
-                    " down, killing all active pipeline runs and session. You have 2s"
-                    " to cancel the update operation."
-                )
-
-                # Give the user the option to cancel the update
-                # operation using a keyboard interrupt.
-                time.sleep(2)
-
-            skip_containers = []
-            if mode == "web":
-                # It is possible to pull new images whilst the older
-                # versions of those images are running. We will invoke
-                # Orchest restart from the webserver ui-updater.
-                skip_containers = [
-                    "orchest/update-server:latest",
-                    "orchest/auth-server:latest",
-                    "orchest/nginx-proxy:latest",
-                    "postgres:13.1",
-                ]
-
-            self.stop(skip_containers=skip_containers)
-
-        # Update the Orchest git repo to get the latest changes to the
-        # "userdir/" structure.
-        if not dev:
-            exit_code = utils.update_git_repo()
-            if exit_code == 0:
-                logger.info("Successfully updated git repo during update.")
-            elif exit_code == 21:
-                utils.echo("Cancelling update...")
-                utils.echo(
-                    "Make sure you have the master branch checked out before updating."
-                )
-                logger.error(
-                    "Failed update due to master branch not being checked out."
-                )
-                return
-            else:
-                utils.echo("Cancelling update...")
-                utils.echo(
-                    "It seems like you have unstaged changes in the 'orchest'"
-                    " repository. Please commit or stash them as 'orchest update'"
-                    " pulls the newest changes to the 'userdir/' using a rebase.",
-                )
-                logger.error("Failed update due to unstaged changes.")
-                return
-
-        # Get all installed images and pull new versions. The pulled
-        # images are checked to make sure optional images, e.g. lang
-        # specific images, are updated as well.
-        pulled_images = self.resource_manager.get_images()
-        to_pull_images = set(ORCHEST_IMAGES["minimal"]) | set(pulled_images)
-        logger.info("Updating images:\n" + "\n".join(to_pull_images))
-        self.docker_client.pull_images(to_pull_images, prog_bar=True, force=True)
-
-        # Delete user-built environment images to avoid the issue of
-        # having environments with mismatching Orchest SDK versions.
-        logger.info("Deleting user-built environment images.")
-        self.resource_manager.remove_env_build_imgs()
-
-        # Delete user-built Jupyter image to make sure the Jupyter
-        # server is updated to the latest version of Orchest.
-        logger.info("Deleting user-built Jupyter image.")
-        self.resource_manager.remove_jupyter_build_imgs()
-
-        # Delete Orchest dangling images.
-        self.resource_manager.remove_orchest_dangling_imgs()
-
-        if mode == "web":
-            utils.echo("Update completed.")
-        else:
-            utils.echo("Update completed. To start Orchest again, run:")
-            utils.echo("\torchest start")
-
-        utils.echo(
-            "Checking whether all containers are running the same version of Orchest."
-        )
-        self.version(ext=True)
 
     def version(self, ext=False):
         """Returns the version of Orchest.
@@ -465,6 +462,124 @@ class OrchestApp:
 
         raise typer.Exit(code=exit_code)
 
+    def run(self, job_name, project_name, pipeline_name):
+        """Queues the pipeline as a one-time job."""
+        # Orchest has to be running for this command to work, since we
+        # will be querying the orchest-webserver directly.
+        _, running_containers = self.resource_manager.get_containers(state="running")
+        if not utils.is_orchest_running(running_containers):
+            utils.echo("Orchest has to be running in order to queue a job. Run:")
+            utils.echo("\torchest start")
+            return
+
+        wait_msg_template = "[{endpoint}]: Could not reach Orchest."
+        base_url = f"{ORCHEST_WEBSERVER_ADDRESS}{{path}}"
+        abs_projects_path = "/orchest-host/userdir/projects"
+
+        # Get project information.
+        _, resp = utils.retry_func(
+            utils.get_response,
+            _wait_msg=wait_msg_template.format(endpoint="projects"),
+            url=base_url.format(path="/async/projects"),
+        )
+        for project in resp:
+            # NOTE: We use here that a project name is unique.
+            if project["name"] == project_name:
+                project_uuid = project["uuid"]
+                project_path = project["path"]
+                break
+        else:
+            utils.echo("The given project does not exist.")
+            return
+
+        # Get pipeline information.
+        _, resp = utils.retry_func(
+            utils.get_response,
+            _wait_msg=wait_msg_template.format(endpoint="pipelines"),
+            url=base_url.format(path=f"/async/pipelines/{project_uuid}"),
+        )
+        for pipeline in resp["result"]:
+            if pipeline["name"] == pipeline_name:
+                pipeline_uuid = pipeline["uuid"]
+                pipeline_path = pipeline["path"]
+                break
+        else:
+            utils.echo("The given pipeline does not exist in the given project.")
+            return
+
+        # Start pipeline run.
+        utils.echo("Creating draft job.")
+        # TODO: Probably want to get the pipeline definition through the
+        # webserver instead of having the orchest-ctl read it from the
+        # userdir.
+        full_pipeline_path = os.path.join(
+            abs_projects_path, project_path, pipeline_path
+        )
+        with open(full_pipeline_path, "r") as f:
+            pipeline_definition = json.load(f)
+
+        _, resp = utils.retry_func(
+            utils.get_response,
+            _wait_msg=wait_msg_template.format(endpoint="jobs"),
+            url=base_url.format(path="/catch/api-proxy/api/jobs/"),
+            data={
+                "draft": True,
+                "project_uuid": project_uuid,
+                "pipeline_uuid": pipeline_uuid,
+                "pipeline_name": pipeline_name,
+                "name": job_name,
+                "parameters": [],
+                "pipeline_run_spec": {
+                    "run_type": "full",
+                    "uuids": None,  # argument is ignored due to "full"
+                },
+            },
+            method="POST",
+        )
+        job_uuid = resp["uuid"]
+
+        # NOTE: When creating a draft for a job, this triggers the
+        # required environment builds which we need to await before
+        # queueing the job.  This behavior is equal to the behavior
+        # through the `orchest-webserver`.
+        utils.echo("Queueing job.")
+        repeat = True
+        while repeat:
+            status_code, resp = utils.retry_func(
+                utils.get_response,
+                _wait_msg="[jobs]: Environment builds have not yet succeeded.",
+                url=base_url.format(
+                    path="/catch/api-proxy/api/validations/environments"
+                ),
+                data={"project_uuid": project_uuid},
+                method="POST",
+            )
+
+            # Check for status code 201 because it is a POST request.
+            repeat = status_code != 201 or resp.get("validation") != "pass"
+
+            if repeat:
+                utils.echo("[Waiting]: environment builds have not yet succeeded.")
+                time.sleep(3)
+
+        parameters, strategy_json = construct_parameters_payload(pipeline_definition)
+        _, resp = utils.retry_func(
+            utils.get_response,
+            _retries=5,
+            _sleep_duration=1,
+            _wait_msg=wait_msg_template.format(endpoint="jobs"),
+            url=base_url.format(path=f"/catch/api-proxy/api/jobs/{job_uuid}"),
+            data={
+                "confirm_draft": True,
+                "env_variables": {},  # TODO
+                "parameters": [parameters],
+                "strategy_json": strategy_json,
+            },
+            method="PUT",
+        )
+
+        utils.echo("Successfully queued the quickstart pipeline as a one-time job.")
+
     def _is_restarting(self) -> bool:
         """Check if Orchest is restarting.
 
@@ -539,3 +654,38 @@ def get_required_images(language: Optional[str], gpu: bool = False) -> List[str]
             required_images += gpu_images[language]
 
     return required_images
+
+
+def construct_parameters_payload(pipeline_definition: dict) -> Tuple[dict, dict]:
+    """Constructs the parameter payload for a one-off job.
+
+    Returns:
+        `parameters`: The default parameters for every step from the
+            `pipeline_definition`.
+        `stategy_json`: Strategy dictionary as required by the job.
+
+    """
+
+    def parse_parameters_format(value: dict) -> dict:
+        """Parses the parameter values to the correct format.
+
+        The format for the strategy JSON parameters is:
+            {a: "[1]", b: "[2]"}
+        whereas, the given value is:
+            {a: 1, b: 2}
+
+        """
+        return {p: str([v]) for p, v in value.items()}
+
+    strategy_json = {}
+    parameters = {}
+    for step_uuid, step_props in pipeline_definition["steps"].items():
+        if step_props["parameters"]:
+            strategy_json[step_uuid] = {
+                "key": step_uuid,
+                "title": step_props["title"],
+                "parameters": parse_parameters_format(step_props["parameters"]),
+            }
+            parameters[step_uuid] = step_props["parameters"]
+
+    return parameters, strategy_json

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -161,7 +161,7 @@ def retry_func(func, _retries=10, _sleep_duration=1, _wait_msg=None, **kwargs) -
             break
         except Exception as e:
             if _wait_msg is not None:
-                print(_wait_msg)
+                echo(_wait_msg)
             e_msg = e
             time.sleep(_sleep_duration)
     else:

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -1,15 +1,17 @@
+import json
 import logging
 import os
 import subprocess
 import textwrap
 import time
 from collections.abc import Mapping
-from typing import List, Union
+from typing import Any, List, Tuple, Union
+from urllib import request
 
 import typer
 
+from app import error
 from app.config import WRAP_LINES
-from app.error import ENVVariableNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ def get_env() -> dict:
 
     not_present = [var for var, value in env.items() if value is None]
     if not_present:
-        raise ENVVariableNotFoundError(
+        raise error.ENVVariableNotFoundError(
             "Required environment variables are not present: " + ", ".join(not_present)
         )
 
@@ -129,6 +131,45 @@ def is_dangling(image: Mapping) -> bool:
     """Checks whether the given image is to be considered dangling."""
     tags = image["RepoTags"]
     return not tags or "<none>:<none>" in tags
+
+
+def get_response(url: str, data=None, method="GET") -> Tuple[int, dict]:
+    """Requests an url."""
+    if data is not None:
+        data = json.dumps(data).encode()
+        req = request.Request(url, data=data, method=method)
+        req.add_header("Content-Type", "application/json")
+    else:
+        req = request.Request(url, method=method)
+
+    with request.urlopen(req) as r:
+        return r.status, json.loads(r.read().decode("utf-8"))
+
+
+# Use leading underscore to make sure `kwargs` names do not collide.
+def retry_func(func, _retries=10, _sleep_duration=1, _wait_msg=None, **kwargs) -> Any:
+    """Tries func(**kwargs) _retries times.
+
+    Raises:
+        RuntimeError: The given `func` did not return within the given
+            number of `_retries`.
+    """
+    e_msg = None
+    for _ in range(_retries):
+        try:
+            func_result = func(**kwargs)
+            break
+        except Exception as e:
+            if _wait_msg is not None:
+                print(_wait_msg)
+            e_msg = e
+            time.sleep(_sleep_duration)
+    else:
+        raise RuntimeError(
+            f"Could not reach Orchest instance before timeout expired: {e_msg}"
+        )
+
+    return func_result
 
 
 # orchest <arguments> cmd <arguments>, excluding the use of cmd as an


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description
Adds functionality to the CLI to run a pipeline as a one-time job.

To try it out:
```bash
./orchest run --job=test --project=quickstart --pipeline="california-housing"
```

## Questions
* Q: Do we want it as a hidden or public CLI command? I would opt for public since we already indicate we are in alpha.
* A: Ended up with public.

* Q: The CLI now reads the pipeline definition (which it needs to create the strategy json for the job) from the `userdir`. Is this against our design decisions? And if so, do we want to add a dedicated endpoint webserver?
* A: Used already existing webserver endpoint.

* Q: How do we want to handle environment variables? I now opted to let the users use project and pipeline environment variables, because passing variables through the CLI, e.g. `--name=value`, would cause them to be in your shells history (which is undesirable as env variables can be secrets).
* A: Out of scope for now. Can definitely include later.
