### PR TITLE
Environment variables name validation

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -216,6 +216,17 @@ def docker_images_rm_safe(docker_client, *args, attempt_count=10, **kwargs):
         time.sleep(1)
 
 
+def are_environment_variables_valid(env_variables: Dict[str, str]) -> bool:
+    return isinstance(env_variables, dict) and all(
+        [
+            isinstance(var, str)
+            and re.match(r"^[0-9a-zA-Z\-_]+$", var)
+            and isinstance(value, str)
+            for var, value in env_variables.items()
+        ]
+    )
+
+
 def is_service_name_valid(service_name: str) -> bool:
     # NOTE: this is enforced at the GUI level as well, needs to be kept
     # in sync.
@@ -254,13 +265,7 @@ def is_service_definition_valid(service: Dict[str, Any]) -> bool:
                 for var in service.get("env_variables_inherit", [])
             ]
         )
-        and isinstance(service.get("env_variables", {}), dict)
-        and all(
-            [
-                isinstance(var, str) and isinstance(value, str) and var
-                for var, value in service.get("env_variables", {}).items()
-            ]
-        )
+        and are_environment_variables_valid(service.get("env_variables", {}))
     )
 
 

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -219,12 +219,19 @@ def docker_images_rm_safe(docker_client, *args, attempt_count=10, **kwargs):
 def are_environment_variables_valid(env_variables: Dict[str, str]) -> bool:
     return isinstance(env_variables, dict) and all(
         [
-            isinstance(var, str)
-            and re.match(r"^[0-9a-zA-Z\-_]+$", var)
-            and isinstance(value, str)
+            is_env_var_name_valid(var) and isinstance(value, str)
             for var, value in env_variables.items()
         ]
     )
+
+
+def is_env_var_name_valid(name: str) -> bool:
+    # Needs to be kept in sync with the FE.
+    return isinstance(name, str) and re.match(r"^[0-9a-zA-Z\-_]+$", name)
+
+
+def make_env_var_name_valid(name: str) -> str:
+    return re.sub("[^0-9a-zA-Z\-_]", "_", name)
 
 
 def is_service_name_valid(service_name: str) -> bool:
@@ -261,7 +268,7 @@ def is_service_definition_valid(service: Dict[str, Any]) -> bool:
         and isinstance(service.get("env_variables_inherit", []), list)
         and all(
             [
-                isinstance(var, str) and var
+                is_env_var_name_valid(var)
                 for var in service.get("env_variables_inherit", [])
             ]
         )

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import joinedload, undefer
 
 import app.models as models
 from _orchest.internals import config as _config
+from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import schema
 from app.celery_app import make_celery
@@ -688,6 +689,8 @@ class UpdateJob(TwoPhaseFunction):
                         "a job which is not a cron job."
                     )
                 )
+            if not _utils.are_environment_variables_valid(env_variables):
+                raise ValueError(("Invalid environment variables definition."))
             job.env_variables = env_variables
 
         if next_scheduled_time is not None:

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -690,7 +690,7 @@ class UpdateJob(TwoPhaseFunction):
                     )
                 )
             if not _utils.are_environment_variables_valid(env_variables):
-                raise ValueError(("Invalid environment variables definition."))
+                raise ValueError("Invalid environment variables definition.")
             job.env_variables = env_variables
 
         if next_scheduled_time is not None:

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -8,6 +8,7 @@ from flask_restx import Namespace, Resource
 from sqlalchemy.orm import undefer
 
 import app.models as models
+from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import schema
 from app.apis.namespace_environment_images import DeleteProjectEnvironmentImages
@@ -36,9 +37,11 @@ class ProjectList(Resource):
     @api.marshal_with(schema.project)
     def post(self):
         """Create a new project."""
+        project = request.get_json()
+        project["env_variables"] = project.get("env_variables", {})
+        if not _utils.are_environment_variables_valid(project["env_variables"]):
+            return {"message": ("Invalid environment variables definition.")}, 400
         try:
