### PR TITLE
Development Mode Improvements

### DIFF
--- a/lib/design-system/vite-plugin/package.json
+++ b/lib/design-system/vite-plugin/package.json
@@ -28,6 +28,6 @@
     "ts-node": "9.1.1",
     "tsconfig-paths": "3.9.0",
     "typescript": "4.3.2",
-    "vite": "2.3.7"
+    "vite": "2.4.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
       ts-node: 9.1.1
       tsconfig-paths: 3.9.0
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
     dependencies:
       "@orchest/design-system": link:../package
     devDependencies:
@@ -102,7 +102,7 @@ importers:
       ts-node: 9.1.1_typescript@4.3.2
       tsconfig-paths: 3.9.0
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
 
   lib/javascript/mdc:
     specifiers:
@@ -142,7 +142,7 @@ importers:
       react-dom: ^16.13.1
       sass: 1.32.8
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
     dependencies:
       "@orchest/lib-mdc": link:../../../lib/javascript/mdc
       "@orchest/lib-utils": link:../../../lib/javascript/utils
@@ -153,7 +153,7 @@ importers:
       "@vitejs/plugin-react-refresh": 1.3.3
       sass: 1.32.8
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
 
   services/orchest-webserver/client:
     specifiers:
@@ -184,7 +184,7 @@ importers:
       socket.io-client: ^2.3.0
       swr: 0.5.5
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
       vite-plugin-stitches: 0.0.1
       xterm-addon-fit: ^0.4.0
       xterm-for-react: ^1.0.4
@@ -211,7 +211,7 @@ importers:
       react-minimal-pie-chart: 8.2.0_react-dom@16.13.1+react@16.13.1
       socket.io-client: 2.4.0
       swr: 0.5.5_react@16.13.1
-      vite-plugin-stitches: 0.0.1_vite@2.3.7
+      vite-plugin-stitches: 0.0.1_vite@2.4.2
       xterm-addon-fit: 0.4.0
       xterm-for-react: 1.0.4_react-dom@16.13.1+react@16.13.1
     devDependencies:
@@ -220,7 +220,7 @@ importers:
       "@vitejs/plugin-react-refresh": 1.3.3
       sass: 1.32.8
       typescript: 4.3.2
-      vite: 2.3.7
+      vite: 2.4.2
 
 packages:
   /@babel/code-frame/7.12.11:
@@ -2639,10 +2639,10 @@ packages:
     resolution: { integrity: sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw= }
     dev: false
 
-  /esbuild/0.12.7:
+  /esbuild/0.12.15:
     resolution:
       {
-        integrity: sha512-vxENKWBo928ErLiT/uUv8Sl2EoC5cF3cZzCTc8hDEh9ZAZ75xblJCr72NeJo74lxWaGopIePZPIWq1qDpLUHQQ==,
+        integrity: sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==,
       }
     hasBin: true
     requiresBuild: true
@@ -4080,10 +4080,10 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /postcss/8.3.0:
+  /postcss/8.3.5:
     resolution:
       {
-        integrity: sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==,
+        integrity: sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==,
       }
     engines: { node: ^10 || ^12 || >=14 }
     dependencies:
@@ -5233,7 +5233,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-plugin-stitches/0.0.1_vite@2.3.7:
+  /vite-plugin-stitches/0.0.1_vite@2.4.2:
     resolution:
       {
         integrity: sha512-P4wm6NziiXgujnTw+RrWZUAqV9X4GgottMgluEP0ixg46irwWQgnlJmwoPW5CMH3S4bX7Ji+7AvQ2E/0POXAYA==,
@@ -5242,19 +5242,19 @@ packages:
       "@stitches/core": ">= 0.1.0"
       vite: ">= 2.1.5"
     dependencies:
-      vite: 2.3.7
+      vite: 2.4.2
     dev: false
 
-  /vite/2.3.7:
+  /vite/2.4.2:
     resolution:
       {
-        integrity: sha512-Y0xRz11MPYu/EAvzN94+FsOZHbSvO6FUvHv127CyG7mV6oDoay2bw+g5y9wW3Blf8OY3chaz3nc/DcRe1IQ3Nw==,
+        integrity: sha512-2MifxD2I9fjyDmmEzbULOo3kOUoqX90A58cT6mECxoVQlMYFuijZsPQBuA14mqSwvV3ydUsqnq+BRWXyO9Qa+w==,
       }
     engines: { node: ">=12.0.0" }
     hasBin: true
     dependencies:
-      esbuild: 0.12.7
-      postcss: 8.3.0
+      esbuild: 0.12.15
+      postcss: 8.3.5
       resolve: 1.20.0
       rollup: 2.45.1
     optionalDependencies:

--- a/services/auth-server/client/package.json
+++ b/services/auth-server/client/package.json
@@ -21,6 +21,6 @@
     "@vitejs/plugin-react-refresh": "1.3.3",
     "sass": "1.32.8",
     "typescript": "4.3.2",
-    "vite": "2.3.7"
+    "vite": "2.4.2"
   }
 }

