### PR TITLE
Fix integration tests hanging on Mac

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -60,10 +60,6 @@ declare global {
   }
 }
 
-before(() => {
-  cy.configureCypressTestingLibrary({ testIdAttribute: "data-test-id" });
-});
-
 Cypress.Commands.add("setOnboardingCompleted", (value: TBooleanString) => {
   cy.setLocalStorage(LOCAL_STORAGE_KEY, value);
   // Needed to close the onboarding modal.

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -60,6 +60,10 @@ declare global {
   }
 }
 
+before(() => {
+  cy.configureCypressTestingLibrary({ testIdAttribute: "data-test-id" });
+});
+
 Cypress.Commands.add("setOnboardingCompleted", (value: TBooleanString) => {
   cy.setLocalStorage(LOCAL_STORAGE_KEY, value);
   // Needed to close the onboarding modal.
@@ -419,10 +423,6 @@ Cypress.Commands.add(
     }
   }
 );
-
-before(() => {
-  cy.configureCypressTestingLibrary({ testIdAttribute: "data-test-id" });
-});
 
 beforeEach(() => {
   cy.cleanDataDir();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,1 +1,5 @@
 import "./commands";
+import { configure } from "@testing-library/cypress";
+
+// https://github.com/testing-library/cypress-testing-library#config-testidattribute
+configure({ testIdAttribute: "data-test-id" });

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -2295,7 +2295,7 @@ const PipelineView: React.FC<IPipelineViewProps> = (props) => {
       initializeResizeHandlers();
 
       // Edit mode fetches latest interactive run
-      if (!queryArgs.read_only !== "true") {
+      if (queryArgs.read_only !== "true") {
         fetchActivePipelineRuns();
       }
     } else {

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -88,11 +88,6 @@ const PipelineView: React.FC<IPipelineViewProps> = (props) => {
     }
   );
 
-  // useEffect(() => {
-  //   enableSelectAllHotkey();
-  //   enableRunStepsHotkey();
-  // }, []);
-
   const timersRef = useRef({
     pipelineStepStatusPollingInterval: undefined,
     doubleClickTimeout: undefined,


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->

When I run Cypress on Mac with scripts like `pnpm run cy:open`, the tests hang and then throw timeout because it couldn't find the test id. According to the [official doc](https://github.com/testing-library/cypress-testing-library#config-testidattribute),  the configuration can be done on level up in `cypress/support/index.ts` instead of inside of the test context. This solves my issue on Mac.

```
import { configure } from "@testing-library/cypress";

configure({ testIdAttribute: "data-test-id" });
```

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
