### PR TITLE
hide close button when importing

### DIFF
--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -84,6 +84,8 @@ const ImportDialog: React.FC<{
   const [importUrlFromQuerystring] = useLocationQuery(["import_url"]);
   const { dispatch } = useOrchest();
 
+  const [isCloseVisible, setIsCloseVisible] = React.useState(true);
+
   const hasPrefilledImportUrl =
     initialImportUrl ||
     (importUrlFromQuerystring && typeof importUrlFromQuerystring === "string");
@@ -103,7 +105,7 @@ const ImportDialog: React.FC<{
 
   const setImportUrl = (url: string) => _setImportUrl(url.trim().toLowerCase());
 
-  const { startImport, importResult } = useImportProject(
+  const { startImport: fireImportRequest, importResult } = useImportProject(
     projectName,
     importUrl,
     async (result) => {
@@ -140,6 +142,16 @@ const ImportDialog: React.FC<{
       }
     }
   );
+  React.useEffect(() => {
+    if (importResult && importResult.status !== "PENDING") {
+      setIsCloseVisible(true);
+    }
+  }, [importResult]);
+
+  const startImport = () => {
+    setIsCloseVisible(false);
+    fireImportRequest();
+  };
 
   const onClose = () => {
     setImportUrl("");
@@ -192,12 +204,14 @@ const ImportDialog: React.FC<{
       }
       actions={
         <>
-          <MDCButtonReact
-            icon="close"
-            label="Close"
-            classNames={["push-right"]}
-            onClick={onClose}
-          />
+          {isCloseVisible && (
+            <MDCButtonReact
+              icon="close"
+              label="Close"
+              classNames={["push-right"]}
+              onClick={onClose}
+            />
+          )}
           <MDCButtonReact
             icon="input"
             // So that the button is disabled when in a states


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

When importing an example or project, the CLOSE button should be hidden to freeze the dialog until success or failure.


### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
