### PR TITLE
Job Duplication

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,6 +30,7 @@ jobs:
           [
             memory-server,
             orchest-api,
+            orchest-webserver,
             orchest-sdk,
             base-images-runnable,
             orchest-ctl,

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 </p>
 
 <p align="center">
-<a href=https://orchest.readthedocs.io/en/stable><img src="https://readthedocs.org/projects/orchest/badge/?version=latest&style=flat"></a> 
-<a href=https://www.orchest.io/knowledge-base><img src="https://img.shields.io/badge/Video tutorials-blue?style=flat&logo=airplayvideo&labelColor=5c5c5c"></a> 
-<a href=https://orchest.readthedocs.io/en/stable/getting_started/quickstart.html><img src="https://img.shields.io/badge/Quickstart-blue?style=flat&logo=readthedocs&labelColor=5c5c5c&color=fc0373"></a> 
+<a href=https://orchest.readthedocs.io/en/stable><img src="https://readthedocs.org/projects/orchest/badge/?version=latest&style=flat"></a>
+<a href=https://www.orchest.io/knowledge-base><img src="https://img.shields.io/badge/Video tutorials-blue?style=flat&logo=airplayvideo&labelColor=5c5c5c"></a>
+<a href=https://orchest.readthedocs.io/en/stable/getting_started/quickstart.html><img src="https://img.shields.io/badge/Quickstart-blue?style=flat&logo=readthedocs&labelColor=5c5c5c&color=fc0373"></a>
 <a href=https://join.slack.com/t/orchest/shared_invite/zt-g6wooj3r-6XI8TCWJrXvUnXKdIKU_8w><img src="https://img.shields.io/badge/Slack-blue?style=flat&logo=slack&labelColor=5c5c5c"></a>
 </p>
 
@@ -62,7 +62,7 @@ docs](https://orchest.readthedocs.io/en/stable/getting_started/installation.html
 
 #### Linux, macOS and Windows
 
-> Alternatively, signup for the free-of-charge [Orchest Cloud](https://cloud.orchest.io/signup) and 
+> Alternatively, signup for the free-of-charge [Orchest Cloud](https://cloud.orchest.io/signup) and
 > get a fully configured Orchest instance out of the box!
 
 ```bash

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -63,6 +63,7 @@ if [ ${#SERVICES[@]} -eq 0 ]; then
         "orchest-api"
         "orchest-sdk"
         "orchest-ctl"
+        "orchest-webserver"
         "base-images-runnable"
     )
 fi
@@ -161,6 +162,17 @@ do
         TEST_DIR=$DIR/../services/orchest-ctl
         REQ_DIR=$TEST_DIR
         REQ_FILE=$REQ_DIR/requirements-dev.txt
+    fi
+    if [ $SERVICE == "orchest-webserver" ]; then
+
+        if [[ -z "${ORCHEST_TEST_DATABASE_HOST}" ]]; then
+            echo "Setting up local test database..."
+            setup_local_test_db
+        fi
+
+        TEST_DIR=$DIR/../services/orchest-webserver/app
+        REQ_DIR=$TEST_DIR/..
+        REQ_FILE=$REQ_DIR/requirements.txt
     fi
     if [ $SERVICE == "base-images-runnable" ]; then
         TEST_DIR=$DIR/../services/base-images/runnable-shared/runner

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -597,7 +597,9 @@ class CreateJob(TwoPhaseFunction):
             "parameters": job_spec["parameters"],
             "env_variables": get_proj_pip_env_variables(
                 job_spec["project_uuid"], job_spec["pipeline_uuid"]
-            ),
+            )
+            if "env_variables" not in job_spec
+            else job_spec["env_variables"],
             # NOTE: the definition of a service is currently
             # persisted to disk and considered to be versioned,
             # meaning that nothing in there is considered to be

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -25,8 +25,7 @@ from sqlalchemy_utils import create_database, database_exists
 
 from _orchest.internals import config as _config
 from _orchest.internals.utils import _proxy, is_werkzeug_parent
-from app import analytics
-from app.config import CONFIG_CLASS
+from app import analytics, config
 from app.connections import db, ma
 from app.kernel_manager import populate_kernels
 from app.models import Project
@@ -53,7 +52,7 @@ def create_app_managed():
 
 def create_app():
     app = Flask(__name__)
-    app.config.from_object(CONFIG_CLASS)
+    app.config.from_object(config.CONFIG_CLASS)
 
     init_logging()
 
@@ -199,82 +198,7 @@ def create_app():
 
 
 def init_logging():
-
-    logging_config = {
-        "version": 1,
-        "formatters": {
-            "verbose": {
-                "format": (
-                    "%(levelname)s:%(name)s:%(filename)s - [%(asctime)s] - %(message)s"
-                ),
-                "datefmt": "%d/%b/%Y %H:%M:%S",
-            },
-            "minimal": {
-                "format": ("%(levelname)s:%(name)s:%(filename)s - %(message)s"),
-                "datefmt": "%d/%b/%Y %H:%M:%S",
-            },
-        },
-        "handlers": {
-            "console": {
-                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-                "class": "logging.StreamHandler",
-                "formatter": "verbose",
-            },
-            "console-minimal": {
-                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-                "class": "logging.StreamHandler",
-                "formatter": "minimal",
-            },
-            "webserver-file-log": {
-                "level": "INFO",
-                "formatter": "verbose",
-                "class": "logging.FileHandler",
-                "filename": _config.WEBSERVER_LOGS,
-                "mode": "a",
-            },
-        },
-        "root": {
-            "handlers": ["console"],
-            "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-        },
-        "loggers": {
-            # NOTE: this is the name of the Flask app, since we use
-            # ``__name__``. Using ``__name__`` is required for the app
-            # to function correctly. See:
-            # https://blog.miguelgrinberg.com/post/why-do-we-pass-name-to-the-flask-class
-            __name__: {
-                "handlers": ["console"],
-                "propagate": False,
-                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-            },
-            "engineio": {
-                "handlers": ["console"],
-                "level": "ERROR",
-            },
-            "alembic": {
-                "handlers": ["console"],
-                "level": "WARNING",
-            },
-            "werkzeug": {
-                # NOTE: Werkzeug automatically creates a handler at the
-                # level of its logger if none is defined.
-                "level": "INFO",
-                "handlers": ["console-minimal"],
-            },
-            "gunicorn": {
-                "handlers": ["webserver-file-log"],
-                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-                "propagate": False,
-            },
-            "orchest-lib": {
-                "handlers": ["console"],
-                "propagate": False,
-                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
-            },
-        },
-    }
-
-    dictConfig(logging_config)
+    dictConfig(config.CONFIG_CLASS.LOGGING_CONFIG)
 
 
 def register_teardown_request(app):

--- a/services/orchest-webserver/app/app/analytics.py
+++ b/services/orchest-webserver/app/app/analytics.py
@@ -35,6 +35,7 @@ class Event(Enum):
     JOB_CANCEL = "job cancel"
     JOB_CREATE = "job create"
     JOB_DELETE = "job delete"
+    JOB_DUPLICATE = "job duplicate"
     JOB_UPDATE = "job update"
     JUPYTER_BUILD_START = "jupyter-build start"
     JUPYTER_BUILD_CANCEL = "jupyter-build cancel"
@@ -221,6 +222,10 @@ class _Anonymizer:
             "parameterized_runs_count": len(job_def.pop("parameters", [])),
         }
         return derived_properties
+
+    @staticmethod
+    def job_duplicate(event_properties: dict) -> dict:
+        return _Anonymizer.job_create(event_properties)
 
     @staticmethod
     def job_update(event_properties: dict) -> dict:

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -93,6 +93,80 @@ class Config:
 
     RESOURCE_DIR = os.path.join(dir_path, "res")
 
+    LOGGING_CONFIG = {
+        "version": 1,
+        "formatters": {
+            "verbose": {
+                "format": (
+                    "%(levelname)s:%(name)s:%(filename)s - [%(asctime)s] - %(message)s"
+                ),
+                "datefmt": "%d/%b/%Y %H:%M:%S",
+            },
+            "minimal": {
+                "format": ("%(levelname)s:%(name)s:%(filename)s - %(message)s"),
+                "datefmt": "%d/%b/%Y %H:%M:%S",
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "class": "logging.StreamHandler",
+                "formatter": "verbose",
+            },
+            "console-minimal": {
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "class": "logging.StreamHandler",
+                "formatter": "minimal",
+            },
+            "webserver-file-log": {
+                "level": "INFO",
+                "formatter": "verbose",
+                "class": "logging.FileHandler",
+                "filename": _config.WEBSERVER_LOGS,
+                "mode": "a",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+        },
+        "loggers": {
+            # NOTE: this is the name of the Flask app, since we use
+            # ``__name__``. Using ``__name__`` is required for the app
+            # to function correctly. See:
+            # https://blog.miguelgrinberg.com/post/why-do-we-pass-name-to-the-flask-class
+            __name__: {
+                "handlers": ["console"],
+                "propagate": False,
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+            },
+            "engineio": {
+                "handlers": ["console"],
+                "level": "ERROR",
+            },
+            "alembic": {
+                "handlers": ["console"],
+                "level": "WARNING",
+            },
+            "werkzeug": {
+                # NOTE: Werkzeug automatically creates a handler at the
+                # level of its logger if none is defined.
+                "level": "INFO",
+                "handlers": ["console-minimal"],
+            },
+            "gunicorn": {
+                "handlers": ["webserver-file-log"],
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "propagate": False,
+            },
+            "orchest-lib": {
+                "handlers": ["console"],
+                "propagate": False,
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+            },
+        },
+    }
+
 
 class DevelopmentConfig(Config):
     DEBUG = True
@@ -102,6 +176,75 @@ class DevelopmentConfig(Config):
 class TestingConfig(Config):
     # This config is used by the tests.
     TESTING = True
+    TELEMETRY_DISABLED = True
+
+    # No file logging.
+    LOGGING_CONFIG = {
+        "version": 1,
+        "formatters": {
+            "verbose": {
+                "format": (
+                    "%(levelname)s:%(name)s:%(filename)s - [%(asctime)s] - %(message)s"
+                ),
+                "datefmt": "%d/%b/%Y %H:%M:%S",
+            },
+            "minimal": {
+                "format": ("%(levelname)s:%(name)s:%(filename)s - %(message)s"),
+                "datefmt": "%d/%b/%Y %H:%M:%S",
+            },
+        },
+        "handlers": {
+            "console": {
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "class": "logging.StreamHandler",
+                "formatter": "verbose",
+            },
+            "console-minimal": {
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "class": "logging.StreamHandler",
+                "formatter": "minimal",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+        },
+        "loggers": {
+            # NOTE: this is the name of the Flask app, since we use
+            # ``__name__``. Using ``__name__`` is required for the app
+            # to function correctly. See:
+            # https://blog.miguelgrinberg.com/post/why-do-we-pass-name-to-the-flask-class
+            __name__: {
+                "handlers": ["console"],
+                "propagate": False,
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+            },
+            "engineio": {
+                "handlers": ["console"],
+                "level": "ERROR",
+            },
+            "alembic": {
+                "handlers": ["console"],
+                "level": "WARNING",
+            },
+            "werkzeug": {
+                # NOTE: Werkzeug automatically creates a handler at the
+                # level of its logger if none is defined.
+                "level": "INFO",
+                "handlers": ["console-minimal"],
+            },
+            "gunicorn": {
+                "handlers": ["console"],
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+                "propagate": False,
+            },
+            "orchest-lib": {
+                "handlers": ["console"],
+                "propagate": False,
+                "level": os.getenv("ORCHEST_LOG_LEVEL", "INFO"),
+            },
+        },
+    }
 
 
 # ---- CONFIGURATIONS ----

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -75,7 +75,7 @@ class Config:
     TELEMETRY_INTERVAL = 15  # in minutes
 
     # The port nginx will listen on. Necessary for a proper restart.
-    ORCHEST_PORT = os.environ["ORCHEST_PORT"]
+    ORCHEST_PORT = os.getenv("ORCHEST_PORT", 8000)
     CLOUD = _config.CLOUD
     GPU_REQUEST_URL = "https://www.orchest.io/redirect-request-gpu"
 

--- a/services/orchest-webserver/app/app/core/jobs.py
+++ b/services/orchest-webserver/app/app/core/jobs.py
@@ -1,0 +1,300 @@
+import copy
+import json
+import uuid
+from collections import defaultdict
+
+import requests
+from flask import current_app
+
+from _orchest.internals import config as _config
+from app import error
+from app.models import Pipeline, Project
+from app.utils import (
+    create_job_directory,
+    get_environments,
+    get_environments_from_pipeline_json,
+    get_pipeline_json,
+    get_project_directory,
+    pipeline_uuid_to_path,
+)
+
+
+def create_job_spec(config) -> dict:
+    """Returns a job spec given the provided configuration.
+
+    Args: Initial configuration with which the job spec should be built.
+        project_uuid, pipeline_uuid, pipeline_run_spec, pipeline_name,
+        name are required. Optional entries such as env_variables can be
+        used to further customize the initial state of the newly created
+        job.
+
+    Returns:
+        A job spec that can be POSTED to the orchest-api to create a job
+        that is a duplicate of the job identified by the provided
+        job_uuid.
+    """
+    job_spec = copy.deepcopy(config)
+    pipeline_path = pipeline_uuid_to_path(
+        job_spec["pipeline_uuid"], job_spec["project_uuid"]
+    )
+    job_spec["pipeline_run_spec"]["run_config"] = {
+        "host_user_dir": current_app.config["HOST_USER_DIR"],
+        "project_dir": get_project_directory(job_spec["project_uuid"], host_path=True),
+        "pipeline_path": pipeline_path,
+    }
+
+    job_spec["pipeline_definition"] = get_pipeline_json(
+        job_spec["pipeline_uuid"], job_spec["project_uuid"]
+    )
+
+    # Validate whether the pipeline contains environments
+    # that do not exist in the project.
+    project_environments = get_environments(job_spec["project_uuid"])
+    project_environment_uuids = set(
+        [environment.uuid for environment in project_environments]
+    )
+    pipeline_environment_uuids = get_environments_from_pipeline_json(
+        job_spec["pipeline_definition"]
+    )
+
+    missing_environment_uuids = pipeline_environment_uuids - project_environment_uuids
+    if len(missing_environment_uuids) > 0:
+        raise error.EnvironmentsDoNotExist(missing_environment_uuids)
+
+    # Jobs should always have eviction enabled.
+    job_spec["pipeline_definition"]["settings"]["auto_eviction"] = True
+
+    job_uuid = str(uuid.uuid4())
+    job_spec["uuid"] = job_uuid
+    create_job_directory(job_uuid, job_spec["pipeline_uuid"], job_spec["project_uuid"])
+    return job_spec
+
+
+def duplicate_job_spec(job_uuid: str) -> dict:
+    """Returns a job spec to duplicate the provided job.
+
+    Args:
+        job_uuid: UUID of the job to duplicate.
+
+    The project, pipeline, name, schedule, env variables and parameters
+    of the "parent" job are inherited. Env variables are resolved
+    according to the following expression:
+        job_spec["env_variables"] = {
+            **current_project_env_vars,
+            **current_pipeline_env_vars,
+            **parent_env_vars}
+
+    Paremeters are resolved by:
+        - removing parameters that do not exist anymore.
+        - adding new parameters, i.e. parameters that exist in the
+          latest version of the pipeline but do not exist for the job
+          that is being duplicated.
+        - parameters that are not to be removed nor are new, i.e.
+          parameters that exist both for the latest pipeline definition
+          and the job use the values that were defined in the job that
+          is being duplicated.
+        - this is true for both the strategy json and the job
+          parameters, where each job parameter effectively represents
+          the parameterization of a run.
+        - the job parameters are updated in a way that, from the client
+          POV and given the logic in the job view, preserves the runs
+          selection and their ordering, along with the constraint that
+          every run parameterization should be unique.
+
+    Returns:
+        A job spec that can be POSTED to the orchest-api to create a job
+        that is a duplicate of the job identified by the provided
+        job_uuid.
+    """
+    resp = requests.get(
+        f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/jobs/{job_uuid}'
+    )
+    if resp.status_code == 404:
+        raise error.JobDoesNotExist()
+
+    parent_job = resp.json()
+    job_spec = {}
+    job_spec["draft"] = True
+    job_spec["name"] = parent_job["name"]
+    job_spec["cron_schedule"] = parent_job["schedule"]
+    job_spec["project_uuid"] = parent_job["project_uuid"]
+    job_spec["pipeline_uuid"] = parent_job["pipeline_uuid"]
+    job_spec["pipeline_name"] = parent_job["pipeline_name"]
+    job_spec["pipeline_run_spec"] = {"run_type": "full", "uuids": []}
+
+    if (
+        Project.query.filter_by(
+            uuid=job_spec["project_uuid"],
+        ).one_or_none()
+        is None
+    ):
+        raise error.ProjectDoesNotExist()
+
+    if (
+        Pipeline.query.filter_by(
+            uuid=job_spec["pipeline_uuid"],
+            project_uuid=job_spec["project_uuid"],
+        ).one_or_none()
+        is None
+    ):
+        raise error.PipelineDoesNotExist()
+
+    # Resolve env variables.
+    parent_env_vars = parent_job["env_variables"]
+    project_env_vars = requests.get(
+        f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/projects/'
+        f'{job_spec["project_uuid"]}'
+    ).json()["env_variables"]
+    pipeline_env_vars = requests.get(
+        f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/pipelines/'
+        f'{job_spec["project_uuid"]}/{job_spec["pipeline_uuid"]}'
+    ).json()["env_variables"]
+
+    # This will merge the project and pipeline env variables then
+    # add the parent job env vars, overriding existing env variables
+    # and adding env variables that were not part of the project and
+    # pipeline env vars. NOTE: we currently have no way to discern
+    # old env variables that the job inherited from project/pipeline
+    # env variables. If we could, old project/pipeline env vars that
+    # do not exist anymore could be discarded.
+    job_spec["env_variables"] = {
+        **project_env_vars,
+        **pipeline_env_vars,
+        **parent_env_vars,
+    }
+
+    # Resolve parameters.
+    latest_pipeline_def = get_pipeline_json(
+        job_spec["pipeline_uuid"], job_spec["project_uuid"]
+    )
+    latest_pipeline_params = latest_pipeline_def["parameters"]
+    latest_steps_params = {
+        uuid: step["parameters"] for uuid, step in latest_pipeline_def["steps"].items()
+    }
+    st_json = parent_job["strategy_json"]
+    st_json_pipe_params = st_json.get(_config.PIPELINE_PARAMETERS_RESERVED_KEY, {}).get(
+        "parameters", {}
+    )
+
+    # Pipeline parameters that are new w.r.t to the inherited
+    # strategy json.
+    new_pipeline_parameters = {
+        k: v for k, v in latest_pipeline_params.items() if k not in st_json_pipe_params
+    }
+    # Pipeline parameters that exist in the strategy json but that
+    # have been removed from the latest version.
+    removed_pipeline_parameters = {
+        k for k in st_json_pipe_params if k not in latest_pipeline_params
+    }
+    # Steps parameters that are new w.r.t the inherited strategy
+    # json.
+    new_steps_parameters = defaultdict(dict)
+    for latest_step, latest_step_params in latest_steps_params.items():
+        if latest_step not in st_json:
+            new_steps_parameters[latest_step] = copy.deepcopy(latest_step_params)
+        else:
+            st_json_step_parameters = st_json[latest_step]["parameters"]
+            for k, v in latest_step_params.items():
+                if k not in st_json_step_parameters:
+                    new_steps_parameters[latest_step][k] = v
+    # Steps parameters that exist in the strategy json but that have
+    # been removed from the latest version.
+    removed_steps_parameters = defaultdict(set)
+    for st_json_step, st_json_data in st_json.items():
+        if st_json_step == _config.PIPELINE_PARAMETERS_RESERVED_KEY:
+            continue
+        # Check which params of this step have been removed. Also
+        # account if a step has been removed or does not exist
+        # anymore.
+        for param in st_json_data["parameters"]:
+            if (
+                st_json_step not in latest_steps_params
+                or param not in latest_steps_params[st_json_step]
+            ):
+                removed_steps_parameters[st_json_step].add(param)
+
+    # Given the current information, i.e. new and to delete
+    # pipeline/steps parameters, we proceed to modify the strategy
+    # json and job parameters.
+    new_job_params = copy.deepcopy(parent_job["parameters"])
+    new_st_json = copy.deepcopy(parent_job["strategy_json"])
+
+    # Remove removed pipeline parameters.
+    for removed_pipeline_param in removed_pipeline_parameters:
+        del new_st_json[_config.PIPELINE_PARAMETERS_RESERVED_KEY]["parameters"][
+            removed_pipeline_param
+        ]
+        for run_params in new_job_params:
+            del run_params[_config.PIPELINE_PARAMETERS_RESERVED_KEY][
+                removed_pipeline_param
+            ]
+    # Remove removed steps parameters.
+    for step_with_removed_params, removed_params in removed_steps_parameters.items():
+        for p in removed_params:
+            del new_st_json[step_with_removed_params]["parameters"][p]
+        for run_params in new_job_params:
+            for p in removed_params:
+                del run_params[step_with_removed_params][p]
+    # Add new pipeline parameters.
+    if new_pipeline_parameters:
+        # In case there were no pipeline parameters before.
+        if _config.PIPELINE_PARAMETERS_RESERVED_KEY not in new_st_json:
+            d = dict()
+            d["title"] = job_spec["pipeline_name"]
+            d["key"] = _config.PIPELINE_PARAMETERS_RESERVED_KEY
+            d["parameters"] = {}
+            new_st_json[_config.PIPELINE_PARAMETERS_RESERVED_KEY] = d
+        # Expected format for the strategy json.
+        for k, v in new_pipeline_parameters.items():
+            new_st_json[_config.PIPELINE_PARAMETERS_RESERVED_KEY]["parameters"][
+                k
+            ] = json.dumps([v])
+        # Given that we use the default value specified in the
+        # pipeline definition we don't have to combinatorially
+        # generate new run_params.
+        for run_params in new_job_params:
+            if _config.PIPELINE_PARAMETERS_RESERVED_KEY not in run_params:
+                run_params[_config.PIPELINE_PARAMETERS_RESERVED_KEY] = {}
+            run_params[_config.PIPELINE_PARAMETERS_RESERVED_KEY].update(
+                new_pipeline_parameters
+            )
+    # Add new steps parameters.
+    for step_with_new_params, new_step_params in new_steps_parameters.items():
+        if step_with_new_params not in new_st_json:
+            d = dict()
+            d["title"] = latest_pipeline_def["steps"][step_with_new_params]["title"]
+            d["key"] = step_with_new_params
+            d["parameters"] = {}
+            new_st_json[step_with_new_params] = d
+        # Expected format for the strategy json.
+        for k, v in new_step_params.items():
+            new_st_json[step_with_new_params]["parameters"][k] = json.dumps([v])
+        # Given that we use the default value specified in the
+        # pipeline definition we don't have to combinatorially
+        # generate new run_params.
+        for run_params in new_job_params:
+            if step_with_new_params not in run_params:
+                run_params[step_with_new_params] = {}
+            run_params[step_with_new_params].update(new_step_params)
+
+    # Empty pipeline parameters and step parameters must be dropped
+    # from the strategy json and run params.
+    for key in list(new_st_json):
+        if not new_st_json[key]["parameters"]:
+            del new_st_json[key]
+    for run_params in new_job_params:
+        for key in list(run_params):
+            if not run_params[key]:
+                del run_params[key]
+
+    # Lastly, we have to merge run_params that are not unique
+    # anymore, given that the deletion of some step or pipeline
+    # parameters could have caused the loss of uniqueness. Use the
+    # fact that starting with python 3.7 dictionaries preserve the
+    # insertion order to preserve the order when merging.
+    new_job_params = {json.dumps(k, sort_keys=True): None for k in new_job_params}
+    new_job_params = [json.loads(k) for k in new_job_params]
+
+    job_spec["parameters"] = new_job_params
+    job_spec["strategy_json"] = new_st_json
+    return create_job_spec(job_spec)

--- a/services/orchest-webserver/app/app/core/jobs.py
+++ b/services/orchest-webserver/app/app/core/jobs.py
@@ -20,7 +20,7 @@ from app.utils import (
 
 
 def create_job_spec(config) -> dict:
-    """Returns a job spec given the provided configuration.
+    """Returns a job spec based on the provided configuration.
 
     Args: Initial configuration with which the job spec should be built.
         project_uuid, pipeline_uuid, pipeline_run_spec, pipeline_name,

--- a/services/orchest-webserver/app/app/error.py
+++ b/services/orchest-webserver/app/app/error.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class ActiveSession(Exception):
     """Some operation could not be done because of an active session."""
 
@@ -25,3 +28,20 @@ class OutOfProjectError(Exception):
     """Attempting to do an operation outside of a project directory."""
 
     pass
+
+
+class ProjectDoesNotExist(Exception):
+    pass
+
+
+class PipelineDoesNotExist(Exception):
+    pass
+
+
+class JobDoesNotExist(Exception):
+    pass
+
+
+class EnvironmentsDoNotExist(Exception):
+    def __init__(self, environment_uuids=List[str]):
+        self.environment_uuids = environment_uuids

--- a/services/orchest-webserver/app/tests/conftest.py
+++ b/services/orchest-webserver/app/tests/conftest.py
@@ -1,0 +1,68 @@
+import os
+
+import pytest
+from sqlalchemy_utils import drop_database
+from tests.test_utils import Pipeline, Project
+
+from _orchest.internals.test_utils import gen_uuid
+from app import config, create_app
+from app.connections import db
+
+
+@pytest.fixture(scope="module")
+def test_app():
+    """Setup a flask application with a working db.
+
+    Expects a postgres database service to be running. A new database
+    will be created with a random name. The database is dropped at the
+    end of scope of the fixture.
+    """
+
+    # Setup the DB URI.
+    db_host = os.environ.get("ORCHEST_TEST_DATABASE_HOST", "localhost")
+    db_port = os.environ.get("ORCHEST_TEST_DATABASE_PORT", "5432")
+    # Postgres does not accept "-" as part of a name.
+    db_name = gen_uuid(use_underscores=True)
+    db_name = "test_db"
+    SQLALCHEMY_DATABASE_URI = f"postgresql://postgres@{db_host}:{db_port}/{db_name}"
+    config.TestingConfig.SQLALCHEMY_DATABASE_URI = SQLALCHEMY_DATABASE_URI
+    config.CONFIG_CLASS = config.TestingConfig
+    app, _, _ = create_app()
+    yield app
+
+    drop_database(app.config["SQLALCHEMY_DATABASE_URI"])
+
+
+@pytest.fixture()
+def client(test_app):
+    """Setup a flask test client.
+
+    Will delete all data in the db at the end of the scope of the
+    fixture.
+    """
+
+    with test_app.test_client() as client:
+        yield client
+
+    # Remove all data, so that every test has access to a clean slate.
+    with test_app.app_context():
+        tables = db.engine.table_names()
+        tables = [t for t in tables if t != "alembic_version"]
+        tables = ",".join(tables)
+
+        # RESTART IDENTITY is to reset sequence generators.
+        cmd = f"TRUNCATE {tables} RESTART IDENTITY;"
+        db.engine.execute(cmd)
+        db.session.commit()
+
+
+@pytest.fixture()
+def project(test_app):
+    """Provides a project backed by an entry in the db."""
+    return Project(test_app, gen_uuid())
+
+
+@pytest.fixture()
+def pipeline(test_app, project):
+    """Provides a pipeline backed by an entry in the db."""
+    return Pipeline(test_app, project, gen_uuid())

--- a/services/orchest-webserver/app/tests/test_jobs.py
+++ b/services/orchest-webserver/app/tests/test_jobs.py
@@ -16,9 +16,9 @@ def _get_parent_job_spec(
     name="job-name",
     schedule=None,
     pipeline_name="pipeline-name",
-    env_variables={},
-    strategy_json={},
-    parameters=[{}],
+    env_variables=None,
+    strategy_json=None,
+    parameters=None,
 ):
     return {
         "name": name,
@@ -26,9 +26,9 @@ def _get_parent_job_spec(
         "project_uuid": project_uuid,
         "pipeline_uuid": pipeline_uuid,
         "pipeline_name": pipeline_name,
-        "env_variables": env_variables,
-        "strategy_json": strategy_json,
-        "parameters": parameters,
+        "env_variables": {} if env_variables is None else env_variables,
+        "strategy_json": {} if strategy_json is None else strategy_json,
+        "parameters": [{}] if parameters is None else parameters,
     }
 
 

--- a/services/orchest-webserver/app/tests/test_jobs.py
+++ b/services/orchest-webserver/app/tests/test_jobs.py
@@ -1,0 +1,433 @@
+import copy
+import json
+import random
+
+import pytest
+import requests
+from tests.test_utils import MockRequestReponse
+
+from _orchest.internals import config as _config
+from app.core import jobs
+
+
+def _get_parent_job_spec(
+    project_uuid="project-uuid",
+    pipeline_uuid="pipeline-uuid",
+    name="job-name",
+    schedule=None,
+    pipeline_name="pipeline-name",
+    env_variables={},
+    strategy_json={},
+    parameters=[{}],
+):
+    return {
+        "name": name,
+        "schedule": schedule,
+        "project_uuid": project_uuid,
+        "pipeline_uuid": pipeline_uuid,
+        "pipeline_name": pipeline_name,
+        "env_variables": env_variables,
+        "strategy_json": strategy_json,
+        "parameters": parameters,
+    }
+
+
+def _update_runs_parameters(parameters, target, name, values):
+    tmp_parameters = []
+    for value in values:
+        for run_params in parameters:
+            tmp_run_params = copy.deepcopy(run_params)
+            if target not in tmp_run_params:
+                tmp_run_params[target] = {}
+            tmp_run_params[target][name] = value
+            tmp_parameters.append(tmp_run_params)
+    return tmp_parameters
+
+
+def test_duplicate_job_no_job(client, monkeypatch):
+    def mock_get_request(url, json=None, *args, **kwargs):
+        return MockRequestReponse(404)
+
+    monkeypatch.setattr(requests, "get", mock_get_request)
+
+    resp = client.post("/catch/api-proxy/api/jobs/duplicate", json={"job_uuid": ""})
+
+    assert resp.status_code == 409
+    assert "it does not exist" in resp.get_json()["message"]
+
+
+def test_duplicate_job_no_project(client, monkeypatch):
+    def mock_get_request(url, json=None, *args, **kwargs):
+        return MockRequestReponse(200, _get_parent_job_spec())
+
+    monkeypatch.setattr(requests, "get", mock_get_request)
+    resp = client.post("/catch/api-proxy/api/jobs/duplicate", json={"job_uuid": ""})
+
+    assert resp.status_code == 409
+    assert "project does not exist" in resp.get_json()["message"]
+
+
+def test_duplicate_job_no_pipeline(client, project, monkeypatch):
+    def mock_get_request(url, json=None, *args, **kwargs):
+        return MockRequestReponse(200, _get_parent_job_spec(project.uuid))
+
+    monkeypatch.setattr(requests, "get", mock_get_request)
+    resp = client.post("/catch/api-proxy/api/jobs/duplicate", json={"job_uuid": ""})
+
+    assert resp.status_code == 409
+    assert "pipeline does not exist" in resp.get_json()["message"]
+
+
+@pytest.mark.parametrize(
+    "proj_env_variables",
+    [{}, {"var1": "project-value", "var2": "10"}],
+    ids=["no-proj-variables", "proj-variables"],
+)
+@pytest.mark.parametrize(
+    "pipe_env_variables",
+    [{}, {"var1": "pipeline-value", "var3": "[1]"}],
+    ids=["no-pipe-variables", "pipe-variables"],
+)
+@pytest.mark.parametrize(
+    "job_env_variables",
+    [{}, {"var1": "job-value", "var2": [20], "var4": "test"}],
+    ids=["no-job-variables", "job-variables"],
+)
+def test_duplicate_job_env_variables(
+    client,
+    pipeline,
+    proj_env_variables,
+    pipe_env_variables,
+    job_env_variables,
+    monkeypatch,
+):
+    def mock_get_request(url, json=None, *args, **kwargs):
+        # Return the parent job.
+        if "/api/jobs" in url:
+            return MockRequestReponse(
+                200,
+                _get_parent_job_spec(
+                    pipeline.project.uuid,
+                    pipeline.uuid,
+                    env_variables=job_env_variables,
+                ),
+            )
+        # Return the project env vars.
+        if "/api/projects" in url:
+            return MockRequestReponse(200, {"env_variables": proj_env_variables})
+        # Return the pipeline env vars.
+        if "/api/pipelines" in url:
+            return MockRequestReponse(200, {"env_variables": pipe_env_variables})
+
+    posted_json = None
+
+    def mock_post_request(self, url="", json=None, *args, **kwargs):
+        nonlocal posted_json
+        posted_json = json
+        return MockRequestReponse()
+
+    monkeypatch.setattr(requests, "get", mock_get_request)
+    monkeypatch.setattr(requests, "post", mock_post_request)
+    monkeypatch.setattr(jobs, "create_job_spec", lambda spec: spec)
+
+    pipeline_definition = {"parameters": {}, "steps": {}}
+
+    monkeypatch.setattr(
+        jobs, "get_pipeline_json", lambda *args, **kwargs: pipeline_definition
+    )
+    resp = client.post("/catch/api-proxy/api/jobs/duplicate", json={"job_uuid": ""})
+
+    assert resp.status_code == 200
+    assert posted_json["env_variables"] == {
+        **proj_env_variables,
+        **pipe_env_variables,
+        **job_env_variables,
+    }
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    ["* * * * *"],
+    ids=["schedule"],
+)
+@pytest.mark.parametrize(
+    "removed_pipeline_parameters",
+    [
+        {},
+        {
+            "removed-pipeline-parameter-1": [1, 2, 3],
+            "removed-step-parameter-2": ["1", "2", "3"],
+        },
+    ],
+    ids=["no-removed-pipeline-params", "removed-pipeline-params"],
+)
+@pytest.mark.parametrize(
+    "removed_step_parameters",
+    [
+        {},
+        {
+            "removed-step-parameter-1": [10, 20, 30],
+            "removed-step-parameter-2": ["10", "20", "30"],
+        },
+    ],
+    ids=["no-removed-step-params", "removed-step-params"],
+)
+@pytest.mark.parametrize(
+    "overlapping_pipeline_parameters",
+    [
+        {},
+        {
+            "overlapping-pipeline-parameter-1": [1, 2, 3],
+            "overlapping-pipeline-parameter-2": ["2", "3", "3"],
+            "overlapping-pipeline-parameter-3": [3, 4, 4, 4],
+        },
+    ],
+    ids=["no-overlapping-pipeline-params", "overlapping-pipeline-params"],
+)
+@pytest.mark.parametrize(
+    "overlapping_step_parameters",
+    [
+        {},
+        {
+            "overlapping-step-parameter-1": [10, 20, 30],
+            "overlapping-step-parameter-2": ["20", "30"],
+            "overlapping-step-parameter-3": [30, 40, 40],
+        },
+    ],
+    ids=["no-overlapping-step-params", "overlapping-step-params"],
+)
+@pytest.mark.parametrize(
+    "new_pipeline_parameters",
+    [
+        {},
+        {
+            "new-pipeline-parameter-1": 1,
+            "new-pipeline-parameter-2": "2",
+            "new-pipeline-parameter-3": [3, 3],
+        },
+    ],
+    ids=["no-new-pipeline-params", "new-pipeline-params"],
+)
+@pytest.mark.parametrize(
+    "new_step_parameters",
+    [
+        {},
+        {
+            "new-step-parameter-1": 10,
+            "new-step-parameter-2": "20",
+            "new-step-parameter-3": [30],
+        },
+    ],
+    ids=["no-new-step-params", "new-step-params"],
+)
+@pytest.mark.parametrize(
+    "random_seed", list(range(1)), ids=[f"seed={i}" for i in range(1)]
+)
+@pytest.mark.parametrize(
+    "runs_parameterizations_subset", [None, 10], ids=[None, "first-10"]
+)
+def test_duplicate_job_spec_configuration(
+    client,
+    pipeline,
+    schedule,
+    removed_pipeline_parameters,
+    removed_step_parameters,
+    overlapping_pipeline_parameters,
+    overlapping_step_parameters,
+    new_pipeline_parameters,
+    new_step_parameters,
+    random_seed,
+    runs_parameterizations_subset,
+    monkeypatch,
+):
+    # We will use this to shuffle.
+    random.seed(random_seed)
+
+    step_name = "step-a"
+    parent_job_strategy_json = {}
+    parent_job_parameters = [{}]
+
+    # Removed parameters are added to the strategy json and parameters,
+    # but not added to the "latest" pipeline definition. Overlapping
+    # parameters are added to both the strategy json + parameters and
+    # the pipeline definition.
+    if removed_pipeline_parameters or overlapping_pipeline_parameters:
+        parent_job_strategy_json[_config.PIPELINE_PARAMETERS_RESERVED_KEY] = {
+            "key": _config.PIPELINE_PARAMETERS_RESERVED_KEY,
+            "title": "title",
+            "parameters": {},
+        }
+    for param, values in list(removed_pipeline_parameters.items()) + list(
+        overlapping_pipeline_parameters.items()
+    ):
+        parent_job_strategy_json[_config.PIPELINE_PARAMETERS_RESERVED_KEY][
+            "parameters"
+        ][param] = json.dumps(values)
+        parent_job_parameters = _update_runs_parameters(
+            parent_job_parameters,
+            _config.PIPELINE_PARAMETERS_RESERVED_KEY,
+            param,
+            values,
+        )
+
+    if removed_step_parameters or overlapping_step_parameters:
+        parent_job_strategy_json[step_name] = {
+            "key": step_name,
+            "title": step_name,
+            "parameters": {},
+        }
+    for param, values in list(removed_step_parameters.items()) + list(
+        overlapping_step_parameters.items()
+    ):
+        parent_job_strategy_json[step_name]["parameters"][param] = json.dumps(values)
+        parent_job_parameters = _update_runs_parameters(
+            parent_job_parameters, step_name, param, values
+        )
+    random.shuffle(parent_job_parameters)
+    if runs_parameterizations_subset is not None:
+        parent_job_parameters = parent_job_parameters[runs_parameterizations_subset:]
+
+    def mock_get_request(url, json=None, *args, **kwargs):
+        # Return the parent job.
+        if "/api/jobs" in url:
+            return MockRequestReponse(
+                200,
+                _get_parent_job_spec(
+                    pipeline.project.uuid,
+                    pipeline.uuid,
+                    schedule=schedule,
+                    parameters=parent_job_parameters,
+                    strategy_json=parent_job_strategy_json,
+                ),
+            )
+        # Return the project env vars.
+        if "/api/projects" in url:
+            return MockRequestReponse(200, {"env_variables": {}})
+        # Return the pipeline env vars.
+        if "/api/pipelines" in url:
+            return MockRequestReponse(200, {"env_variables": {}})
+
+    posted_json = None
+
+    def mock_post_request(self, url="", json=None, *args, **kwargs):
+        nonlocal posted_json
+        posted_json = json
+        return MockRequestReponse()
+
+    monkeypatch.setattr(requests, "get", mock_get_request)
+    monkeypatch.setattr(requests, "post", mock_post_request)
+    monkeypatch.setattr(jobs, "create_job_spec", lambda spec: spec)
+
+    # New parameters are added to the "latest" pipeline definition, but
+    # not to the parent job strategy json and parameters. Overlapping
+    # parameters are added to both the parent job strategy json and
+    # parameters and the pipeline definition.
+    pipeline_definition = {
+        "parameters": copy.deepcopy(new_pipeline_parameters),
+        "steps": {
+            step_name: {
+                "title": step_name,
+                "parameters": copy.deepcopy(new_step_parameters),
+            }
+        },
+    }
+    for k in overlapping_pipeline_parameters:
+        pipeline_definition["parameters"][k] = "should-be-overriden"
+    for k in overlapping_step_parameters:
+        pipeline_definition["steps"][step_name]["parameters"][k] = "should-be-overriden"
+
+    monkeypatch.setattr(
+        jobs, "get_pipeline_json", lambda *args, **kwargs: pipeline_definition
+    )
+    resp = client.post("/catch/api-proxy/api/jobs/duplicate", json={"job_uuid": ""})
+
+    assert resp.status_code == 200
+    assert posted_json["cron_schedule"] == schedule
+
+    # Assert that removed parameters have been accounted for.
+    for run_parameters in posted_json["parameters"]:
+        if not new_pipeline_parameters and not overlapping_pipeline_parameters:
+            assert _config.PIPELINE_PARAMETERS_RESERVED_KEY not in run_parameters
+        else:
+            for k in removed_pipeline_parameters:
+                assert k not in run_parameters[_config.PIPELINE_PARAMETERS_RESERVED_KEY]
+
+        if not new_step_parameters and not overlapping_step_parameters:
+            assert step_name not in run_parameters
+        else:
+            for k in removed_pipeline_parameters:
+                assert k not in run_parameters[step_name]
+
+    # Assert that new parameters have been added.
+    for run_parameters in posted_json["parameters"]:
+        for key, value in new_pipeline_parameters.items():
+            assert (
+                run_parameters[_config.PIPELINE_PARAMETERS_RESERVED_KEY][key] == value
+            )
+
+        for key, value in new_step_parameters.items():
+            assert run_parameters[step_name][key] == value
+
+    # Here we are verifying the overlapping parameters, making sure that
+    # the order has been respected and that the user selection has been
+    # respected.
+    # For each new run parameterization map the string dump to its
+    # index. We will use the string dump for equality later and the
+    # index to verify ordering and selection.
+    new_runs_parameters_to_index = {}
+    for i, params in enumerate(posted_json["parameters"]):
+        params = copy.deepcopy(params)
+
+        # Remove the new pipeline parameters to match the "old"
+        # parameterization.
+        for k in new_pipeline_parameters:
+            del params[_config.PIPELINE_PARAMETERS_RESERVED_KEY][k]
+        if (
+            _config.PIPELINE_PARAMETERS_RESERVED_KEY in params
+            and not params[_config.PIPELINE_PARAMETERS_RESERVED_KEY]
+        ):
+            del params[_config.PIPELINE_PARAMETERS_RESERVED_KEY]
+
+        for k in new_step_parameters:
+            del params[step_name][k]
+        if step_name in params and not params[step_name]:
+            del params[step_name]
+
+        json_dump = json.dumps(params, sort_keys=True)
+        assert json_dump not in new_runs_parameters_to_index
+        new_runs_parameters_to_index[json_dump] = i
+
+    # For each run parameterization of the parent job account for the
+    # removed parameters, then make sure that the ordering of the new
+    # parameterizations is correct.
+    index = -1
+    already_checked = set()
+    for params in parent_job_parameters:
+        params = copy.deepcopy(params)
+
+        for k in removed_pipeline_parameters:
+            del params[_config.PIPELINE_PARAMETERS_RESERVED_KEY][k]
+        if (
+            _config.PIPELINE_PARAMETERS_RESERVED_KEY in params
+            and not params[_config.PIPELINE_PARAMETERS_RESERVED_KEY]
+        ):
+            del params[_config.PIPELINE_PARAMETERS_RESERVED_KEY]
+
+        for k in removed_step_parameters:
+            del params[step_name][k]
+        if step_name in params and not params[step_name]:
+            del params[step_name]
+
+        json_dump = json.dumps(params, sort_keys=True)
+        # Account for the fact that removing the removed parameters
+        # might introduced non uniqueness.
+        if json_dump not in already_checked:
+            already_checked.add(json_dump)
+            found_at = new_runs_parameters_to_index.get(json_dump, -1)
+            # Make sure the ordering has been respected and that the
+            # specific parameterization has been found.
+            assert found_at > index
+            index = found_at
+
+    # Finalize checking that the selection is respected.
+    assert len(already_checked) == len(posted_json["parameters"])

--- a/services/orchest-webserver/app/tests/test_utils.py
+++ b/services/orchest-webserver/app/tests/test_utils.py
@@ -1,0 +1,37 @@
+from app import models
+from app.connections import db
+
+
+class Project:
+    def __init__(self, app, uuid, path="my-project", status="READY"):
+        self.uuid = uuid
+        with app.app_context():
+            project = models.Project(uuid=uuid, path=path, status=status)
+            db.session.add(project)
+            db.session.commit()
+
+
+class Pipeline:
+    def __init__(self, app, proj, uuid, path="my-pipeline", status="READY"):
+        self.project = proj
+        self.uuid = uuid
+        with app.app_context():
+            pipeline = models.Pipeline(
+                project_uuid=proj.uuid, uuid=uuid, path=path, status=status
+            )
+            db.session.add(pipeline)
+            db.session.commit()
+
+
+class MockRequestReponse:
+    def __init__(self, status_code=200, json=None):
+        self.status_code = status_code
+        self._json = json
+        self.content = {}
+        self.headers = {}
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def json(self):
+        return self._json

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -73,6 +73,10 @@ p {
   white-space: initial;
 }
 
+.float-right {
+  float: right;
+}
+
 .mdc-drawer .mdc-list-item {
   font-weight: 400;
 }

--- a/services/orchest-webserver/client/src/views/EditJobView.tsx
+++ b/services/orchest-webserver/client/src/views/EditJobView.tsx
@@ -118,7 +118,12 @@ const EditJobView: React.FC<TViewProps> = (props) => {
 
         let strategyJSON;
 
-        if (state.job.status === "DRAFT") {
+        // Do not generate another strategy_json if it has been defined
+        // already.
+        if (
+          state.job.status === "DRAFT" &&
+          Object.keys(state.job.strategy_json).length === 0
+        ) {
           strategyJSON = generateStrategyJson(pipeline);
         } else {
           strategyJSON = state.job.strategy_json;
@@ -130,7 +135,10 @@ const EditJobView: React.FC<TViewProps> = (props) => {
           selectedIndices,
         ] = generateWithStrategy(strategyJSON);
 
-        if (state.job.status !== "DRAFT") {
+        // Account for the fact that a job might have a list of
+        // parameters already defined, i.e. when editing a non draft
+        // job or when duplicating a job.
+        if (state.job.parameters.length > 0) {
           // Determine selection based on strategyJSON
           selectedIndices = parseParameters(
             state.job.parameters,


### PR DESCRIPTION
## Description

This PR introduces job duplication, which allows duplicating a job, creating a job with the latest code and environments but inheriting the settings of the job that is being duplicated.

The environment variables of the new job are resolved by merging the current project and pipelines environment variables, then adding the inherited job environment variables. Note that this implies that environment variables that were "inherited" by the job that is being duplicated from project/env variables cannot be distinguished from environment variables that were defined in the job. This might be of interest given that if those project/pipeline variables do not exist anymore it might make more sense to not include them in the newly defined job.

Job parameters are resolved by:
 - removing parameters that do not exist anymore.
 - adding new parameters, i.e. parameters that exist in the latest version of the pipeline but do not exist for the job that is being duplicated.
  - parameters that are not to be removed nor are new, i.e. parameters that exist both for the latest pipeline definition and the job use the values that were defined in the job that is being duplicated.
  - this is true for both the strategy json and the job parameters, where each job parameter effectively represents the parameterization of a run.
  - the job parameters are updated in a way that, from the client POV and given the logic in the job view, preserves the runs selection and their ordering, along with the constraint that every run parameterization should be unique.

If the job that is being duplicated is a cronjob, the new job will have its schedule.

Fixes: #144 (partially) 

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

### Things that need to be discussed further:
- where in the UI should job duplication happen? It's currently done by a button in the `JobView`, which implies that only non `DRAFT` jobs can be duplicated (although it's technically possible to duplicate `DRAFT` jobs)
- env variables inheritance (see the env variables paragraph)


Current UI changes
![image](https://user-images.githubusercontent.com/19429509/130250952-852a41fa-e0bf-4532-b09c-604e22d82a68.png)
