### PR TITLE
Replace fetcher with no-op promise to avoid requests.

### DIFF
--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
@@ -6,9 +6,16 @@ import { onboardingDialogCarouselSlides } from "./content";
 export const useOnboardingDialogCarousel = () => {
   const initialState = { isAnimating: false, slide: [0, 0] };
 
-  const { data: state, mutate: setState } = useSWR("useOnboardingCarousel", {
-    initialData: initialState,
-  });
+  const { data: state, mutate: setState } = useSWR(
+    "useOnboardingCarousel",
+    (_) => {
+      // no-op fetcher
+      return new Promise(() => {});
+    },
+    {
+      initialData: initialState,
+    }
+  );
 
   const length = onboardingDialogCarouselSlides.length;
 

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
@@ -6,9 +6,16 @@ import { useProjects } from "@/hooks/projects";
 import useSWR from "swr";
 
 export const useOnboardingDialog = () => {
-  const { data: state, mutate: setState } = useSWR("useOnboardingDialog", {
-    initialData: { isOpen: false, shouldFetchQuickstart: false },
-  });
+  const { data: state, mutate: setState } = useSWR(
+    "useOnboardingDialog",
+    (_) => {
+      // no-op fetcher
+      return new Promise(() => {});
+    },
+    {
+      initialData: { isOpen: false, shouldFetchQuickstart: false },
+    }
+  );
 
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useLocalStorage(
     "onboarding_completed",


### PR DESCRIPTION
## Description

This is a temporary work-around to avoid issuing requests for the onboarding component.

@joe-bell I think we're using SWR in the wrong way here. It looks to me like you're using it for hook-style state management. This was triggering requests to a random endpoint (that doesn't exist). Let's sync on this next week.

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
