### PR TITLE
Disable IPv6 in nginx-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docs](https://orchest.readthedocs.io/en/stable/getting_started/installation.html
 
 #### Requirements
 
-- Docker ([API version](https://docs.docker.com/engine/api/#api-version-matrix) of `>= 1.40`; `docker version | grep "API version"`)
+- Docker ([Engine version](https://docs.docker.com/engine/install/) of `>= 20.10.7`; run `docker version` to check.)
 
 If you do not yet have Docker installed, please visit https://docs.docker.com/get-docker/.
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -35,6 +35,15 @@ Simply follow the steps below to install Orchest.
 Now that you have installed Orchest, get started with the :ref:`quickstart <quickstart>` tutorial.
 
 .. note::
+   For Linux/WSL 2 users, please take the following into account regarding the Docker 
+   networking configuration.
+
+   Docker has `some network interruption issues <https://github.com/docker/for-linux/issues/914>`_,
+   if you're connecting to Orchest from the same machine on which you're running it
+   (e.g. using ``localhost``) it's recommended to disable IPv6 networking at the kernel
+   level using a boot directive like ``ipv6.disable=1``.
+
+.. note::
    By default, running ``./orchest install``, installs only the language dependencies for Python.
    Other language dependencies can be installed as follows:
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -43,7 +43,7 @@ Now that you have installed Orchest, get started with the :ref:`quickstart <quic
    (e.g. using ``localhost``) it's recommended to disable IPv6 networking at the kernel
    level using a boot directive like ``ipv6.disable=1``.
 
-   Please note this requires Docker version ``>= 20.10.7``.
+   Please note disabling IPv6 on Linux requires Docker version ``>= 20.10.7``.
 
 .. note::
    By default, running ``./orchest install``, installs only the language dependencies for Python.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -39,8 +39,11 @@ Now that you have installed Orchest, get started with the :ref:`quickstart <quic
 
    Docker has `some network interruption issues <https://github.com/docker/for-linux/issues/914>`_,
    if you're connecting to Orchest from the same machine on which you're running it
-   (e.g. using ``localhost``) it's recommended to disable IPv6 networking at the kernel
-   level using a boot directive like ``ipv6.disable=1``.
+   (e.g. using ``localhost``) it's recommended to disable IPv6 networking.
+   
+   It's recommended to disable it at the kernel level using a boot directive like ``ipv6.disable=1``. 
+   `This article <https://www.thegeekdiary.com/how-to-disable-ipv6-on-ubuntu-18-04-bionic-beaver-linux/>`_ 
+   describes how to do that for Ubuntu Linux.
 
 .. note::
    By default, running ``./orchest install``, installs only the language dependencies for Python.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -5,8 +5,7 @@ Orchest can be run on Linux, macOS and Windows (using the exact same steps!).
 
 Prerequisites
 -------------
-* Docker (`API version <https://docs.docker.com/engine/api/#api-version-matrix>`_ of ``>= 1.40``;
-  ``docker version | grep "API version"``)
+* Docker (`Engine version <https://docs.docker.com/engine/install/>`_ of ``>= 20.10.7``; run ``docker version`` to check.)
 
 If you do not yet have Docker installed, please visit https://docs.docker.com/get-docker/.
 
@@ -42,8 +41,6 @@ Now that you have installed Orchest, get started with the :ref:`quickstart <quic
    if you're connecting to Orchest from the same machine on which you're running it
    (e.g. using ``localhost``) it's recommended to disable IPv6 networking at the kernel
    level using a boot directive like ``ipv6.disable=1``.
-
-   Please note disabling IPv6 on Linux requires Docker version ``>= 20.10.7``.
 
 .. note::
    By default, running ``./orchest install``, installs only the language dependencies for Python.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -43,6 +43,8 @@ Now that you have installed Orchest, get started with the :ref:`quickstart <quic
    (e.g. using ``localhost``) it's recommended to disable IPv6 networking at the kernel
    level using a boot directive like ``ipv6.disable=1``.
 
+   Please note this requires Docker version ``>= 20.10.7``.
+
 .. note::
    By default, running ``./orchest install``, installs only the language dependencies for Python.
    Other language dependencies can be installed as follows:

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -41,7 +41,7 @@ Now that you have installed Orchest, get started with the :ref:`quickstart <quic
    if you're connecting to Orchest from the same machine on which you're running it
    (e.g. using ``localhost``) it's recommended to disable IPv6 networking.
    
-   It's recommended to disable it at the kernel level using a boot directive like ``ipv6.disable=1``. 
+   It's recommended to disable IPv6 at the kernel level using a boot directive like ``ipv6.disable=1``. 
    `This article <https://www.thegeekdiary.com/how-to-disable-ipv6-on-ubuntu-18-04-bionic-beaver-linux/>`_ 
    describes how to do that for Ubuntu Linux.
 

--- a/services/nginx-proxy/orchest.conf
+++ b/services/nginx-proxy/orchest.conf
@@ -5,10 +5,8 @@ map $http_upgrade $connection_upgrade {
 
 server {
   listen 80;
-  listen [::]:80;
 
   listen 443 ssl;
-  listen [::]:443 ssl;
 
   ssl_certificate     /etc/ssl/certs/server.crt;
   ssl_certificate_key /etc/ssl/certs/server.key;


### PR DESCRIPTION
## Description

Disable IPv6 in nginx. We weren't attching to the IPv6 address in the Docker network forwarding anyway. And disabling the listen is required to fix https://github.com/docker/for-linux/issues/914.

This partially solves https://github.com/orchest/orchest/issues/9. It still requires manual disabling of IPv6 in Linux.

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.