--- a/services/auth-server/client/vite.config.ts
+++ b/services/auth-server/client/vite.config.ts
@@ -2,34 +2,29 @@ import path from "path";
 import { defineConfig } from "vite";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 
-// https://vitejs.dev/config/
-export default (conditions) =>
-  defineConfig({
-    plugins: [reactRefresh()],
-    base: "/login/",
-    server: {
-      host: "0.0.0.0",
-      port: 3001,
-      proxy: conditions.mode === "development" && {
-        "^/login/(server-config|submit|users)/*": "http://localhost:8000",
+export default defineConfig((env) => ({
+  plugins: [reactRefresh()],
+  base: "/login/",
+  server: {
+    host: "0.0.0.0",
+    port: 3001,
+    proxy: env.mode === "development" && {
+      "^/login/(server-config|submit|users)/*": "http://localhost:8000",
+    },
+  },
+  define: {
+    global: "window",
+  },
+  resolve: {
+    alias: {
+      "@material": path.resolve(__dirname, "../../../node_modules/@material/"),
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: ["node_modules"],
       },
     },
-    define: {
-      global: "window",
-    },
-    resolve: {
-      alias: {
-        "@material": path.resolve(
-          __dirname,
-          "../../../node_modules/@material/"
-        ),
-      },
-    },
-    css: {
-      preprocessorOptions: {
-        scss: {
-          includePaths: ["node_modules"],
-        },
-      },
-    },
-  });
+  },
+}));

--- a/services/auth-server/client/vite.config.ts
+++ b/services/auth-server/client/vite.config.ts
@@ -11,10 +11,7 @@ export default (conditions) =>
       host: "0.0.0.0",
       port: 3001,
       proxy: conditions.mode === "development" && {
-        "^/login/(server-config|submit|users)/*": {
-          target: "http://localhost:8000",
-          changeOrigin: true,
-        },
+        "^/login/(server-config|submit|users)/*": "http://localhost:8000",
       },
     },
     define: {

--- a/services/auth-server/client/vite.config.ts
+++ b/services/auth-server/client/vite.config.ts
@@ -3,26 +3,36 @@ import { defineConfig } from "vite";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [reactRefresh()],
-  base: "/login/",
-  server: {
-    host: "0.0.0.0",
-    port: 3001,
-  },
-  define: {
-    global: "window",
-  },
-  resolve: {
-    alias: {
-      "@material": path.resolve(__dirname, "../../../node_modules/@material/"),
-    },
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        includePaths: ["node_modules"],
+export default (conditions) =>
+  defineConfig({
+    plugins: [reactRefresh()],
+    base: "/login/",
+    server: {
+      host: "0.0.0.0",
+      port: 3001,
+      proxy: conditions.mode === "development" && {
+        "^/login/(server-config|submit|users)/*": {
+          target: "http://localhost:8000",
+          changeOrigin: true,
+        },
       },
     },
-  },
-});
+    define: {
+      global: "window",
+    },
+    resolve: {
+      alias: {
+        "@material": path.resolve(
+          __dirname,
+          "../../../node_modules/@material/"
+        ),
+      },
+    },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          includePaths: ["node_modules"],
+        },
+      },
+    },
+  });

--- a/services/orchest-webserver/client/package.json
+++ b/services/orchest-webserver/client/package.json
@@ -45,6 +45,6 @@
     "@vitejs/plugin-react-refresh": "1.3.3",
     "sass": "1.32.8",
     "typescript": "4.3.2",
