### PR TITLE
Fix project selector routing behaviour

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -153,12 +153,7 @@ const App = () => {
     );
   };
 
-  const loadView = (TagName, dynamicProps?, onCancelled?) => {
-    // dynamicProps default
-    if (!dynamicProps) {
-      dynamicProps = {};
-    }
-
+  const loadView = (TagName, dynamicProps = {}, onCancelled?) => {
     let conditionalBody = () => {
       // This public loadView sets the state through the
       // history API.
@@ -301,10 +296,9 @@ const App = () => {
   };
 
   React.useEffect(() => {
-    if (state.TagName) {
+    if (state.TagName && context?.state?.project_uuid)
       setView(_generateView(state.TagName, state.dynamicProps));
-    }
-  }, [state]);
+  }, [state, context?.state?.project_uuid]);
 
   return (
     <>


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Adds the context `project_uuid` to route `_generateView` dependencies.

Fixes: #334 

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
