### PR TITLE
Improv/callback dialog disable close

### DIFF
--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -168,7 +168,6 @@ const ImportDialog: React.FC<{
     <MDCDialogReact
       title="Import a project"
       onClose={onClose}
-      disableClose
       content={
         <div data-test-id="import-project-dialog">
           {shouldShowWarning && <PrefilledWarning />}
@@ -202,7 +201,7 @@ const ImportDialog: React.FC<{
           </p>
         </div>
       }
-      actions={
+      actions={({ setAllowClose }) => (
         <>
           {isCloseVisible && (
             <MDCButtonReact
@@ -222,11 +221,14 @@ const ImportDialog: React.FC<{
             classNames={["mdc-button--raised", "themed-secondary"]}
             label="Import"
             submitButton
-            onClick={startImport}
+            onClick={() => {
+              setAllowClose(false);
+              startImport();
+            }}
             data-test-id="import-project-ok"
           />
         </>
-      }
+      )}
     />
   );
 };

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   plugins: [reactRefresh(), vitePluginDesignSystem()],
   server: {
     host: "0.0.0.0",
-    hmr: false,
   },
   resolve: {
     alias: [

--- a/services/orchest-webserver/client/vite.config.ts
+++ b/services/orchest-webserver/client/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [reactRefresh(), vitePluginDesignSystem()],
   server: {
     host: "0.0.0.0",
+    hmr: false,
   },
   resolve: {
     alias: [


### PR DESCRIPTION


<!-- Thank you for your contribution, you rock! 💪 -->

## Description

make it possible for this.props.actions to call setAllowClose to enable/disable close, e.g. ImportDialog could disable close when importing a project. User can still use ESCAPE and mouse click outside to close ImportDialog before they click IMPORT button.

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->


### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.