### PR TITLE
Fix debug expected celery log file name

### DIFF
--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -224,7 +224,7 @@ def celery_debug_dump(
     if ext:
         # Add log files to the files to copy.
         for worker in [
-            "celery_env_builds",
+            "celery_builds",
             "celery_interactive",
             "celery_jobs",
         ]:


### PR DESCRIPTION
## Description
Fixes the name of a log file that the debug dump expected to be there in the celery container.

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
