### PR TITLE
Select imported project automatically

### DIFF
--- a/services/orchest-webserver/app/scripts/background_tasks.py
+++ b/services/orchest-webserver/app/scripts/background_tasks.py
@@ -25,7 +25,8 @@ def git_clone_project(args):
         # if the project_name is not provided
         git_command = f"git clone {args.url}"
 
-        # args.path contains the desired project name, if the user specified it
+        # args.path contains the desired project name,
+        # if the user specified it
         project_name = args.path
         if project_name:
             if "/" in project_name:
@@ -38,10 +39,13 @@ def git_clone_project(args):
         if exit_code != 0:
             msg = "git clone failed"
         else:
-            msg = "successfully cloned"
             # should be the only directory in there, also this way we
-            # get the directory without knowing the repo name if the project_name has not been provided
+            # get the directory without knowing the repo name if the
+            # project_name has not been provided
             inferred_project_name = os.listdir(tmp_path)[0]
+
+            # The msg will contain the project name if the task succeeds
+            msg = inferred_project_name
 
             from_path = os.path.join(tmp_path, inferred_project_name)
             exit_code = os.system(f'mv "{from_path}" /userdir/projects/')
@@ -52,7 +56,11 @@ def git_clone_project(args):
             # on projects directory.
             projects_gid = os.stat("/userdir/projects").st_gid
             os.system(
-                f'chown -R :{projects_gid} "{os.path.join("/userdir/projects", inferred_project_name)}"'
+                'chown -R :%s "%s"'
+                % (
+                    projects_gid,
+                    os.path.join("/userdir/projects", inferred_project_name),
+                )
             )
 
     except Exception as e:

--- a/services/orchest-webserver/client/src/views/ProjectsView.jsx
+++ b/services/orchest-webserver/client/src/views/ProjectsView.jsx
@@ -130,8 +130,9 @@ class ProjectsView extends React.Component {
         () => {
           // Verify selected project UUID
           if (
+            this.context.state.project_uuid !== undefined &&
             projects.filter(
-              (project) => project.uuid == this.context.project_uuid
+              (project) => project.uuid == this.context.state.project_uuid
             ).length == 0
           ) {
             this.context.dispatch({
@@ -357,14 +358,27 @@ class ProjectsView extends React.Component {
               this.state.showImportModal && result.status != "SUCCESS",
           });
 
+          let cb;
+
           if (result.status == "SUCCESS") {
+            cb = () => {
+              let importedProject = this.state.projects.filter((proj) => {
+                return proj.path == result.result;
+              })[0];
+
+              this.context.dispatch({
+                type: "projectSet",
+                payload: importedProject.uuid,
+              });
+            };
+
             this.setState({
               import_project_name: "",
               import_url: "",
             });
           }
 
-          this.fetchList();
+          this.fetchList(cb);
         }
       );
     });


### PR DESCRIPTION
## Description
Select imported project automatically

Closes: https://github.com/orchest/orchest/issues/343

This also fixes "resetting" of the selected project to the first project in Orchest when visiting the /projects page.

### Checklist
- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.