### PR TITLE
Integrate algolia search into docs

### DIFF
--- a/docs/source/_static/css/custom_styles.css
+++ b/docs/source/_static/css/custom_styles.css
@@ -9,20 +9,20 @@
   display: block;
 }
 
-.sidebar form.search,
-.vp-sidebar form.search {
-  display: flex;
-  justify-content: space-between;
-}
-
 .sidebar form.search input[type="text"],
 .vp-sidebar form.search input[type="text"] {
   padding: 4px;
-  flex: 1;
   min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.sidebar form.search input[type="submit"],
-.vp-sidebar form.search input[type="submit"] {
-  margin-left: 1.5rem;
+#searchbox {
+  width: 100%;
+}
+
+/* Algolia search overlay fix */
+.ds-dropdown-menu {
+  position: fixed !important;
+  top: auto !important;
 }

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,21 @@
+{% extends "sphinx_press_theme/layout.html" %} {% block extrahead %}
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+/>
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+></script>
+<script type="text/javascript">
+  window.document.addEventListener("DOMContentLoaded", function () {
+    docsearch({
+      apiKey: "485712a32cd1f03c2fc8eade49adbb5d",
+      indexName: "orchest",
+      inputSelector: "#doc_search",
+      algoliaOptions: { facetFilters: ["lang:en"] },
+      debug: false, // Set debug to true if you want to inspect the dropdown
+    });
+  });
+</script>
+{% endblock %}

--- a/docs/source/_templates/searchbox.html
+++ b/docs/source/_templates/searchbox.html
@@ -1,32 +1,10 @@
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
-/>
-
 <div id="searchbox" class="searchbox" role="search">
   <div class="caption">
     <span class="caption-text">{{ _('Quick search') }}</span>
     <div class="searchformwrapper">
       <form class="search" action="{{ pathto('search') }}" method="get">
-        <input id="doc_search" type="text" name="q" />
-        <input type="submit" value="{{ _('Search') }}" />
-        <input type="hidden" name="check_keywords" value="yes" />
-        <input type="hidden" name="area" value="default" />
+        <input type="text" id="doc_search" name="q" />
       </form>
     </div>
   </div>
 </div>
-
-<script
-  type="text/javascript"
-  src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
-></script>
-<script type="text/javascript">
-  docsearch({
-    apiKey: "485712a32cd1f03c2fc8eade49adbb5d",
-    indexName: "orchest",
-    inputSelector: "#doc_search",
-    algoliaOptions: { facetFilters: ["lang:en"] },
-    debug: false, // Set debug to true if you want to inspect the dropdown
-  });
-</script>

--- a/docs/source/_templates/searchbox.html
+++ b/docs/source/_templates/searchbox.html
@@ -1,0 +1,32 @@
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+/>
+
+<div id="searchbox" class="searchbox" role="search">
+  <div class="caption">
+    <span class="caption-text">{{ _('Quick search') }}</span>
+    <div class="searchformwrapper">
+      <form class="search" action="{{ pathto('search') }}" method="get">
+        <input id="doc_search" type="text" name="q" />
+        <input type="submit" value="{{ _('Search') }}" />
+        <input type="hidden" name="check_keywords" value="yes" />
+        <input type="hidden" name="area" value="default" />
+      </form>
+    </div>
+  </div>
+</div>
+
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+></script>
+<script type="text/javascript">
+  docsearch({
+    apiKey: "485712a32cd1f03c2fc8eade49adbb5d",
+    indexName: "orchest",
+    inputSelector: "#doc_search",
+    algoliaOptions: { facetFilters: ["lang:en"] },
+    debug: false, // Set debug to true if you want to inspect the dropdown
+  });
+</script>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,6 +71,8 @@ html_theme_options = {
         ("Github", "https://github.com/orchest/orchest"),
     ]
 }
+html_sidebars = {"**": ["searchbox.html", "util/sidetoc.html"]}
+
 
 # Add any paths that contain custom static files (such as style sheets)
 # here, relative to this directory. They are copied after the builtin


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->
**NOTE:** does not work yet!

## Description

Powers the documentations search by algolia.

## Why it did not work -> SOLVED
We use the `press` theme for our docs ([reference](https://github.com/schettino72/sphinx_press_theme)), however in their `layout.html` they have
```html
      <script src="{{ pathto('_static/theme.js', 1)}}" defer></script>
```
which prohibits the search from working. If you comment this line out, then the search works.

To, locally, comment this line out you can:
1. `python -m site` to find your site packages
2. open `sphinx_press_theme/layout.html`

> which prohibits the search from working

Why and how exactly, I do not know...