### PR TITLE
Allow the user to control the level of job runs parallelism

### DIFF
--- a/docs/source/user_guide/other.rst
+++ b/docs/source/user_guide/other.rst
@@ -18,20 +18,28 @@ Example content:
 .. code-block:: json
 
    {
-     "TELEMETRY_UUID": "69b40767-e315-4953-8a2b-355833e344b8",
+     "AUTH_ENABLED": false,
+     "MAX_JOB_RUNS_PARALLELISM": 1,
      "TELEMETRY_DISABLED": false,
-     "AUTH_ENABLED": false
+     "TELEMETRY_UUID": "69b40767-e315-4953-8a2b-355833e344b8"
    }
 
 Explanation of possible configuration settings:
 
-``TELEMETRY_UUID``
-    UUID to track usage across user sessions.
+``AUTH_ENABLED``
+    Enable authentication, see :ref:`authentication <authentication>`.
+
+``MAX_JOB_RUNS_PARALLELISM``
+    Controls the level of parallelism of job runs. By default, only one
+    run at a time will be executed, across all jobs. You need to restart
+    Orchest for this change to take effect.
+
 ``TELEMETRY_DISABLED``
     Option to disable telemetry completely.
 
-``AUTH_ENABLED``
-    Enable authentication, see :ref:`authentication <authentication>`.
+``TELEMETRY_UUID``
+    UUID to track usage across user sessions.
+
 
 .. note::
    We do not use any third-party to track telemetry, see what telemetry we track and how in `our

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -38,6 +38,11 @@ def run_orchest_ctl(client, command):
                 target="/orchest-host",
                 type="bind",
             ),
+            docker.types.Mount(
+                source=os.environ.get("HOST_CONFIG_DIR"),
+                target="/config",
+                type="bind",
+            ),
         ],
         environment={
             "HOST_CONFIG_DIR": os.environ.get("HOST_CONFIG_DIR"),

--- a/services/orchest-api/celery_daemon_configs/worker_jobs.conf
+++ b/services/orchest-api/celery_daemon_configs/worker_jobs.conf
@@ -14,5 +14,5 @@ command=celery worker
 	-n worker-jobs
 	--statedb /userdir/.orchest/celery-state.db
 	-f celery_jobs.log
-	--concurrency=1
+	--concurrency=%(ENV_MAX_JOB_RUNS_PARALLELISM)s
 	--pidfile="worker-jobs.pid"

--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -332,14 +332,12 @@ def containers_version_dump(
 def orchest_config_dump(path: str) -> None:
     """Get the Orchest config file, with telemetry UUID removed"""
 
-    # Copy the config
-    with open("/config/config.json") as input_json_file:
-        config = json.load(input_json_file)
-        # Removed for privacy.
-        del config["TELEMETRY_UUID"]
+    config = utils.get_orchest_config()
+    # Removed for privacy.
+    del config["TELEMETRY_UUID"]
 
-        with open(os.path.join(path, "config.json"), "w") as output_json_file:
-            json.dump(config, output_json_file)
+    with open(os.path.join(path, "config.json"), "w") as output_json_file:
+        json.dump(config, output_json_file)
 
 
 def health_check_dump(resource_manager: OrchestResourceManager, path: str) -> None:

--- a/services/orchest-ctl/app/spec.py
+++ b/services/orchest-ctl/app/spec.py
@@ -167,6 +167,10 @@ def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
     if env is None:
         env = utils.get_env()
 
+    max_job_runs_parallelism = utils.get_orchest_config().get(
+        "MAX_JOB_RUNS_PARALLELISM", 1
+    )
+
     # name -> request body
     container_config = {
         "orchest-api": {
@@ -209,6 +213,7 @@ def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
             "Image": "orchest/celery-worker:latest",
             "Env": [
                 f'ORCHEST_HOST_GID={env["ORCHEST_HOST_GID"]}',
+                f"MAX_JOB_RUNS_PARALLELISM={max_job_runs_parallelism}",
                 # Set a default log level because supervisor can't deal
                 # with non assigned env variables.
                 "ORCHEST_LOG_LEVEL=INFO",

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -172,6 +172,15 @@ def retry_func(func, _retries=10, _sleep_duration=1, _wait_msg=None, **kwargs) -
     return func_result
 
 
+def get_orchest_config() -> dict:
+    try:
+        with open("/config/config.json") as input_json_file:
+            return json.load(input_json_file)
+    except Exception:
+        echo("Could not find the configuration file.")
+        return {}
+
+
 # orchest <arguments> cmd <arguments>, excluding the use of cmd as an
 # argument, so that "orchest --update update" would match but
 # "orchest update update" would not.

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -31,7 +31,7 @@ from app.connections import db, ma
 from app.kernel_manager import populate_kernels
 from app.models import Project
 from app.socketio_server import register_socketio_broadcast
-from app.utils import get_repo_tag, get_user_conf
+from app.utils import get_repo_tag, get_user_conf, migrate_user_config
 from app.views.analytics import register_analytics_views
 from app.views.background_tasks import register_background_tasks_view
 from app.views.orchest_api import register_orchest_api_views
@@ -64,6 +64,7 @@ def create_app():
 
     # read directory mount based config into Flask config
     try:
+        migrate_user_config()
         conf_data = get_user_conf()
         app.config.update(conf_data)
     except Exception:

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -332,6 +332,16 @@ def get_user_conf_raw():
         current_app.logger.debug(e)
 
 
+def migrate_user_config():
+    config = get_user_conf_raw()
+    if config is None:
+        return
+    config = json.loads(config)
+    if "MAX_JOB_RUNS_PARALLELISM" not in config:
+        config["MAX_JOB_RUNS_PARALLELISM"] = 1
+        save_user_conf_raw(json.dumps(config))
+
+
 def save_user_conf_raw(config):
     try:
         with open("/config/config.json", "w") as f:

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -243,6 +243,14 @@ def register_views(app, db):
                         else:
                             config.pop(setting, None)
 
+                j_run_parall = config.get("MAX_JOB_RUNS_PARALLELISM")
+                if not (isinstance(j_run_parall, int) and j_run_parall > 0):
+                    config["MAX_JOB_RUNS_PARALLELISM"] = 1
+
+                auth = config.get("AUTH_ENABLED")
+                if not isinstance(auth, bool):
+                    config["AUTH_ENABLED"] = False
+
                 # Save the updated configuration.
                 save_user_conf_raw(json.dumps(config))
                 current_config = config

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -30,6 +30,7 @@ const SettingsView: React.FC<TViewProps> = () => {
     configJSON: undefined,
     version: undefined,
     unsavedChanges: false,
+    requiresRestart: false,
   });
   const [promiseManager] = React.useState(new PromiseManager());
 
@@ -42,6 +43,8 @@ const SettingsView: React.FC<TViewProps> = () => {
       setState((prevState) => ({ ...prevState, version: data }));
     });
   };
+
+  const REQUIRES_RESTART_ON_CHANGE = ["MAX_JOB_RUNS_PARALLELISM"];
 
   const getConfig = () => {
     let getConfigPromise = makeCancelable(
@@ -121,6 +124,9 @@ const SettingsView: React.FC<TViewProps> = () => {
         ...prevState,
         configJSON: joinedConfig,
         unsavedChanges: false,
+        requiresRestart: REQUIRES_RESTART_ON_CHANGE.some(
+          (key) => state.configJSON[key] != joinedConfig[key]
+        ),
       }));
 
       makeRequest("POST", "/async/user-config", {
@@ -195,6 +201,7 @@ const SettingsView: React.FC<TViewProps> = () => {
           ...prevState,
           restarting: true,
           status: "restarting",
+          requiresRestart: false,
         }));
 
         makeRequest("POST", "/async/restart")
@@ -313,6 +320,16 @@ const SettingsView: React.FC<TViewProps> = () => {
                           <div className="warning push-up">
                             <i className="material-icons">warning</i> Your input
                             is not valid JSON.
+                          </div>
+                        );
+                      }
+                    })()}
+                    {(() => {
+                      if (state.requiresRestart) {
+                        return (
+                          <div className="warning push-up">
+                            <i className="material-icons">info</i> Restart
+                            Orchest to have the changes take effect.
                           </div>
                         );
                       }


### PR DESCRIPTION
## Description

Allows the user to control the level of parallelism of job runs through the settings. Once the settings are saved Orchest must be restarted for the change to take effect.

### Checklist

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

