### PR TITLE
Extend and cleanup Onboarding Spec

### DIFF
--- a/services/orchest-webserver/client/src/views/HelpView.tsx
+++ b/services/orchest-webserver/client/src/views/HelpView.tsx
@@ -83,6 +83,7 @@ const HelpView: React.FC = () => {
         </div>
         <h2 className="push-up">Introduction</h2>
         <MDCButtonReact
+          data-test-id="onboarding-open"
           onClick={() => {
             setIsOnboardingDialogOpen(true);
           }}


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->

1. Cleans up existing onboarding spec to make use of `before` and other hooks more efficiently – which encourages grouping in a more logical manner
2. Extend onboarding spec to check toggling in `/help`

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [ ] The documentation reflects the changes.
- [ ] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
