### PR TITLE
Add R Orchest SDK docs

### DIFF
--- a/docs/source/user_guide/sdk/R.rst
+++ b/docs/source/user_guide/sdk/R.rst
@@ -1,18 +1,18 @@
 R
 =
 
-Orchest currently does not support a native **R** SDK. You can make use of the
-`reticulate <https://rstudio.github.io/reticulate/>`_ package to interface the python SDK. An example project is
+Orchest currently does not support a native **R** SDK. You can make use of the `reticulate
+<https://rstudio.github.io/reticulate/>`_ package to interface the Python SDK. An example project is
 provided `here <https://github.com/orchest-examples/orchest-pipeline-r-python-mix>`_.
 
-Using Reticulate to interface the Orchest python SDK
-----------------------------------------------------
-First, create an Orchest environment which uses the
-**orchest/base-kernel-r** base image, through said environment you can
-install **reticulate** and configure access to **python** and the **Orchest
-SDK**.  
-You can do so by having a script (let's say **Install.r**) in your project
-with the following content::
+Using ``reticulate`` to interface the Orchest Python SDK
+--------------------------------------------------------
+First, create an Orchest environment which uses the ``orchest/base-kernel-r`` base image (you can
+find more details :ref:`here <environments>`). Next you want to install ``reticulate`` and configure
+access to Python and the Orchest SDK.  You can do so by having a script (let's say ``Install.r``) in
+your project with the following content:
+
+.. code-block:: r
 
    install.packages("reticulate", repos = "http://cran.us.r-project.org")
    library(reticulate)
@@ -26,10 +26,11 @@ with the following content::
 
    print(orchest)
 
-And having the environment set-up script perform ``Rscript Install.r``.
-You will then be able to access the Orchest SDK through R **in every step
-that makes use of this environment** . To do data passing, for example, you
-would do the following::
+and having the environment set-up script perform ``Rscript Install.r``.  You will then be able to
+access the Orchest SDK through R **in every step that makes use of this environment** . To do data
+passing, for example, you would do the following:
+
+.. code-block:: r
 
  library(reticulate);
  python_path <- system("which python", intern=TRUE);
@@ -37,7 +38,9 @@ would do the following::
  orchest <- import("orchest");
  orchest$output(2, name="Test");
 
-In a child step you will be able to retrieve the output::
+In a child step you will be able to retrieve the output:
+
+.. code-block:: r
 
  library(reticulate);
  python_path <- system("which python", intern=TRUE);
@@ -45,6 +48,3 @@ In a child step you will be able to retrieve the output::
  orchest <- import("orchest")
  step_inputs = orchest$get_inputs()
  step_inputs$Test
-
-
-

--- a/docs/source/user_guide/sdk/R.rst
+++ b/docs/source/user_guide/sdk/R.rst
@@ -1,8 +1,8 @@
 R
 =
 
-Orchest currently does not support a native **R** SDK. You can make use of the `reticulate
-<https://rstudio.github.io/reticulate/>`_ package to interface the Python SDK. An example project is
+The Orchest SDK in **R** works through the `reticulate
+<https://rstudio.github.io/reticulate/>`_ package. An example project is
 provided `here <https://github.com/orchest-examples/orchest-pipeline-r-python-mix>`_.
 
 Using ``reticulate`` to interface the Orchest Python SDK

--- a/docs/source/user_guide/sdk/R.rst
+++ b/docs/source/user_guide/sdk/R.rst
@@ -1,0 +1,50 @@
+R
+=
+
+Orchest currently does not support a native **R** SDK. You can make use of the
+`reticulate <https://rstudio.github.io/reticulate/>`_ package to interface the python SDK. An example project is
+provided `here <https://github.com/orchest-examples/orchest-pipeline-r-python-mix>`_.
+
+Using Reticulate to interface the Orchest python SDK
+----------------------------------------------------
+First, create an Orchest environment which uses the
+**orchest/base-kernel-r** base image, through said environment you can
+install **reticulate** and configure access to **python** and the **Orchest
+SDK**.  
+You can do so by having a script (let's say **Install.r**) in your project
+with the following content::
+
+   install.packages("reticulate", repos = "http://cran.us.r-project.org")
+   library(reticulate)
+
+   # Dynamically find system Python
+   python_path <- system("which python", intern=TRUE)
+   use_python(python_path)
+
+   # Pre compile orchest deps
+   orchest <- import("orchest")
+
+   print(orchest)
+
+And having the environment set-up script perform ``Rscript Install.r``.
+You will then be able to access the Orchest SDK through R **in every step
+that makes use of this environment** . To do data passing, for example, you
+would do the following::
+
+ library(reticulate);
+ python_path <- system("which python", intern=TRUE);
+ use_python(python_path);
+ orchest <- import("orchest");
+ orchest$output(2, name="Test");
+
+In a child step you will be able to retrieve the output::
+
+ library(reticulate);
+ python_path <- system("which python", intern=TRUE);
+ use_python(python_path);
+ orchest <- import("orchest")
+ step_inputs = orchest$get_inputs()
+ step_inputs$Test
+
+
+

--- a/docs/source/user_guide/sdk/index.rst
+++ b/docs/source/user_guide/sdk/index.rst
@@ -16,3 +16,4 @@ Convenience wrapper to interact with Orchest. Through code the Orchest SDK, lets
    :caption: Languages
 
    python
+   R


### PR DESCRIPTION
## Description
Updates the `Orchest SDK` section of the docs with a section related to the `R` language, which explains how to interface with the Orchest SDK through `reticulate`.