### PR TITLE
disk information in settings

### DIFF
--- a/lib/javascript/mdc/src/MDCLinearProgressReact.tsx
+++ b/lib/javascript/mdc/src/MDCLinearProgressReact.tsx
@@ -19,10 +19,16 @@ export class MDCLinearProgressReact extends React.Component<any> {
   }
 
   render() {
-    let topClasses = ["mdc-linear-progress mdc-linear-progress--indeterminate"];
-
+    let topClasses = ["mdc-linear-progress"];
     if (this.props.classNames) {
       topClasses = topClasses.concat(this.props.classNames);
+    }
+
+    if (this.props.progress === undefined) {
+      topClasses.push("mdc-linear-progress--indeterminate");
+    } else {
+      this.mdc.determinate = true;
+      this.mdc.progress = Number(this.props.progress);
     }
 
     return (
@@ -31,6 +37,8 @@ export class MDCLinearProgressReact extends React.Component<any> {
         ref={this.refManager.nrefs.progress}
         className={topClasses.join(" ")}
         aria-label="Progress Bar"
+        aria-valuemin={0}
+        aria-valuemax={1}
       >
         <div className="mdc-linear-progress__buffer">
           <div className="mdc-linear-progress__buffer-bar"></div>

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -266,20 +266,24 @@ def register_views(app, db):
     @app.route("/async/host-info", methods=["GET"])
     def host_info():
         disk_info = subprocess.getoutput(
-            "df /config --output=used,avail,pcent | sed -n '2{p;q}'"
+            "df -BGB /config --output=size,avail,pcent | sed -n '2{p;q}'"
         )
         disk_info
 
-        used, avail, pcent = disk_info.strip().split()
-        # Incoming data is in KBs.
-        used = float(used) / 10 ** 6
-        avail = float(avail) / 10 ** 6
+        # Incoming data is in GB (-BGB)
+        size, avail, pcent = disk_info.strip().split()
+        # Remove the "GB"
+        avail = int(avail[:-2])
+        # Account for the 5% reserved root space, so that used + avail
+        # add up to the total disk size the user would see in a file
+        # explorer.
+        used = int(size[:-2]) - avail
         pcent = float(pcent.replace("%", ""))
 
         host_info = {
             "disk_info": {
-                "used_gbs": used,
-                "avail_gbs": avail,
+                "used_GB": used,
+                "avail_GB": avail,
                 "used_pcent": pcent,
             }
         }

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import uuid
 
 import docker
@@ -261,6 +262,29 @@ def register_views(app, db):
                 app.logger.debug(e)
 
         return current_config
+
+    @app.route("/async/host-info", methods=["GET"])
+    def host_info():
+        disk_info = subprocess.getoutput(
+            "df /config --output=used,avail,pcent | sed -n '2{p;q}'"
+        )
+        disk_info
+
+        used, avail, pcent = disk_info.strip().split()
+        # Incoming data is in KBs.
+        used = float(used) / 10 ** 6
+        avail = float(avail) / 10 ** 6
+        pcent = float(pcent.replace("%", ""))
+
+        host_info = {
+            "disk_info": {
+                "used_gbs": used,
+                "avail_gbs": avail,
+                "used_pcent": pcent,
+            }
+        }
+
+        return host_info
 
     @app.route("/async/jupyter-setup-script", methods=["GET", "POST"])
     def jupyter_setup_script():

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -280,11 +280,16 @@ a.button {
     }
     .columns {
       .column {
+        margin-bottom: var(--space-5);
         &:nth-child(2n) {
           padding-left: 2.5%;
         }
         &:nth-child(2n + 1) {
           padding-right: 2.5%;
+        }
+        .disk-size-info {
+          width: 70%;
+          font-weight: 500;
         }
       }
     }

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -734,6 +734,10 @@ p > i.material-icons.float-left {
   margin-right: var(--space-5);
 }
 
+.push-up-half {
+  margin-top: var(--space-3);
+}
+
 .persistent-view {
   flex: 1;
   display: flex;

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -15,6 +15,7 @@ import { Layout } from "@/components/Layout";
 import UpdateView from "@/views/UpdateView";
 import ManageUsersView from "@/views/ManageUsersView";
 import ConfigureJupyterLabView from "@/views/ConfigureJupyterLabView";
+import { MDCLinearProgress } from "@material/linear-progress";
 
 const SettingsView: React.FC<TViewProps> = () => {
   const { orchest } = window;
@@ -29,6 +30,7 @@ const SettingsView: React.FC<TViewProps> = () => {
     // the full JSON config object
     configJSON: undefined,
     version: undefined,
+    hostInfo: undefined,
     requiresRestart: false,
   });
 
@@ -42,6 +44,19 @@ const SettingsView: React.FC<TViewProps> = () => {
     makeRequest("GET", "/async/version").then((data) => {
       setState((prevState) => ({ ...prevState, version: data }));
     });
+  };
+
+  const getHostInfo = () => {
+    makeRequest("GET", "/async/host-info")
+      .then((data: string) => {
+        try {
+          let parsed_data = JSON.parse(data);
+          setState((prevState) => ({ ...prevState, hostInfo: parsed_data }));
+        } catch (error) {
+          console.warn("Received invalid host-info JSON from the server.");
+        }
+      })
+      .catch(console.error);
   };
 
   const REQUIRES_RESTART_ON_CHANGE = ["MAX_JOB_RUNS_PARALLELISM"];
@@ -248,6 +263,7 @@ const SettingsView: React.FC<TViewProps> = () => {
   React.useEffect(() => {
     checkOrchestStatus();
     getConfig();
+    getHostInfo();
     getVersion();
   }, []);
 
@@ -356,26 +372,10 @@ const SettingsView: React.FC<TViewProps> = () => {
           </div>
         </div>
 
-        <h3>JupyterLab configuration</h3>
+        <h3>System status</h3>
         <div className="columns">
           <div className="column">
-            <p>Configure JupyterLab by installing server extensions.</p>
-          </div>
-          <div className="column">
-            <MDCButtonReact
-              classNames={["mdc-button--outlined"]}
-              label="Configure JupyterLab"
-              icon="tune"
-              onClick={loadConfigureJupyterLab}
-            />
-          </div>
-          <div className="clear"></div>
-        </div>
-
-        <h3>Version information</h3>
-        <div className="columns">
-          <div className="column">
-            <p>Find out Orchest's version.</p>
+            <p>Version information.</p>
           </div>
           <div className="column">
             {(() => {
@@ -398,6 +398,61 @@ const SettingsView: React.FC<TViewProps> = () => {
                 );
               }
             })()}
+          </div>
+          <div className="clear"></div>
+        </div>
+        <div className="columns">
+          <div className="column">
+            <p>Disk usage.</p>
+          </div>
+          <div className="column">
+            {(() => {
+              if (state.hostInfo !== undefined) {
+                return (
+                  <React.Fragment>
+                    <MDCLinearProgressReact
+                      classNames={["disk-size-info"]}
+                      progress={state.hostInfo.disk_info.used_pcent / 100}
+                    />
+
+                    <div className="disk-size-info">
+                      <span>
+                        {state.hostInfo.disk_info.used_gbs.toFixed(2) +
+                          " GB used"}
+                      </span>
+                      <span className="float-right">
+                        {state.hostInfo.disk_info.avail_gbs.toFixed(2) +
+                          " GB free"}
+                      </span>
+                    </div>
+                  </React.Fragment>
+                );
+              } else {
+                return (
+                  <React.Fragment>
+                    <MDCLinearProgressReact
+                      classNames={["push-down", "disk-size-info"]}
+                    />
+                  </React.Fragment>
+                );
+              }
+            })()}
+          </div>
+        </div>
+        <div className="clear"></div>
+
+        <h3>JupyterLab configuration</h3>
+        <div className="columns">
+          <div className="column">
+            <p>Configure JupyterLab by installing server extensions.</p>
+          </div>
+          <div className="column">
+            <MDCButtonReact
+              classNames={["mdc-button--outlined"]}
+              label="Configure JupyterLab"
+              icon="tune"
+              onClick={loadConfigureJupyterLab}
+            />
           </div>
           <div className="clear"></div>
         </div>

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -415,25 +415,21 @@ const SettingsView: React.FC<TViewProps> = () => {
                       progress={state.hostInfo.disk_info.used_pcent / 100}
                     />
 
-                    <div className="disk-size-info">
+                    <div className="disk-size-info push-up-half">
                       <span>
-                        {state.hostInfo.disk_info.used_gbs.toFixed(2) +
-                          " GB used"}
+                        {state.hostInfo.disk_info.used_GB + "GB used"}
                       </span>
                       <span className="float-right">
-                        {state.hostInfo.disk_info.avail_gbs.toFixed(2) +
-                          " GB free"}
+                        {state.hostInfo.disk_info.avail_GB + "GB free"}
                       </span>
                     </div>
                   </React.Fragment>
                 );
               } else {
                 return (
-                  <React.Fragment>
-                    <MDCLinearProgressReact
-                      classNames={["push-down", "disk-size-info"]}
-                    />
-                  </React.Fragment>
+                  <MDCLinearProgressReact
+                    classNames={["push-down", "disk-size-info"]}
+                  />
                 );
               }
             })()}


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description
This PR adds an entry to the settings view that shows the disk usage of the disk that docker is making use of.

![image](https://user-images.githubusercontent.com/19429509/132314110-e9f6648a-3ce0-4ed8-864f-8b91112af2c9.png)


### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
