### PR TITLE
Show an 'NOT BUILT' status instead of an empty span

### DIFF
--- a/services/orchest-webserver/client/src/components/EnvironmentList.jsx
+++ b/services/orchest-webserver/client/src/components/EnvironmentList.jsx
@@ -254,7 +254,7 @@ const EnvironmentList = (props) => {
             </>
           )}
         </span>,
-        <span>{environmentBuild ? environmentBuild.status : ""}</span>,
+        <span>{environmentBuild ? environmentBuild.status : "UNBUILT"}</span>,
       ]);
     }
     return listData;

--- a/services/orchest-webserver/client/src/components/EnvironmentList.jsx
+++ b/services/orchest-webserver/client/src/components/EnvironmentList.jsx
@@ -254,7 +254,7 @@ const EnvironmentList = (props) => {
             </>
           )}
         </span>,
-        <span>{environmentBuild ? environmentBuild.status : "UNBUILT"}</span>,
+        <span>{environmentBuild ? environmentBuild.status : "NOT BUILT"}</span>,
       ]);
     }
     return listData;


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->

Fixes: #367 

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
