### PR TITLE
Fix query args passing at `/login`

### DIFF
--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -142,6 +142,9 @@ def register_views(app):
                     db.session.commit()
 
                     redirect_url = request.args.get("redirect_url", "/")
+                    import_url = request.args.get("import_url")
+                    if import_url is not None:
+                        redirect_url += "?" + "import_url=" + import_url
 
                     resp = redirect_response(redirect_url, redirect_type)
                     resp.set_cookie("auth_token", token.token)

--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -141,10 +141,15 @@ def register_views(app):
                     db.session.add(token)
                     db.session.commit()
 
-                    redirect_url = request.args.get("redirect_url", "/")
-                    import_url = request.args.get("import_url")
-                    if import_url is not None:
-                        redirect_url += "?" + "import_url=" + import_url
+                    # Returns a shallow mutable copy of the immutable
+                    # multi dict.
+                    request_args = request.args.copy()
+                    redirect_url = request_args.pop("redirect_url", "/")
+                    query_args = "&".join(
+                        [arg + "=" + value for arg, value in request_args.items()]
+                    )
+                    if query_args:
+                        redirect_url += "?" + query_args
 
                     resp = redirect_response(redirect_url, redirect_type)
                     resp.set_cookie("auth_token", token.token)

--- a/services/auth-server/client/src/App.tsx
+++ b/services/auth-server/client/src/App.tsx
@@ -25,13 +25,18 @@ export default class App extends React.Component {
   }
 
   render() {
+    const view = window.location.pathname.split("/")[1];
+    const urlSearchParams = new URLSearchParams(window.location.search);
+    const queryArgs = urlSearchParams.toString();
+
     if (this.state.config) {
-      switch (this.props.view) {
+      switch (view) {
         case "login":
           return (
             <Login
               cloud={this.state.config.CLOUD}
               cloudURL={this.state.config.CLOUD_URL}
+              queryArgs={queryArgs}
             />
           );
         case "admin":

--- a/services/auth-server/client/src/App.tsx
+++ b/services/auth-server/client/src/App.tsx
@@ -25,18 +25,14 @@ export default class App extends React.Component {
   }
 
   render() {
-    const view = window.location.pathname.split("/")[1];
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const queryArgs = urlSearchParams.toString();
-
     if (this.state.config) {
-      switch (view) {
+      switch (this.props.view) {
         case "login":
           return (
             <Login
               cloud={this.state.config.CLOUD}
               cloudURL={this.state.config.CLOUD_URL}
-              queryArgs={queryArgs}
+              queryArgs={this.props.queryArgs}
             />
           );
         case "admin":

--- a/services/auth-server/client/src/main.tsx
+++ b/services/auth-server/client/src/main.tsx
@@ -4,11 +4,10 @@ import App from "./App";
 import "./styles/main.scss";
 
 // Get path components
-let view = window.location.href.split("/").slice(-1)[0];
 let reactRoot = document.getElementById("root");
 
 ReactDOM.render(
   // @ts-ignore
-  <App view={view} />,
+  <App />,
   reactRoot
 );

--- a/services/auth-server/client/src/main.tsx
+++ b/services/auth-server/client/src/main.tsx
@@ -4,10 +4,13 @@ import App from "./App";
 import "./styles/main.scss";
 
 // Get path components
+const view = window.location.pathname.split("/")[1];
+const urlSearchParams = new URLSearchParams(window.location.search);
+const queryArgs = urlSearchParams.toString();
 let reactRoot = document.getElementById("root");
 
 ReactDOM.render(
   // @ts-ignore
-  <App />,
+  <App view={view} queryArgs={queryArgs} />,
   reactRoot
 );

--- a/services/auth-server/client/src/views/Login.tsx
+++ b/services/auth-server/client/src/views/Login.tsx
@@ -21,7 +21,8 @@ export default class Login extends React.Component {
     formData.append("username", this.state.username);
     formData.append("password", this.state.password);
 
-    makeRequest("POST", "/login/submit", {
+    let queryString = this.props.queryArgs ? "?" + this.props.queryArgs : "";
+    makeRequest("POST", "/login/submit" + queryString, {
       type: "FormData",
       content: formData,
     })


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

The view to load (either `login` or `admin`) in the `auth-server` was determined by 
```javascript
let view = window.location.href.split("/").slice(-1)[0];
```
which incorrectly handles URLs such as `http://localhost:8000/login?redirect_url=/environments` (`view` would be `environments`).

This PR fixes the issue, making the following possible again:
* http://localhost:8000/login?redirect_url=/environments
*  http://localhost:8000/login?redirect_url=/projects&import_url=https://github.com/orchest/quickstart

> FYI the issue was (unknowingly) reintroduced in a6770357512250425ac927aa1cae6227ed760f1f.
