### PR TITLE
Improvement: add `--wait` to CLI `run` command

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -326,7 +326,6 @@ def adduser(
     app.add_user(username, password, token, is_admin)
 
 
-# TODO: hidden=True
 @typer_app.command()
 def run(
     job_name: str = typer.Option(
@@ -344,6 +343,11 @@ def run(
         "--pipeline",
         help="Name of pipeline to run.",
     ),
+    wait: bool = typer.Option(
+        False,
+        show_default="--no-wait",
+        help="Wait for the pipeline run to finish.",
+    ),
 ):
     """
     Queue a pipeline as a one-time job.
@@ -360,4 +364,4 @@ def run(
 
     - 1: Something went wrong.
     """
-    app.run(job_name, project_name, pipeline_name)
+    app.run(job_name, project_name, pipeline_name, wait=wait)

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -605,7 +605,7 @@ class OrchestApp:
             return
 
         repeat = True
-        end_states = ["SUCCESS", "ABORTED"]
+        end_states = ["SUCCESS", "ABORTED", "FAILURE"]
         while repeat:
             try:
                 status_code, resp = utils.retry_func(

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -482,7 +482,7 @@ class OrchestApp:
             url=base_url.format(path="/async/projects"),
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'projects' endpoint.")
+            utils.echo(f"[projects]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         for project in resp:
             # NOTE: We use here that a project name/path is unique.
@@ -500,7 +500,7 @@ class OrchestApp:
             url=base_url.format(path=f"/async/pipelines/{project_uuid}"),
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'pipelines' endpoint.")
+            utils.echo(f"[pipelines]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         for pipeline in resp["result"]:
             if pipeline["name"] == pipeline_name:
@@ -531,7 +531,7 @@ class OrchestApp:
             method="POST",
         )
         if status_code != 201:
-            utils.echo("Got an unexpected status code for 'jobs' endpoint.")
+            utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         job_uuid = resp["uuid"]
 
@@ -557,9 +557,11 @@ class OrchestApp:
                 )
                 raise typer.Exit(code=1)
             else:
-                # Check for status code 201 because it is a POST
-                # request.
-                repeat = status_code != 201 or resp.get("validation") != "pass"
+                if status_code != 201:
+                    utils.echo(f"[validations]: Unexpected status code: {status_code}.")
+                    raise typer.Exit(code=1)
+
+                repeat = resp.get("validation") != "pass"
 
                 if repeat:
                     utils.echo("[Waiting]: environment builds have not yet succeeded.")
@@ -594,7 +596,7 @@ class OrchestApp:
             method="PUT",
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'jobs' endpoint.")
+            utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
 
         utils.echo(
@@ -619,7 +621,11 @@ class OrchestApp:
                 )
                 raise typer.Exit(code=1)
             else:
-                repeat = status_code != 200 or resp.get("status") not in end_states
+                if status_code != 200:
+                    utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
+                    raise typer.Exit(code=1)
+
+                repeat = resp.get("status") not in end_states
 
                 if repeat:
                     utils.echo("[Waiting]: job has not finished running yet.")


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Add `--wait` to `orchest run ...` to wait for the pipeline run to finish executing. This makes the CLI command blocking. Default is `--no-wait`, i.e. not waiting/blocking.


