### PR TITLE
Align all Stitches usage to styled API

### DIFF
--- a/lib/design-system/package/src/components/alert.tsx
+++ b/lib/design-system/package/src/components/alert.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useId } from "@radix-ui/react-id";
 import { styled } from "../core";
 import {
-  icon,
+  Icon,
   IconChevronLeftOutline,
   IconChevronRightOutline,
 } from "../icons";
@@ -118,7 +118,7 @@ const StyledAlertHeader = styled("p", {
   display: "flex",
   alignItems: "center",
   fontWeight: "$bold",
-  [`> .${icon}, > svg:not([class])`]: {
+  [`> ${Icon}, > svg:not([class])`]: {
     display: "inline-flex",
     flexShrink: 0,
     alignSelf: "center",

--- a/lib/design-system/package/src/icons/index.tsx
+++ b/lib/design-system/package/src/icons/index.tsx
@@ -1,14 +1,13 @@
-import { InternalCSS } from "@stitches/core";
 import * as React from "react";
-import { css, config } from "../core";
-import { ExtractVariants, ICSSProp } from "../types";
+import { styled, config } from "../core";
+import { ExtractVariants, ICSSProp, CSS } from "../types";
 
 const getSizes = Object.keys(config.theme.space).reduce(
   (acc, cv) => ({ ...acc, [`${cv}`]: { $$iconSize: `$space$${cv}` } }),
   {}
-) as { [key in keyof typeof config.theme.space]: InternalCSS };
+) as { [key in keyof typeof config.theme.space]: CSS };
 
-export const icon = css({
+export const Icon = styled("svg", {
   color: "currentcolor",
   width: "$$iconSize",
   height: "$$iconSize",
@@ -25,19 +24,15 @@ export const icon = css({
 });
 
 export type IIconRef = SVGSVGElement;
-export interface IIconProps
-  extends ExtractVariants<typeof icon>,
-    ICSSProp,
-    React.SVGProps<IIconRef> {}
+export interface IIconProps extends ExtractVariants<typeof Icon>, ICSSProp {}
 
 export const IconCheckSolid = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -45,17 +40,16 @@ export const IconCheckSolid = React.forwardRef<IIconRef, IIconProps>(
         d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
         clipRule="evenodd"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconCheckCircleOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      className={icon({ className, css, size })}
       fill="none"
       stroke="currentColor"
       {...props}
@@ -66,17 +60,16 @@ export const IconCheckCircleOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconClockOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      className={icon({ className, css, size })}
       fill="none"
       stroke="currentColor"
       {...props}
@@ -87,18 +80,17 @@ export const IconClockOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconClockSolid = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -106,18 +98,17 @@ export const IconClockSolid = React.forwardRef<IIconRef, IIconProps>(
         d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
         clipRule="evenodd"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconCrossSolid = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -125,17 +116,16 @@ export const IconCrossSolid = React.forwardRef<IIconRef, IIconProps>(
         d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
         clipRule="evenodd"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconCrossCircleOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      className={icon({ className, css, size })}
       fill="none"
       stroke="currentColor"
       {...props}
@@ -146,19 +136,18 @@ export const IconCrossCircleOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconChevronLeftOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -167,7 +156,7 @@ export const IconChevronLeftOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M15 19l-7-7 7-7"
       />
-    </svg>
+    </Icon>
   )
 );
 
@@ -175,14 +164,13 @@ export const IconChevronLeftOutline = React.forwardRef<IIconRef, IIconProps>(
 export const IconChevronLeft = IconChevronLeftOutline;
 
 export const IconChevronRightOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -191,7 +179,7 @@ export const IconChevronRightOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M9 5l7 7-7 7"
       />
-    </svg>
+    </Icon>
   )
 );
 
@@ -199,14 +187,13 @@ export const IconChevronRightOutline = React.forwardRef<IIconRef, IIconProps>(
 export const IconChevronRight = IconChevronRightOutline;
 
 export const IconDraftOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ css, className, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -215,34 +202,32 @@ export const IconDraftOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconDraftCircleOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      className={icon({ className, css, size })}
       fill="currentColor"
       {...props}
     >
       <path d="M15.5355 9.8787C15.9261 9.48817 15.9261 8.85501 15.5355 8.46448C15.145 8.07396 14.5118 8.07396 14.1213 8.46448L15.5355 9.8787ZM8.47154 14.1284C8.08101 14.5189 8.08101 15.1521 8.47154 15.5426C8.86206 15.9331 9.49523 15.9331 9.88575 15.5426L8.47154 14.1284ZM18.364 5.63606L17.6569 6.34316L18.364 5.63606ZM14.1213 8.46448L10.2929 12.2929L11.7071 13.7071L15.5355 9.8787L14.1213 8.46448ZM17.6569 17.6569C16.914 18.3997 16.0321 18.989 15.0615 19.3911L15.8268 21.2388C17.0401 20.7363 18.1425 19.9997 19.0711 19.0711L17.6569 17.6569ZM15.0615 19.3911C14.0909 19.7931 13.0506 20 12 20V22C13.3132 22 14.6136 21.7414 15.8268 21.2388L15.0615 19.3911ZM12 20C10.9494 20 9.90914 19.7931 8.93853 19.3911L8.17317 21.2388C9.38642 21.7414 10.6868 22 12 22V20ZM8.93853 19.3911C7.96793 18.989 7.08601 18.3997 6.34315 17.6569L4.92893 19.0711C5.85752 19.9997 6.95991 20.7363 8.17317 21.2388L8.93853 19.3911ZM6.34315 17.6569C5.60028 16.914 5.011 16.0321 4.60896 15.0615L2.7612 15.8269C3.26375 17.0401 4.00035 18.1425 4.92893 19.0711L6.34315 17.6569ZM4.60896 15.0615C4.20693 14.0909 4 13.0506 4 12L2 12C2 13.3132 2.25866 14.6136 2.7612 15.8269L4.60896 15.0615ZM4 12C4 10.9494 4.20693 9.90915 4.60896 8.93855L2.7612 8.17318C2.25866 9.38644 2 10.6868 2 12L4 12ZM4.60896 8.93855C5.011 7.96794 5.60028 7.08603 6.34315 6.34316L4.92893 4.92895C4.00035 5.85753 3.26375 6.95993 2.7612 8.17318L4.60896 8.93855ZM6.34315 6.34316C7.84344 4.84287 9.87827 4.00002 12 4.00002V2.00002C9.34784 2.00002 6.8043 3.05359 4.92893 4.92895L6.34315 6.34316ZM12 4.00002C14.1217 4.00002 16.1566 4.84287 17.6569 6.34316L19.0711 4.92895C17.1957 3.05359 14.6522 2.00002 12 2.00002V4.00002ZM17.6569 6.34316C19.1571 7.84345 20 9.87828 20 12L22 12C22 9.34785 20.9464 6.80431 19.0711 4.92895L17.6569 6.34316ZM20 12C20 14.1217 19.1571 16.1566 17.6569 17.6569L19.0711 19.0711C20.9464 17.1957 22 14.6522 22 12L20 12ZM9.29289 13.3071L8.47154 14.1284L9.88575 15.5426L10.7071 14.7213L9.29289 13.3071Z" />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconLightBulbOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ css, className, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -251,7 +236,7 @@ export const IconLightBulbOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
       />
-    </svg>
+    </Icon>
   )
 );
 
@@ -259,14 +244,13 @@ export const IconLightBulbOutline = React.forwardRef<IIconRef, IIconProps>(
 export const IconLightBulb = IconLightBulbOutline;
 
 export const IconWarningOutline = React.forwardRef<IIconRef, IIconProps>(
-  ({ css, className, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -275,7 +259,7 @@ export const IconWarningOutline = React.forwardRef<IIconRef, IIconProps>(
         strokeWidth={2}
         d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
       />
-    </svg>
+    </Icon>
   )
 );
 
@@ -283,13 +267,12 @@ export const IconWarningOutline = React.forwardRef<IIconRef, IIconProps>(
 export const IconWarning = IconWarningOutline;
 
 export const IconServicesSolid = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -297,6 +280,6 @@ export const IconServicesSolid = React.forwardRef<IIconRef, IIconProps>(
         clipRule="evenodd"
         d="M6.47584 2.80439c.26126-1.07252 1.78755-1.07252 2.04881 0l-.00069.00068a1.05329 1.05329 0 001.57234.65108c.9433-.57476 2.0227.50463 1.4479 1.4479a1.05363 1.05363 0 00-.151.46694 1.05237 1.05237 0 00.077.48469 1.0527 1.0527 0 00.2882.39721c.126.10786.2757.18444.4369.22349 1.0732.25988 1.0732 1.78684 0 2.04741a1.05385 1.05385 0 00-.4366.22372 1.0539 1.0539 0 00-.2881.39716 1.05438 1.05438 0 00.0736.95143c.5748.9433-.5046 2.0227-1.4479 1.4479a1.05319 1.05319 0 00-.4669-.1506 1.05434 1.05434 0 00-.48454.077 1.05361 1.05361 0 00-.6209.7247c-.25988 1.0732-1.78687 1.0732-2.04744 0a1.05312 1.05312 0 00-.22349-.4369 1.0527 1.0527 0 00-.39721-.2882 1.05243 1.05243 0 00-.4847-.077 1.0537 1.0537 0 00-.46696.151c-.94328.5748-2.02269-.5046-1.44792-1.4479a1.053 1.053 0 00.15103-.46692 1.05332 1.05332 0 00-.80211-1.10539c-1.07322-.25988-1.07322-1.78684 0-2.04741.69302-.16844 1.02234-.9632.65108-1.57233-.57477-.94327.50464-2.02266 1.44792-1.4479a1.0533 1.0533 0 001.57168-.65176zM8.9587 8.95852a2.0626 2.0626 0 01-2.91691 0 2.06251 2.06251 0 010-2.91686 2.0626 2.0626 0 012.91691 0 2.06253 2.06253 0 010 2.91686zM14.255 10.585c.19-.78 1.3-.78 1.49 0l-.0005.0005a.76557.76557 0 00.1626.3178.76678.76678 0 00.2888.2096.76795.76795 0 00.3526.056.76625.76625 0 00.3396-.1099c.686-.418 1.471.367 1.053 1.053a.76612.76612 0 00-.1098.3396.76594.76594 0 00.2655.6414.76735.76735 0 00.3178.1626c.7805.189.7805 1.2995 0 1.489a.76619.76619 0 00-.3176.1627.7676.7676 0 00-.2095.2888.76672.76672 0 00.0536.692c.418.686-.367 1.471-1.053 1.053a.76712.76712 0 00-.3396-.1096.76565.76565 0 00-.3524.0561.76658.76658 0 00-.4516.527c-.189.7805-1.2995.7805-1.489 0a.7652.7652 0 00-.1626-.3177.76596.76596 0 00-.2888-.2097.76657.76657 0 00-.6922.0539c-.686.418-1.471-.367-1.053-1.053a.76446.76446 0 00.1098-.3396.76594.76594 0 00-.0559-.3525.76712.76712 0 00-.2096-.2889.76716.76716 0 00-.3178-.1625c-.7805-.189-.7805-1.2995 0-1.489.504-.1226.7435-.7006.4735-1.1436-.418-.686.367-1.471 1.053-1.053.103.0628.2194.1003.3396.1096.1203.0092.241-.01.3524-.0562a.76561.76561 0 00.2887-.2097.76598.76598 0 00.1624-.3177zm1.8057 4.4757A1.5002 1.5002 0 0115 15.5001a1.5002 1.5002 0 01-1.0607-.4394 1.49988 1.49988 0 01-.4393-1.0606c0-.3979.158-.7794.4393-1.0607A1.5002 1.5002 0 0115 12.5c.3978 0 .7794.1581 1.0607.4394s.4393.6628.4393 1.0607c0 .3978-.158.7793-.4393 1.0606z"
       />
-    </svg>
+    </Icon>
   )
 );

--- a/lib/design-system/package/src/logos/index.tsx
+++ b/lib/design-system/package/src/logos/index.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { css } from "../core";
+import { styled } from "../core";
 import type { ExtractVariants, ICSSProp } from "../types";
 
-const logo = css({
+const LogoSvg = styled("svg", {
   include: "box",
   width: "100%",
   height: "auto",
@@ -11,19 +11,15 @@ const logo = css({
 });
 
 export type ILogoRef = SVGSVGElement;
-export interface ILogoProps
-  extends ExtractVariants<typeof logo>,
-    ICSSProp,
-    React.SVGProps<ILogoRef> {}
+export interface ILogoProps extends ExtractVariants<typeof LogoSvg>, ICSSProp {}
 
 export const LogoBrand = React.forwardRef<ILogoRef, ILogoProps>(
-  ({ className, css, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <LogoSvg
       ref={ref}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 330 71"
-      className={logo({ className, css })}
       {...props}
     >
       <title>Orchest</title>
@@ -41,6 +37,6 @@ export const LogoBrand = React.forwardRef<ILogoRef, ILogoProps>(
         stroke="currentColor"
         strokeWidth="5"
       />
-    </svg>
+    </LogoSvg>
   )
 );

--- a/services/orchest-webserver/client/src/components/DescriptionList.tsx
+++ b/services/orchest-webserver/client/src/components/DescriptionList.tsx
@@ -1,18 +1,18 @@
 import * as React from "react";
-import { css, Grid, ICSSProp, TGridVariants } from "@orchest/design-system";
+import { styled, Grid, ICSSProp, TGridVariants } from "@orchest/design-system";
 
-const descriptionPair = css({
+const DescriptionPair = styled("div", {
   include: "box",
   display: "flex",
   flexDirection: "column",
 });
 
-const descriptionTerm = css({
+const DescriptionTerm = styled("dt", {
   include: "box",
   gridRow: 1,
 });
 
-const descriptionDetails = css({
+const DescriptionDetails = styled("dd", {
   fontSize: "$xl",
   lineHeight: "$xl",
 });
@@ -33,10 +33,10 @@ export const DescriptionList: React.FC<IDescriptionListProps> = ({
 }) => (
   <Grid as={DEFAULT_ELEMENT} {...props}>
     {items.map((item, i) => (
-      <div key={i} className={descriptionPair()}>
-        <dt className={descriptionTerm()}>{item.term}</dt>
-        <dd className={descriptionDetails()}>{item.details}</dd>
-      </div>
+      <DescriptionPair key={i}>
+        <DescriptionTerm>{item.term}</DescriptionTerm>
+        <DescriptionDetails>{item.details}</DescriptionDetails>
+      </DescriptionPair>
     ))}
   </Grid>
 );

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialog.tsx
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { m, AnimatePresence } from "framer-motion";
 import { MDCButtonReact } from "@orchest/lib-mdc";
 import {
-  css,
+  styled,
   Box,
   Flex,
   Dialog,
@@ -27,8 +27,8 @@ import {
 } from "./OnboardingDialogCarousel";
 import { useOnboardingDialog } from "./use-onboarding-dialog";
 
-const codeHeader = css({ include: "box", textAlign: "right" });
-const codeHeading = css({
+const CodeHeader = styled("header", { include: "box", textAlign: "right" });
+const CodeHeading = styled("h1", {
   include: "box",
   display: "inline-block",
   padding: "$1 $2",
@@ -39,14 +39,14 @@ const codeHeading = css({
   backgroundColor: "$primary",
   color: "$white",
 });
-const codeWindow = css({
+const CodeWindow = styled("div", {
   include: "box",
   border: "2px $gray300 solid",
   borderRadius: "$md",
   borderTopRightRadius: 0,
   padding: "$1",
 });
-const codeList = css({
+const CodeList = styled("ul", {
   include: "box",
   fontFamily: "monospace",
   textAlign: "left",
@@ -56,7 +56,7 @@ const codeList = css({
   padding: "$2",
   paddingLeft: "$7",
 });
-const codeListItem = css({
+const CodeListItem = styled("li", {
   include: "box",
   fontSize: "$sm",
   lineHeight: "$sm",
@@ -67,13 +67,13 @@ const codeListItem = css({
   },
 });
 
-const iconList = css({
+const IconList = styled("ul", {
   include: "box",
   display: "grid",
   gridTemplateColumns: "repeat(auto-fit, minmax(0, 1fr))",
   gridAutoFlow: "column",
 });
-const iconListItem = css({
+const IconListItem = styled("li", {
   include: "box",
   display: "flex",
   flexDirection: "column",
@@ -168,20 +168,16 @@ export const OnboardingDialog: React.FC = () => {
                         <React.Fragment>
                           <Text>{item.description}</Text>
                           <article>
-                            <header className={codeHeader()}>
-                              <h1 className={codeHeading()}>
-                                {item.code.title}
-                              </h1>
-                            </header>
-                            <div className={codeWindow()}>
-                              <ul role="list" className={codeList()}>
+                            <CodeHeader>
+                              <CodeHeading>{item.code.title}</CodeHeading>
+                            </CodeHeader>
+                            <CodeWindow>
+                              <CodeList role="list">
                                 {item.code.lines.map((line, i) => (
-                                  <li key={line} className={codeListItem()}>
-                                    {line}
-                                  </li>
+                                  <CodeListItem key={line}>{line}</CodeListItem>
                                 ))}
-                              </ul>
-                            </div>
+                              </CodeList>
+                            </CodeWindow>
                           </article>
                         </React.Fragment>
                       )}
@@ -189,12 +185,9 @@ export const OnboardingDialog: React.FC = () => {
                       {item.variant === "icons" && (
                         <React.Fragment>
                           <Text>{item.description}</Text>
-                          <ul className={iconList()}>
+                          <IconList>
                             {item.icons.map(({ icon, label }) => (
-                              <li
-                                key={[icon, label].join("-")}
-                                className={iconListItem()}
-                              >
+                              <IconListItem key={[icon, label].join("-")}>
                                 <i
                                   aria-hidden={true}
                                   className="material-icons"
@@ -202,9 +195,9 @@ export const OnboardingDialog: React.FC = () => {
                                   {icon}
                                 </i>
                                 {label}
-                              </li>
+                              </IconListItem>
                             ))}
-                          </ul>
+                          </IconList>
                         </React.Fragment>
                       )}
 

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/OnboardingDialogCarousel.tsx
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/OnboardingDialogCarousel/OnboardingDialogCarousel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { css, ICSSProp } from "@orchest/design-system";
+import { styled, ICSSProp } from "@orchest/design-system";
 import { m, AnimatePresence } from "framer-motion";
 import { useOnboardingDialogCarousel } from "./use-onboarding-dialog-carousel";
 
@@ -58,21 +58,21 @@ export const OnboardingDialogCarouselSlide = ({ children, ...props }) => {
   );
 };
 
-const indicatorList = css({
+const IndicatorList = styled("ul", {
   include: "box",
   display: "flex",
   width: "100%",
   listStyleType: "none",
   justifyContent: "center",
 });
-const indicatorListItem = css({
+const IndicatorListItem = styled("li", {
   include: "box",
   display: "block",
   "& + &": {
     marginLeft: "$2",
   },
 });
-const indicatorButton = css({
+const IndicatorButton = styled("button", {
   include: "box",
   appearance: "none",
   width: "$space$2",
@@ -94,38 +94,36 @@ const indicatorButton = css({
     },
   },
 });
-const indicatorLabel = css({ include: "screenReaderOnly" });
+const IndicatorLabel = styled("span", { include: "screenReaderOnly" });
 
 interface IOnboardingDialogCarouselIndicatorProps
   extends React.HTMLAttributes<HTMLUListElement>,
     ICSSProp {}
 
-export const OnboardingDialogCarouselIndicator: React.FC<IOnboardingDialogCarouselIndicatorProps> = ({
-  css,
-  className,
-}) => {
+export const OnboardingDialogCarouselIndicator: React.FC<IOnboardingDialogCarouselIndicatorProps> = (
+  props
+) => {
   const { length, slideIndex, setSlide } = useOnboardingDialogCarousel();
 
   return (
-    <ul role="list" className={indicatorList({ css, className })}>
+    <IndicatorList role="list" {...props}>
       {Array(length)
         .fill(0)
         .map((_, i) => (
-          <li
+          <IndicatorListItem
             key={`indicatorListItem-${i}`}
-            className={indicatorListItem()}
             aria-current={i === slideIndex ? "step" : undefined}
           >
-            <button
-              className={indicatorButton({ isCurrent: i === slideIndex })}
+            <IndicatorButton
+              isCurrent={i === slideIndex}
               onClick={() => {
                 if (i !== slideIndex) setSlide([i, slideIndex > i ? -1 : 1]);
               }}
             >
-              <span className={indicatorLabel()}>Slide {i + 1}</span>
-            </button>
-          </li>
+              <IndicatorLabel>Slide {i + 1}</IndicatorLabel>
+            </IndicatorButton>
+          </IndicatorListItem>
         ))}
-    </ul>
+    </IndicatorList>
   );
 };

--- a/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/assets.tsx
+++ b/services/orchest-webserver/client/src/components/Layout/OnboardingDialog/assets.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { css, ExtractVariants, ICSSProp } from "@orchest/design-system";
+import { styled, ExtractVariants, ICSSProp } from "@orchest/design-system";
 
-const svg = css({
+const PipelineDiagramSvg = styled("svg", {
   include: "box",
   display: "block",
   width: "100%",
@@ -10,25 +10,21 @@ const svg = css({
 });
 
 type TPipelineDiagramRef = SVGSVGElement;
-type TPipelineDiagramVariants = ExtractVariants<typeof svg>;
+type TPipelineDiagramVariants = ExtractVariants<typeof PipelineDiagramSvg>;
 
-interface IPipelineDiagramProps
-  extends React.HTMLAttributes<TPipelineDiagramRef>,
-    TPipelineDiagramVariants,
-    ICSSProp {}
+interface IPipelineDiagramProps extends TPipelineDiagramVariants, ICSSProp {}
 
 export const PipelineDiagram = React.forwardRef<
   TPipelineDiagramRef,
   IPipelineDiagramProps
->(({ className, css, ...props }, ref) => (
-  <svg
+>((props, ref) => (
+  <PipelineDiagramSvg
     ref={ref}
     width="366"
     height="192"
     viewBox="0 0 366 192"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    className={svg({ className, css })}
     {...props}
   >
     <title>
@@ -153,5 +149,5 @@ export const PipelineDiagram = React.forwardRef<
         <feBlend in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
       </filter>
     </defs>
-  </svg>
+  </PipelineDiagramSvg>
 ));

--- a/services/orchest-webserver/client/src/components/MultiSelect.tsx
+++ b/services/orchest-webserver/client/src/components/MultiSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {
-  css,
+  styled,
   useId,
   Box,
   IconButton,
@@ -207,7 +207,7 @@ export const MultiSelectLabel: React.FC<{ screenReaderOnly?: boolean }> = ({
   );
 };
 
-const multiSelectInputContainer = css({
+const MultiSelectInputContainer = styled("div", {
   $$borderWidth: "1px",
   include: "box",
   position: "relative",
@@ -238,7 +238,7 @@ const multiSelectInputContainer = css({
   },
 });
 
-const multiSelectInputList = css({
+const MultiSelectInputList = styled("ul", {
   $$gap: "$space$2",
   $$gapOuter: "calc(($$gap * -1) / 2)",
   $$gapInner: "calc($$gap / 2)",
@@ -252,7 +252,7 @@ const multiSelectInputList = css({
   "> li": { margin: "$$gapInner", "&:last-child": { flexGrow: 1 } },
 });
 
-const multiSelectInputChip = css({
+const MultiSelectInputChip = styled("li", {
   include: "box",
   display: "inline-flex",
   alignItems: "center",
@@ -261,7 +261,7 @@ const multiSelectInputChip = css({
   borderRadius: "$rounded",
 });
 
-const multiSelectInputElement = css({
+const MultiSelectInputElement = styled("input", {
   include: "box",
   display: "block",
   width: "100%",
@@ -286,16 +286,13 @@ export const MultiSelectInput: React.FC = () => {
   const inputProps = getInputProps();
 
   return (
-    <div
-      className={multiSelectInputContainer({ hasError: error ? true : false })}
-    >
-      <ul role="list" className={multiSelectInputList()}>
+    <MultiSelectInputContainer hasError={error ? true : false}>
+      <MultiSelectInputList role="list">
         {items.map((selectedItem, index) => (
-          <li
+          <MultiSelectInputChip
             key={index}
             onClick={() => setTabIndex({ index, value: 0 })}
             onBlur={() => setTabIndex({ index, value: -1 })}
-            className={multiSelectInputChip()}
           >
             {selectedItem.value}
             <IconButton
@@ -321,21 +318,17 @@ export const MultiSelectInput: React.FC = () => {
             >
               <IconCrossSolid />
             </IconButton>
-          </li>
+          </MultiSelectInputChip>
         ))}
         <li>
-          <input
-            type="text"
-            className={multiSelectInputElement()}
-            {...inputProps}
-          />
+          <MultiSelectInputElement type="text" {...inputProps} />
         </li>
-      </ul>
-    </div>
+      </MultiSelectInputList>
+    </MultiSelectInputContainer>
   );
 };
 
-const multiSelectError = css({
+const MultiSelectErrorText = styled("div", {
   include: "box",
   marginTop: "$2",
   color: "$error",
@@ -348,11 +341,8 @@ export const MultiSelectError = () => {
   const { error, getErrorProps } = useMultiSelect();
 
   return (
-    <div
-      {...getErrorProps()}
-      className={multiSelectError({ isVisible: error ? true : false })}
-    >
+    <MultiSelectErrorText {...getErrorProps()} isVisible={error ? true : false}>
       {error}
-    </div>
+    </MultiSelectErrorText>
   );
 };

--- a/services/orchest-webserver/client/src/components/ServiceTemplatesDialog/ServiceTemplatesDialog.tsx
+++ b/services/orchest-webserver/client/src/components/ServiceTemplatesDialog/ServiceTemplatesDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   css,
+  styled,
   Dialog,
   DialogBody,
   DialogContent,
@@ -14,7 +15,7 @@ import { MDCButtonReact } from "@orchest/lib-mdc";
 import { templates, IServiceTemplate } from "./content";
 
 // we'll extract this into the design-system later
-const createServiceButton = css({
+const CreateServiceButton = styled("button", {
   appearance: "none",
   display: "inline-flex",
   backgroundColor: "$background",
@@ -60,9 +61,8 @@ export const ServiceTemplatesDialog: React.FC<IServiceTemplatesDialogProps> = ({
               const template = templates[item];
               return (
                 <li key={item}>
-                  <button
+                  <CreateServiceButton
                     disabled={!template.config}
-                    className={createServiceButton()}
                     onClick={(e) => {
                       e.preventDefault();
 
@@ -72,7 +72,7 @@ export const ServiceTemplatesDialog: React.FC<IServiceTemplatesDialogProps> = ({
                   >
                     {template?.icon || <IconServicesSolid />}
                     {template.label}
-                  </button>
+                  </CreateServiceButton>
                 </li>
               );
             })}

--- a/services/orchest-webserver/client/src/icons/index.tsx
+++ b/services/orchest-webserver/client/src/icons/index.tsx
@@ -1,14 +1,13 @@
 import * as React from "react";
-import { icon, IIconRef, IIconProps } from "@orchest/design-system";
+import { Icon, IIconRef, IIconProps } from "@orchest/design-system";
 
 export const IconPostgreSQL = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 64 64"
       fill="none"
-      className={icon({ className, css, size })}
       {...props}
     >
       <g clipPath="url(#clip0)">
@@ -78,18 +77,17 @@ export const IconPostgreSQL = React.forwardRef<IIconRef, IIconProps>(
           <path fill="#fff" transform="translate(1)" d="M0 0h62.09v64H0z" />
         </clipPath>
       </defs>
-    </svg>
+    </Icon>
   )
 );
 
 export const IconRedis = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 64 64"
       fill="none"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -128,18 +126,17 @@ export const IconRedis = React.forwardRef<IIconRef, IIconProps>(
         d="M36.689 17.573l9.635-3.784.007 6.83-.945.366-8.697-3.412z"
         fill="#9A2928"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconStreamlit = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 64 64"
       fill="none"
-      className={icon({ className, css, size })}
       {...props}
     >
       <path
@@ -154,18 +151,17 @@ export const IconStreamlit = React.forwardRef<IIconRef, IIconProps>(
         d="M32.898 15.542c-.496-.723-1.576-.723-2.054 0L20.691 30.64l11.173 5.896 21.175 11.17c.133-.13.24-.256.352-.39.16-.196.308-.407.44-.642L43.043 30.64 32.898 15.542z"
         fill="#BD4043"
       />
-    </svg>
+    </Icon>
   )
 );
 
 export const IconTensorBoard = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 64 64"
       fill="none"
-      className={icon({ className, css, size })}
       {...props}
     >
       <mask
@@ -200,18 +196,17 @@ export const IconTensorBoard = React.forwardRef<IIconRef, IIconProps>(
           <stop offset="1" stopColor="#FFA800" />
         </linearGradient>
       </defs>
-    </svg>
+    </Icon>
   )
 );
 
 export const IconVSCode = React.forwardRef<IIconRef, IIconProps>(
-  ({ className, css, size, ...props }, ref) => (
-    <svg
+  (props, ref) => (
+    <Icon
       ref={ref}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 64 64"
       fill="none"
-      className={icon({ className, css, size })}
       {...props}
     >
       <g clipPath="url(#icon-vscode_clip0)">
@@ -321,6 +316,6 @@ export const IconVSCode = React.forwardRef<IIconRef, IIconProps>(
           <path fill="#fff" d="M0 0h64v64H0z" />
         </clipPath>
       </defs>
-    </svg>
+    </Icon>
   )
 );


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

One side-output of the functional transformation (#266) was solving the dreaded type issues related to `styled` outside of the `@orchest/design-system` package (#279)

Now that this issue has been resolved, it makes sense to align our Stitches strategy and stick to the `styled` API – which comes with "polymorphic" (via the `as` prop) type support out-of-the-box

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