-            project = request.get_json()
-            project["env_variables"] = project.get("env_variables", {})
             db.session.add(models.Project(**project))
             db.session.commit()
         except Exception as e:
@@ -68,9 +71,14 @@ class Project(Resource):
     @api.doc("update_project")
     def put(self, project_uuid):
         """Update a project."""
+        req_json = request.get_json()
+        if not _utils.are_environment_variables_valid(
+            req_json.get("env_variables", {})
+        ):
+            return {"message": ("Invalid environment variables definition.")}, 400
 
         try:
-            models.Project.query.filter_by(uuid=project_uuid).update(request.get_json())
+            models.Project.query.filter_by(uuid=project_uuid).update(req_json)
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/services/orchest-api/app/tests/namespaces/test_namespace_jobs.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_jobs.py
@@ -18,12 +18,12 @@ def test_joblist_get_empty(client, query_string):
 
 @pytest.mark.parametrize(
     "proj_env_variables",
-    [{}, {"var1": "project-value", "var2": 10}],
+    [{}, {"var1": "project-value", "var2": "10"}],
     ids=["no-proj-variables", "proj-variables"],
 )
 @pytest.mark.parametrize(
     "pipe_env_variables",
-    [{}, {"var1": "pipeline-value", "var3": [1]}],
+    [{}, {"var1": "pipeline-value", "var3": "[1]"}],
     ids=["no-pipe-variables", "pipe-variables"],
 )
 @pytest.mark.parametrize(
@@ -101,12 +101,12 @@ def test_job_get_empty(client):
 def test_job_get_exist(client, pipeline):
     project = pipeline.project
 
-    proj_env_variables = {"var1": 1, "var2": 2}
+    proj_env_variables = {"var1": "1", "var2": "2"}
     client.put(
         f"/api/projects/{project.uuid}", json={"env_variables": proj_env_variables}
     )
 
-    pipe_env_variables = {"var2": ["hello"], "var3": {}}
+    pipe_env_variables = {"var2": '["hello"]', "var3": "{}"}
     client.put(
         f"/api/pipelines/{project.uuid}/{pipeline.uuid}",
         json={"env_variables": pipe_env_variables},
@@ -123,7 +123,7 @@ def test_job_get_exist(client, pipeline):
 
 @pytest.mark.parametrize(
     "env_variables",
-    [None, {}, {"var1": "project-value", "var2": 10}],
+    [None, {}, {"var1": "project-value", "var2": "10"}],
     ids=["no-env-variables", "empty-env-variables", "env-variables"],
 )
 @pytest.mark.parametrize(

--- a/services/orchest-api/app/tests/namespaces/test_namespace_pipelines.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_pipelines.py
@@ -11,7 +11,7 @@ def test_pipelinelist_post(client, project):
     pipeline = {
         "project_uuid": project.uuid,
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
     client.post("/api/pipelines/", json=pipeline)
 
@@ -26,7 +26,7 @@ def test_pipelinelist_post_no_project(client):
     pipeline = {
         "project_uuid": gen_uuid(),
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
     resp = client.post("/api/pipelines/", json=pipeline)
 
@@ -37,7 +37,7 @@ def test_pipelinelist_post_same_uuid(client, project):
     pipeline = {
         "project_uuid": project.uuid,
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
 
     resp1 = client.post("/api/pipelines/", json=pipeline)
@@ -53,7 +53,7 @@ def test_pipelinelist_post_n(client, project):
         pipeline = {
             "project_uuid": project.uuid,
             "uuid": gen_uuid(),
-            "env_variables": {"a": [1]},
+            "env_variables": {"a": "[1]"},
         }
         client.post("/api/pipelines/", json=pipeline)
 
@@ -65,7 +65,7 @@ def test_pipeline_get(client, project):
     pipeline = {
         "project_uuid": project.uuid,
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
     client.post("/api/pipelines/", json=pipeline)
 
@@ -84,11 +84,11 @@ def test_pipeline_put(client, project):
     pipeline = {
         "project_uuid": project.uuid,
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
     client.post("/api/pipelines/", json=pipeline)
 
-    pipeline["env_variables"] = {"b": {"x": 1}}
+    pipeline["env_variables"] = {"b": '{"x": ""}'}
     client.put(f'/api/pipelines/{project.uuid}/{pipeline["uuid"]}', json=pipeline)
 
     data = client.get(f'/api/pipelines/{project.uuid}/{pipeline["uuid"]}').get_json()
@@ -105,7 +105,7 @@ def test_delete_existing(client, project):
     pipeline = {
         "project_uuid": project.uuid,
         "uuid": gen_uuid(),
-        "env_variables": {"a": [1]},
+        "env_variables": {"a": "[1]"},
     }
 
     client.post("/api/pipelines/", json=pipeline)

--- a/services/orchest-api/app/tests/namespaces/test_namespace_projects.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_projects.py
@@ -9,7 +9,7 @@ def test_projectlist_get_empty(client):
 
 
 def test_projectlist_post(client):
-    project = {"uuid": gen_uuid(), "env_variables": {"a": [1]}}
+    project = {"uuid": gen_uuid(), "env_variables": {"a": "[1]"}}
 
     client.post("/api/projects/", json=project)
     data = client.get("/api/projects/").get_json()["projects"][0]
@@ -20,7 +20,7 @@ def test_projectlist_post(client):
 
 
 def test_projectlist_post_same_uuid(client):
-    project = {"uuid": gen_uuid(), "env_variables": {"a": [1]}}
+    project = {"uuid": gen_uuid(), "env_variables": {"a": "   [1]   "}}
     resp1 = client.post("/api/projects/", json=project)
     resp2 = client.post("/api/projects/", json=project)
 
@@ -31,7 +31,7 @@ def test_projectlist_post_same_uuid(client):
 def test_projectlist_post_n(client):
     n = 5
     for _ in range(n):
-        project = {"uuid": gen_uuid(), "env_variables": {"a": [1]}}
+        project = {"uuid": gen_uuid(), "env_variables": {"a": "[1]"}}
         client.post("/api/projects/", json=project)
 
     data = client.get("/api/projects/").get_json()["projects"]
@@ -39,7 +39,7 @@ def test_projectlist_post_n(client):
 
 
 def test_project_get(client):
-    project = {"uuid": gen_uuid(), "env_variables": {"a": [1]}}
+    project = {"uuid": gen_uuid(), "env_variables": {"a": "[1]"}}
 
     client.post("/api/projects/", json=project)
     data = client.get(f'/api/projects/{project["uuid"]}').get_json()
@@ -54,10 +54,10 @@ def test_project_get_non_existent(client):
 
 
 def test_project_put(client):
-    project = {"uuid": gen_uuid(), "env_variables": {"a": [1]}}
+    project = {"uuid": gen_uuid(), "env_variables": {"a": "[1]"}}
 
     client.post("/api/projects/", json=project)
-    project["env_variables"] = {"b": {"x": 1}}
+    project["env_variables"] = {"b": '{"x": ""}'}
     client.put(f'/api/projects/{project["uuid"]}', json=project)
 
     data = client.get(f'/api/projects/{project["uuid"]}').get_json()

--- a/services/orchest-api/app/tests/namespaces/test_namespace_runs.py
+++ b/services/orchest-api/app/tests/namespaces/test_namespace_runs.py
@@ -33,12 +33,12 @@ def test_runlist_post_success(client, celery, pipeline):
 
 def test_runlist_post_success_env_vars(client, celery, pipeline):
     # Prepare proj/pipeline env variables.
-    proj_env_vars = {"var1": 1, "var2": 2}
+    proj_env_vars = {"var1": "1", "var2": "2"}
     client.put(
         f"/api/projects/{pipeline.project.uuid}", json={"env_variables": proj_env_vars}
     )
 
-    pipe_env_vars = {"var2": "overwritten", "var3": 3}
+    pipe_env_vars = {"var2": "overwritten", "var3": "3"}
     client.put(
         f"/api/pipelines/{pipeline.project.uuid}/{pipeline.uuid}",
         json={"env_variables": pipe_env_vars},

--- a/services/orchest-webserver/app/app/compat.py
+++ b/services/orchest-webserver/app/app/compat.py
@@ -1,8 +1,40 @@
+from _orchest.internals import utils as _utils
+
+
 def migrate_pipeline(pipeline):
 
     # Take care of old pipelines with no defined params.
     if "parameters" not in pipeline:
         pipeline["parameters"] = {}
+
+    # Pipelines had no constraints related to env var names.
+    services = pipeline.get("services", {})
+    for service in services.values():
+        env_variables = service.get("env_variables", {})
+
+        if not _utils.are_environment_variables_valid(env_variables):
+            tmp = {}
+            for key, value in env_variables.items():
+                valid_key = _utils.make_env_var_name_valid(key)
+
+                # Do not lose variables to collisions.
+                i = 2
+                while valid_key in tmp:
+                    valid_key = f"{valid_key}_{i}"
+                    i += 1
+                tmp[valid_key] = value
+            service["env_variables"] = tmp
+
+        env_vars_inherit = service.get("env_variables_inherit", [])
+        tmp = set()
+        for var in env_vars_inherit:
+            valid_var = _utils.make_env_var_name_valid(var)
+            i = 2
+            while valid_var in tmp:
+                valid_var = f"{valid_var}_{i}"
+                i += 1
+            tmp.add(valid_var)
+        service["env_variables_inherit"] = list(tmp)
 
     for step in pipeline["steps"].values():
         if (

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -746,8 +746,7 @@ def register_views(app, db):
                     404,
                 )
             else:
-                with open(pipeline_json_path, "r") as json_file:
-                    pipeline_json = json.load(json_file)
+                pipeline_json = get_pipeline_json(pipeline_uuid, project_uuid)
 
                 # json.dumps because the front end expects it as a
                 # string.

--- a/services/orchest-webserver/client/src/components/EnvVarList.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarList.tsx
@@ -5,6 +5,8 @@ import {
   MDCTextFieldReact,
 } from "@orchest/lib-mdc";
 
+import { isValidEnvironmentVariableName } from "@/utils/webserver-utils";
+
 export interface IEnvVarListProps {
   value?: any;
   onChange?: any;
@@ -30,10 +32,14 @@ export const EnvVarList: React.FC<IEnvVarListProps> = (props) => (
           <li key={idx}>
             <MDCTextFieldReact
               value={pair["name"]}
-              onChange={(e) => props.onChange(e, idx, "name")}
+              onChange={(e) => {
+                props.onChange(e, idx, "name");
+              }}
               label="Name"
               disabled={props.readOnly === true}
-              classNames={["column push-down push-right"]}
+              classNames={["column push-down push-right"].concat(
+                isValidEnvironmentVariableName(pair["name"]) ? [] : ["invalid"]
+              )}
             />
             <MDCTextFieldReact
               value={pair["value"]}

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -570,6 +570,13 @@ p > i.material-icons.float-left {
   padding-bottom: var(--space-5);
 }
 
+.mdc-text-field.invalid {
+  &:not(.mdc-text-field--disabled) .mdc-text-field__input,
+  &:not(.mdc-text-field--disabled) .mdc-floating-label {
+    color: var(--colors-red700);
+  }
+}
+
 // rounded notched buttons
 .mdc-text-field--outlined {
   .mdc-text-field__input {
@@ -1063,7 +1070,7 @@ span.floating-button {
   padding: calc(var(--space-5) / 2);
   border-radius: 3px;
   color: #fff;
-  background: #b00020;
+  background: var(--color-red700);
   font-size: 15px;
 
   .material-icons {

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -109,6 +109,10 @@ export function componentName(TagName) {
   }
 }
 
+export function isValidEnvironmentVariableName(name) {
+  return /^[0-9a-zA-Z\-_]+$/gm.test(name);
+}
+
 export function validatePipeline(pipelineJson) {
   let errors = [];
 

--- a/services/orchest-webserver/client/src/views/EditJobView.tsx
+++ b/services/orchest-webserver/client/src/views/EditJobView.tsx
@@ -18,6 +18,7 @@ import {
   getPipelineJSONEndpoint,
   envVariablesArrayToDict,
   envVariablesDictToArray,
+  isValidEnvironmentVariableName,
 } from "@/utils/webserver-utils";
 import type { TViewProps } from "@/types";
 import { useOrchest } from "@/hooks/orchest";
@@ -312,6 +313,7 @@ const EditJobView: React.FC<TViewProps> = (props) => {
     if (state.selectedIndices.reduce((acc, val) => acc + val, 0) == 0) {
       return {
         pass: false,
+        selectView: 3,
         reason:
           "You selected 0 pipeline runs. Please choose at least one pipeline run configuration.",
       };
@@ -323,8 +325,20 @@ const EditJobView: React.FC<TViewProps> = (props) => {
     } catch (err) {
       return {
         pass: false,
+        selectView: 0,
         reason: "Invalid cron schedule: " + state.cronString,
       };
+    }
+
+    // Valid environment variables
+    for (let envPair of state.envVariables) {
+      if (!isValidEnvironmentVariableName(envPair.name)) {
+        return {
+          pass: false,
+          selectView: 2,
+          reason: 'Invalid environment variable name: "' + envPair.name + '"',
+        };
+      }
     }
 
     return { pass: true };
@@ -333,11 +347,13 @@ const EditJobView: React.FC<TViewProps> = (props) => {
   const attemptRunJob = () => {
     // validate job configuration
     let validation = validateJobConfig();
-
     if (validation.pass === true) {
       runJob();
     } else {
       orchest.alert("Error", validation.reason);
+      if (validation.selectView !== undefined) {
+        onSelectSubview(validation.selectView);
+      }
     }
   };
 
@@ -480,6 +496,9 @@ const EditJobView: React.FC<TViewProps> = (props) => {
         });
     } else {
       orchest.alert("Error", validation.reason);
+      if (validation.selectView !== undefined) {
+        onSelectSubview(validation.selectView);
+      }
     }
   };
 

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
@@ -14,6 +14,7 @@ import {
   envVariablesArrayToDict,
   envVariablesDictToArray,
   OverflowListener,
+  isValidEnvironmentVariableName,
 } from "@/utils/webserver-utils";
 import PipelinesView from "@/views/PipelinesView";
 import JobsView from "@/views/JobsView";
@@ -70,6 +71,17 @@ const ProjectSettingsView: React.FC<TViewProps> = (props) => {
     // Do not go through if env variables are not correctly defined.
     if (envVariables === undefined) {
       return;
+    }
+
+    // Validate environment variable names
+    for (let envVariableName of Object.keys(envVariables)) {
+      if (!isValidEnvironmentVariableName(envVariableName)) {
+        orchest.alert(
+          "Error",
+          'Invalid environment variable name: "' + envVariableName + '".'
+        );
+        return;
+      }
     }
 
     // perform PUT to update


### PR DESCRIPTION
## Description
Adds validation to environment variable names.
Fixes: #376 

@joe-bell, when it comes to the front end, the following things needs to be validated:
- project env variables
- pipeline env variables
- jobs env variables
- services env variables and inherited env variables

Only the name of environment variables needs to be validated. The backend considers `^[0-9a-zA-Z\-_]+$` as valid, the BE and the FE are to be in sync with this.

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

