### PR TITLE
Switch SWR fetcher to null

### DIFF
--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/use-onboarding-dialog-carousel.js
@@ -8,10 +8,7 @@ export const useOnboardingDialogCarousel = () => {
 
   const { data: state, mutate: setState } = useSWR(
     "useOnboardingCarousel",
-    (_) => {
-      // no-op fetcher
-      return new Promise(() => {});
-    },
+    null,
     {
       initialData: initialState,
     }

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/use-onboarding-dialog.js
@@ -8,10 +8,7 @@ import useSWR from "swr";
 export const useOnboardingDialog = () => {
   const { data: state, mutate: setState } = useSWR(
     "useOnboardingDialog",
-    (_) => {
-      // no-op fetcher
-      return new Promise(() => {});
-    },
+    null,
     {
       initialData: { isOpen: false, shouldFetchQuickstart: false },
     }


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

**Why SWR?**

To avoid wrapping our `App.tsx` with endless `Context.Provider`s for all our different hooks, SWR was chosen for shared state – following [this article written by **the library's co-maintainer**](https://paco.sh/blog/shared-hook-state-with-swr).

The article outlines well the headaches that come with maintaining shared state, with a solution that leverages client-side cache – thoughts that echo my own.

**Workaround**

After merging, @yannickperrenet/@ricklamers noticed that SWR was trying to "fetch" the key as an endpoint. As a workaround, this fetcher was set to a `null`-returning promise.

This PR switches that `null`-returning Promise workaround to `null` – skipping the [optional `fetcher`](https://swr.vercel.app/docs/options) option altogether. It seems like this is a genuine bug in SWR, so I've raised an issue over at https://github.com/vercel/swr/issues/1244 to track further

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
