### PR TITLE
Prevent loadDefaultView firing twice

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -164,10 +164,12 @@ const App = () => {
       // history API.
 
       let [pathname, search] = generateRoute(TagName, dynamicProps);
+      console.log(pathname, search);
 
       // Because pushState objects need to be serialized,
       // we need to store the string representation of the TagName.
       let viewName = componentName(TagName);
+      console.log(viewName);
       window.history.pushState(
         {
           viewName,
@@ -288,7 +290,6 @@ const App = () => {
   React.useEffect(() => {
     setJupyter(new Jupyter(jupyterRef.current));
     initializeFirstView();
-    loadDefaultView();
   }, []);
 
   window.orchest = {

--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -164,12 +164,10 @@ const App = () => {
       // history API.
 
       let [pathname, search] = generateRoute(TagName, dynamicProps);
-      console.log(pathname, search);
 
       // Because pushState objects need to be serialized,
       // we need to store the string representation of the TagName.
       let viewName = componentName(TagName);
-      console.log(viewName);
       window.history.pushState(
         {
           viewName,


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Prevents the default view from being loaded twice on mount (`loadDefaultView` is handled by `initializeFirstView`)

Closes #333 

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
