### PR TITLE
Ctrl + Enter always ends up "No Session" error

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect } from "react";
 import io from "socket.io-client";
 import _ from "lodash";
 

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useHotKey.ts
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useHotKey.ts
@@ -1,13 +1,20 @@
-import { useEffect, useCallback } from "react";
+import { useRef, useCallback } from "react";
 import hotkeys from "hotkeys-js";
 
-const useHotKey = (keys: string, scope = "all", callback: () => void) => {
-  useEffect(() => {
-    hotkeys(keys, scope, function (event) {
-      event.preventDefault();
-      callback();
-    });
-  }, [keys]); // eslint-disable-line react-hooks/exhaustive-deps
+const useHotKey = (keys: string, scope = "all", _callback: () => void) => {
+  const callbackRef = useRef<(event: KeyboardEvent) => void>();
+
+  // hotkeys-js persists the callback function
+  // so we need to unbind the previous callback to ensure that our callback is latest one
+  // we use useRef to keep track of the old one in order to unbind it in the next render
+  if (callbackRef.current) {
+    hotkeys.unbind(keys, scope, callbackRef.current);
+  }
+  callbackRef.current = (event) => {
+    event.preventDefault();
+    _callback();
+  };
+  hotkeys(keys, scope, callbackRef.current);
 
   const enableHotKey = useCallback(
     () => {


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

In the Pipeline Editor view, using Ctrl + Enter hotky always ends up a "no active session" error.

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->



### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->


- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
