### PR TITLE
v2021.06.5

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -326,7 +326,6 @@ def adduser(
     app.add_user(username, password, token, is_admin)
 
 
-# TODO: hidden=True
 @typer_app.command()
 def run(
     job_name: str = typer.Option(
@@ -344,6 +343,11 @@ def run(
         "--pipeline",
         help="Name of pipeline to run.",
     ),
+    wait: bool = typer.Option(
+        False,
+        show_default="--no-wait",
+        help="Wait for the pipeline run to finish.",
+    ),
 ):
     """
     Queue a pipeline as a one-time job.
@@ -360,4 +364,4 @@ def run(
 
     - 1: Something went wrong.
     """
-    app.run(job_name, project_name, pipeline_name)
+    app.run(job_name, project_name, pipeline_name, wait=wait)

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -462,7 +462,7 @@ class OrchestApp:
 
         raise typer.Exit(code=exit_code)
 
-    def run(self, job_name, project_name, pipeline_name):
+    def run(self, job_name, project_name, pipeline_name, wait=False):
         """Queues the pipeline as a one-time job."""
         # Orchest has to be running for this command to work, since we
         # will be querying the orchest-webserver directly.
@@ -482,7 +482,7 @@ class OrchestApp:
             url=base_url.format(path="/async/projects"),
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'projects' endpoint.")
+            utils.echo(f"[projects]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         for project in resp:
             # NOTE: We use here that a project name/path is unique.
@@ -500,7 +500,7 @@ class OrchestApp:
             url=base_url.format(path=f"/async/pipelines/{project_uuid}"),
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'pipelines' endpoint.")
+            utils.echo(f"[pipelines]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         for pipeline in resp["result"]:
             if pipeline["name"] == pipeline_name:
@@ -531,7 +531,7 @@ class OrchestApp:
             method="POST",
         )
         if status_code != 201:
-            utils.echo("Got an unexpected status code for 'jobs' endpoint.")
+            utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
         job_uuid = resp["uuid"]
 
@@ -557,9 +557,11 @@ class OrchestApp:
                 )
                 raise typer.Exit(code=1)
             else:
-                # Check for status code 201 because it is a POST
-                # request.
-                repeat = status_code != 201 or resp.get("validation") != "pass"
+                if status_code != 201:
+                    utils.echo(f"[validations]: Unexpected status code: {status_code}.")
+                    raise typer.Exit(code=1)
+
+                repeat = resp.get("validation") != "pass"
 
                 if repeat:
                     utils.echo("[Waiting]: environment builds have not yet succeeded.")
@@ -594,12 +596,42 @@ class OrchestApp:
             method="PUT",
         )
         if status_code != 200:
-            utils.echo("Got an unexpected status code for 'jobs' endpoint.")
+            utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
             raise typer.Exit(code=1)
 
         utils.echo(
             f"Successfully queued the {pipeline_name} pipeline as a one-time job."
         )
+
+        if not wait:
+            return
+
+        repeat = True
+        end_states = ["SUCCESS", "ABORTED", "FAILURE"]
+        while repeat:
+            try:
+                status_code, resp = utils.retry_func(
+                    utils.get_response,
+                    _wait_msg=wait_msg_template.format(endpoint="jobs"),
+                    url=base_url.format(path=f"/catch/api-proxy/api/jobs/{job_uuid}"),
+                )
+            except RuntimeError:
+                utils.echo(
+                    "It seems like Orchest experienced an internal server error."
+                )
+                raise typer.Exit(code=1)
+            else:
+                if status_code != 200:
+                    utils.echo(f"[jobs]: Unexpected status code: {status_code}.")
+                    raise typer.Exit(code=1)
+
+                repeat = resp.get("status") not in end_states
+
+                if repeat:
+                    utils.echo("[Waiting]: job has not finished running yet.")
+                    time.sleep(3)
+
+        utils.echo(f"Successfully ran the {pipeline_name} pipeline as a one-time job.")
 
     def _is_restarting(self) -> bool:
         """Check if Orchest is restarting.

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
@@ -6,9 +6,16 @@ import { onboardingDialogCarouselSlides } from "./content";
 export const useOnboardingDialogCarousel = () => {
   const initialState = { isAnimating: false, slide: [0, 0] };
 
-  const { data: state, mutate: setState } = useSWR("useOnboardingCarousel", {
-    initialData: initialState,
-  });
+  const { data: state, mutate: setState } = useSWR(
+    "useOnboardingCarousel",
+    (_) => {
+      // no-op fetcher
+      return new Promise(() => {});
+    },
+    {
+      initialData: initialState,
+    }
+  );
 
   const length = onboardingDialogCarouselSlides.length;
 

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
@@ -6,9 +6,16 @@ import { useProjects } from "@/hooks/projects";
 import useSWR from "swr";
 
 export const useOnboardingDialog = () => {
-  const { data: state, mutate: setState } = useSWR("useOnboardingDialog", {
-    initialData: { isOpen: false, shouldFetchQuickstart: false },
-  });
+  const { data: state, mutate: setState } = useSWR(
+    "useOnboardingDialog",
+    (_) => {
+      // no-op fetcher
+      return new Promise(() => {});
+    },
+    {
+      initialData: { isOpen: false, shouldFetchQuickstart: false },
+    }
+  );
 
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useLocalStorage(
     "onboarding_completed",


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

* Adds `--wait` option to the `run` CLI command to block until the pipeline has finished executing.
* Avoids making unnecessary request regarding the new onboarding dialog. 