-    "vite": "2.3.7"
+    "vite": "2.4.2"
   }
 }

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -10,18 +10,9 @@ export default (conditions) =>
     server: {
       host: "0.0.0.0",
       proxy: conditions.mode === "development" && {
-        "^/(analytics|api|async|catch|container-file-manager|heartbeat|store|update-server)/*": {
-          target: "http://localhost:8000",
-          changeOrigin: true,
-        },
-        "^/login/*": {
-          target: "http://localhost:3001/login/",
-          changeOrigin: true,
-          rewrite: (path) => {
-            console.log(path.replace("/login", ""));
-            return path.replace("/login", "");
-          },
-        },
+        "^/(analytics|api|async|catch|container-file-manager|heartbeat|store|update-server)/*":
+          "http://localhost:8000",
+        "^/login/*": "http://localhost:3001",
       },
     },
     resolve: {

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -3,35 +3,33 @@ import { defineConfig } from "vite";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 import { vitePluginDesignSystem } from "@orchest/design-system-vite-plugin";
 
-// https://vitejs.dev/config/
-export default (conditions) =>
-  defineConfig({
-    plugins: [reactRefresh(), vitePluginDesignSystem()],
-    server: {
-      host: "0.0.0.0",
-      proxy: conditions.mode === "development" && {
-        "^/(analytics|api|async|catch|container-file-manager|heartbeat|store|update-server)/*":
-          "http://localhost:8000",
-        "^/login/*": "http://localhost:3001",
+export default defineConfig((env) => ({
+  plugins: [reactRefresh(), vitePluginDesignSystem()],
+  server: {
+    host: "0.0.0.0",
+    proxy: env.mode === "development" && {
+      "^/(analytics|api|async|catch|container-file-manager|heartbeat|store|update-server)/*":
+        "http://localhost:8000",
+      "^/login/*": "http://localhost:3001",
+    },
+  },
+  resolve: {
+    alias: [
+      { find: "@", replacement: path.resolve(__dirname, "src") },
+      {
+        find: "@material",
+        replacement: path.resolve(
+          __dirname,
+          "../../../node_modules/@material/"
+        ),
+      },
+    ],
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: ["node_modules"],
       },
     },
-    resolve: {
-      alias: [
-        { find: "@", replacement: path.resolve(__dirname, "src") },
-        {
-          find: "@material",
-          replacement: path.resolve(
-            __dirname,
-            "../../../node_modules/@material/"
-          ),
-        },
-      ],
-    },
-    css: {
-      preprocessorOptions: {
-        scss: {
-          includePaths: ["node_modules"],
-        },
-      },
-    },
-  });
+  },
+}));

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -10,9 +10,17 @@ export default (conditions) =>
     server: {
       host: "0.0.0.0",
       proxy: conditions.mode === "development" && {
-        "^/async/*": {
+        "^/(analytics|api|async|catch|container-file-manager|heartbeat|store|update-server)/*": {
           target: "http://localhost:8000",
           changeOrigin: true,
+        },
+        "^/login/*": {
+          target: "http://localhost:3001/login/",
+          changeOrigin: true,
+          rewrite: (path) => {
+            console.log(path.replace("/login", ""));
+            return path.replace("/login", "");
+          },
         },
       },
     },

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -4,28 +4,35 @@ import reactRefresh from "@vitejs/plugin-react-refresh";
 import { vitePluginDesignSystem } from "@orchest/design-system-vite-plugin";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [reactRefresh(), vitePluginDesignSystem()],
-  server: {
-    host: "0.0.0.0",
-  },
-  resolve: {
-    alias: [
-      { find: "@", replacement: path.resolve(__dirname, "src") },
-      {
-        find: "@material",
-        replacement: path.resolve(
-          __dirname,
-          "../../../node_modules/@material/"
-        ),
-      },
-    ],
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        includePaths: ["node_modules"],
+export default (conditions) =>
+  defineConfig({
+    plugins: [reactRefresh(), vitePluginDesignSystem()],
+    server: {
+      host: "0.0.0.0",
+      proxy: conditions.mode === "development" && {
+        "^/async/*": {
+          target: "http://localhost:8000",
+          changeOrigin: true,
+        },
       },
     },
-  },
-});
+    resolve: {
+      alias: [
+        { find: "@", replacement: path.resolve(__dirname, "src") },
+        {
+          find: "@material",
+          replacement: path.resolve(
+            __dirname,
+            "../../../node_modules/@material/"
+          ),
+        },
+      ],
+    },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          includePaths: ["node_modules"],
+        },
+      },
+    },
+  });


### PR DESCRIPTION
> :warning: **NOT READY FOR REVIEW** :warning:

<!-- Thank you for your contribution, you rock! 💪 -->

## Description

- Switches our development setup to access the Vite server directly, with [proxies](https://vitejs.dev/config/#server-proxy) to the `orchest-webserver` (rather than the other way around)

## To-do

- [x] Add proxies to the Vite configs of `orchest-webserver` and `orchest-authserver`
- [ ] Fix websocket warnings in logs view (not super familiar with how this works)
- [ ] Remove existing proxies in `orchest-webserver`
- [ ] Should we remap `orchest-webserver`'s port in development so that Vite can use `localhost:8000`?   
It might make sense to have the same local URL in development and production (particularly when it comes to Cypress setup)

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [ ] The documentation reflects the changes.
- [ ] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [ ] In case I changed code in the `orchest-sdk`, I updated its version according to [SemVer](https://semver.org/) in its `_version.py` and updated the version compability table in its `README.md`
<!-- For the item below, refer to: `scripts/migration_manager.sh` -->
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.
