### PR TITLE
Disable close for import dialog

### DIFF
--- a/lib/javascript/mdc/src/MDCDialogReact.tsx
+++ b/lib/javascript/mdc/src/MDCDialogReact.tsx
@@ -15,6 +15,8 @@ export class MDCDialogReact extends React.Component<any> {
   }
   componentDidMount() {
     this.mdc = new MDCDialog(this.refManager.refs.dialog);
+
+    if (this.props.disableClose) this.disableClose();
     this.mdc.open();
 
     this.mdc.listen("MDCDialog:closed", () => {
@@ -27,6 +29,11 @@ export class MDCDialogReact extends React.Component<any> {
         this.props.onOpened();
       }
     });
+  }
+
+  disableClose() {
+    this.mdc.escapeKeyAction = "";
+    this.mdc.scrimClickAction = "";
   }
 
   close() {

--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -11,7 +11,7 @@ import { useLocationQuery } from "@/hooks/useCustomRoute";
 import { BackgroundTask, CreateProjectError } from "@/utils/webserver-utils";
 
 import { useImportProject } from "./hooks/useImportProject";
-import { makeRequest } from "../../../../../lib/javascript/utils/src";
+import { makeRequest } from "@orchest/lib-utils";
 import { Project } from "@/types";
 import { useOrchest } from "@/hooks/orchest";
 
@@ -156,6 +156,7 @@ const ImportDialog: React.FC<{
     <MDCDialogReact
       title="Import a project"
       onClose={onClose}
+      disableClose
       content={
         <div data-test-id="import-project-dialog">
           {shouldShowWarning && <PrefilledWarning />}


### PR DESCRIPTION


<!-- Thank you for your contribution, you rock! 💪 -->

## Description

this is to prevent user losing import progress. The downside is that if user was just checking the functionality, user cannot easily close it with ESCAPE key or mouse click outside.


### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
