### PR TITLE
Remove dialog on buildComplete

### DIFF
--- a/services/orchest-webserver/client/src/components/Dialogs.jsx
+++ b/services/orchest-webserver/client/src/components/Dialogs.jsx
@@ -47,7 +47,10 @@ const Dialogs = React.forwardRef((_, ref) => {
         project_uuid={project_uuid}
         environmentValidationData={environmentValidationData}
         requestedFromView={requestedFromView}
-        onBuildComplete={onBuildComplete}
+        onBuildComplete={() => {
+          remove(uuid);
+          onBuildComplete();
+        }}
         onCancel={onCancel}
         onClose={() => {
           remove(uuid);


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Remove dialog on buildComplete

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running. appropriate database migrations.
