### PR TITLE
Enable authless services

### DIFF
--- a/docs/source/developer_guide/implementation_details.rst
+++ b/docs/source/developer_guide/implementation_details.rst
@@ -228,6 +228,9 @@ Full JSON Schema:
               },
               "preserve_base_path": {
                 "type": "boolean"
+              },
+              "requires_authentication": {
+                "type": "boolean"
               }
             },
             "required": [

--- a/services/auth-server/app/app/utils.py
+++ b/services/auth-server/app/app/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 import json
 
@@ -39,3 +40,31 @@ def get_user_conf():
             logger.debug(e)
 
     return conf_data
+
+
+def set_auth_cache(
+    project_uuid_prefix, session_uuid_prefix, requires_authentication, auth_cache
+):
+    auth_cache["%s-%s" % (project_uuid_prefix, session_uuid_prefix)] = {
+        "date": datetime.datetime.now(),
+        "requires_authentication": requires_authentication,
+    }
+
+
+def get_auth_cache(
+    project_uuid_prefix, session_uuid_prefix, auth_cache, auth_cache_age
+):
+    key = "%s-%s" % (project_uuid_prefix, session_uuid_prefix)
+
+    if key not in auth_cache:
+        return {"status": "missing"}
+
+    if (
+        datetime.datetime.now() - auth_cache[key]["date"]
+    ).total_seconds() > auth_cache_age:
+        return {"status": "expired"}
+
+    return {
+        "status": "available",
+        "requires_authentication": auth_cache[key]["requires_authentication"],
+    }

--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -320,11 +320,11 @@ def register_views(app):
                     )
                     return "", 200
                 else:
+                    set_auth_cache(
+                        project_uuid_prefix, session_uuid_prefix, True, _auth_cache
+                    )
                     raise Exception("'requires_authentication' is not set to False")
 
             except Exception as e:
-                set_auth_cache(
-                    project_uuid_prefix, session_uuid_prefix, True, _auth_cache
-                )
                 app.logger.error(e)
                 return "", 401

--- a/services/auth-server/app/config.py
+++ b/services/auth-server/app/config.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+from _orchest.internals import config as _config
+
 
 def get_dev_server_url():
     if os.environ.get("HOST_OS") == "darwin":
@@ -33,6 +35,7 @@ class Config:
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
     CLOUD = os.environ.get("CLOUD") == "true"
+    ORCHEST_API_ADDRESS = _config.ORCHEST_API_ADDRESS
     CLOUD_URL = "https://cloud.orchest.io"
     GITHUB_URL = "https://github.com/orchest/orchest"
     DOCUMENTATION_URL = "https://www.orchest.io/docs"

--- a/services/auth-server/requirements.txt
+++ b/services/auth-server/requirements.txt
@@ -6,4 +6,5 @@ eventlet==0.30.2
 SQLAlchemy-Utils==0.37.4
 psycopg2-binary==2.8.6
 greenlet==0.4.17
+requests==2.26.0
 -e ../../lib/python/orchest-internals

--- a/services/nginx-proxy/Dockerfile
+++ b/services/nginx-proxy/Dockerfile
@@ -6,7 +6,8 @@ RUN mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.disabled
 # Add environment variable
 RUN echo "\nenv ENABLE_SSL;" >> /usr/local/openresty/nginx/conf/nginx.conf
 
-COPY ./*.conf* /etc/nginx/conf.d/
+COPY ./orchest.conf /etc/nginx/conf.d/
+COPY ./*.conf /usr/local/openresty/nginx/conf/
 
 COPY ./certs/* /etc/ssl/certs/
 COPY ./generate-dummy-certs.sh /etc/ssl/certs/

--- a/services/nginx-proxy/orchest.conf
+++ b/services/nginx-proxy/orchest.conf
@@ -45,7 +45,7 @@ server {
     return 302 $scheme://$http_host/login;
   }
 
-  location = /auth {
+  location /auth {
 
       set $auth_server "auth-server";
 
@@ -112,79 +112,8 @@ server {
   }
 
   location ~ ^/(pbp-)?service-[0-9a-zA-Z\-]+-[\-0-9a-f]+-[\-0-9a-f]+_[0-9]+ {
-
-    auth_request /auth;
-    
-    set $dynamic_host '';
-    set $dynamic_port '';
-    set $dynamic_request_uri '';
-
-    access_by_lua_block {
-
-        local function split(pString, pPattern)
-            local Table = {}  -- NOTE: use {n = 0} in Lua-5.0
-            local fpat = "(.-)" .. pPattern
-            local last_end = 1
-            local s, e, cap = pString:find(fpat, 1)
-            while s do
-                if s ~= 1 or cap ~= "" then
-                table.insert(Table,cap)
-                end
-                last_end = e+1
-                s, e, cap = pString:find(fpat, last_end)
-            end
-            if last_end <= #pString then
-                cap = pString:sub(last_end)
-                table.insert(Table, cap)
-            end
-            return Table
-        end
-
-        --[[
-          URL structure
-          /[dynamic-host]_[port][request_uri_remainder]
-        --]]
-
-        local splitted_uri = split(ngx.var.uri, "/");
-        -- wont add an empty entry if the string starts with separator
-        local base_path = splitted_uri[1];
-
-        local host_port = split(base_path, "_");
-        -- excludes initial /
-        local host = host_port[1]
-        if string.sub(host, 1, 4) == "pbp-" then
-          -- preserve the base path by proxyng the entire URI
-          host = string.sub(host, 5);
-          ngx.var.dynamic_request_uri = ngx.var.uri;
-        else
-          -- do not preserve the base path
-          -- + 1 for the starting "/", + 1 for not including the last
-          -- char of base_path
-          ngx.var.dynamic_request_uri = string.sub(ngx.var.uri, 2 + string.len(base_path));
-        end
-
-        ngx.var.dynamic_host = host;
-        ngx.var.dynamic_port = host_port[2]:match "%d+";
-
-    }
-
-    proxy_pass http://$dynamic_host:$dynamic_port$dynamic_request_uri$is_args$args;
-
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-NginX-Proxy true;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_buffering off;
-
-    proxy_pass_header Set-Cookie;
-    proxy_cookie_domain $host $dynamic_host;
-
-    # WebSocket support
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-    proxy_read_timeout 86400;
+    auth_request /auth/service;
+    include service.conf;
   }
 
   location ~ ^/jupyter-server-[\-0-9a-f]+-[\-0-9a-f]+ {

--- a/services/nginx-proxy/service.conf
+++ b/services/nginx-proxy/service.conf
@@ -1,0 +1,70 @@
+set $dynamic_host '';
+set $dynamic_port '';
+set $dynamic_request_uri '';
+
+access_by_lua_block {
+
+    local function split(pString, pPattern)
+        local Table = {}  -- NOTE: use {n = 0} in Lua-5.0
+        local fpat = "(.-)" .. pPattern
+        local last_end = 1
+        local s, e, cap = pString:find(fpat, 1)
+        while s do
+            if s ~= 1 or cap ~= "" then
+            table.insert(Table,cap)
+            end
+            last_end = e+1
+            s, e, cap = pString:find(fpat, last_end)
+        end
+        if last_end <= #pString then
+            cap = pString:sub(last_end)
+            table.insert(Table, cap)
+        end
+        return Table
+    end
+
+    --[[
+        URL structure
+        /[dynamic-host]_[port][request_uri_remainder]
+    --]]
+
+    local splitted_uri = split(ngx.var.uri, "/");
+    -- wont add an empty entry if the string starts with separator
+    local base_path = splitted_uri[1];
+
+    local host_port = split(base_path, "_");
+    -- excludes initial /
+    local host = host_port[1]
+    if string.sub(host, 1, 4) == "pbp-" then
+        -- preserve the base path by proxyng the entire URI
+        host = string.sub(host, 5);
+        ngx.var.dynamic_request_uri = ngx.var.uri;
+    else
+        -- do not preserve the base path
+        -- + 1 for the starting "/", + 1 for not including the last
+        -- char of base_path
+        ngx.var.dynamic_request_uri = string.sub(ngx.var.uri, 2 + string.len(base_path));
+    end
+
+    ngx.var.dynamic_host = host;
+    ngx.var.dynamic_port = host_port[2]:match "%d+";
+
+}
+
+proxy_pass http://$dynamic_host:$dynamic_port$dynamic_request_uri$is_args$args;
+
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_buffering off;
+
+proxy_pass_header Set-Cookie;
+proxy_cookie_domain $host $dynamic_host;
+
+# WebSocket support
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_read_timeout 86400;

--- a/services/orchest-api/app/app/apis/__init__.py
+++ b/services/orchest-api/app/app/apis/__init__.py
@@ -8,6 +8,7 @@ from app.apis.namespace_jupyter_builds import api as ns_jupyter_builds
 from app.apis.namespace_pipelines import api as ns_pipelines
 from app.apis.namespace_projects import api as ns_projects
 from app.apis.namespace_runs import api as ns_runs
+from app.apis.namespace_services import api as ns_services
 from app.apis.namespace_sessions import api as ns_sessions
 from app.apis.namespace_validations import api as ns_validations
 
@@ -28,4 +29,5 @@ api.add_namespace(ns_pipelines)
 api.add_namespace(ns_projects)
 api.add_namespace(ns_runs)
 api.add_namespace(ns_sessions)
+api.add_namespace(ns_services)
 api.add_namespace(ns_validations)

--- a/services/orchest-api/app/app/apis/namespace_services.py
+++ b/services/orchest-api/app/app/apis/namespace_services.py
@@ -1,0 +1,132 @@
+from itertools import chain
+
+from flask import request
+from flask_restx import Namespace, Resource
+
+import app.models as models
+from app import schema
+from app.utils import register_schema
+
+api = Namespace("services", description="Get information about running services")
+api = register_schema(api)
+
+
+@api.route("/")
+class ServiceList(Resource):
+    @api.doc("fetch_services")
+    @api.marshal_with(schema.service_descriptions)
+    def get(self):
+        """Fetches all services.
+
+        Services can be part of Job runs or InteractiveSessions"""
+
+        # Filter options
+
+        # The session URLs contain information about the
+        # project UUID and session UUID.
+        # It's only the first path component of the UUID string.
+        # E.g. [766907b5]-cb1e-4e6f-985b-ebded3a55435
+        # Similarly it's only the first path component of the UUID
+        # of the session UUID.
+
+        project_uuid_prefix_filter = None
+        if "project_uuid_prefix" in request.args:
+            project_uuid_prefix_filter = request.args["project_uuid_prefix"]
+
+        session_uuid_prefix_filter = None
+        if "session_uuid_prefix" in request.args:
+            session_uuid_prefix_filter = request.args["session_uuid_prefix"]
+
+        # Get services of the InteractiveSessions
+        query = models.InteractiveSession.query
+
+        if project_uuid_prefix_filter:
+            query = query.filter(
+                models.InteractiveSession.project_uuid.startswith(
+                    project_uuid_prefix_filter
+                )
+            )
+
+        if session_uuid_prefix_filter:
+            query = query.filter(
+                models.InteractiveSession.pipeline_uuid.startswith(
+                    session_uuid_prefix_filter
+                )
+            )
+
+        sessions = query.all()
+        session_services = [
+            [
+                {
+                    "service": service,
+                    "type": "INTERACTIVE",
+                    "project_uuid": session.project_uuid,
+                    "pipeline_uuid": session.pipeline_uuid,
+                }
+                for service in session.user_services.values()
+            ]
+            for session in sessions
+        ]
+        session_services = list(chain(*session_services))
+
+        # Get services of the Job runs
+        query_runs = models.NonInteractivePipelineRun.query.with_entities(
+            models.NonInteractivePipelineRun.job_uuid,
+            models.NonInteractivePipelineRun.uuid,
+        )
+
+        if project_uuid_prefix_filter:
+            query_runs = query_runs.join(models.Job).filter(
+                models.Job.project_uuid.startswith(project_uuid_prefix_filter)
+            )
+
+        if session_uuid_prefix_filter:
+            query_runs = query_runs.filter(
+                models.NonInteractivePipelineRun.uuid.startswith(
+                    session_uuid_prefix_filter
+                )
+            )
+
+        active_pipeline_runs = query_runs.filter_by(status="STARTED").all()
+
+        job_ids = set([run.job_uuid for run in active_pipeline_runs])
+
+        jobs_lookup = {}
+        jobs_definitions = (
+            models.Job.query.with_entities(
+                models.Job.pipeline_definition,
+                models.Job.uuid,
+                models.Job.project_uuid,
+                models.Job.pipeline_uuid,
+            )
+            .filter(models.Job.uuid.in_(job_ids))
+            .all()
+        )
+
+        for job in jobs_definitions:
+            jobs_lookup[job.uuid] = job
+
+        # This is a list of lists of services
+        run_services = [
+            [
+                {
+                    "service": service,
+                    "type": "NONINTERACTIVE",
+                    "project_uuid": jobs_lookup[run.job_uuid].project_uuid,
+                    "pipeline_uuid": jobs_lookup[run.job_uuid].pipeline_uuid,
+                    "job_uuid": run.job_uuid,
+                    "run_uuid": run.uuid,
+                }
+                for service in jobs_lookup[run.job_uuid]
+                .pipeline_definition["services"]
+                .values()
+            ]
+            for run in active_pipeline_runs
+            if "services" in jobs_lookup[run.job_uuid].pipeline_definition
+        ]
+        run_services = list(chain(*run_services))
+
+        # Combine services
+        all_services = session_services + run_services
+
+        return {"services": all_services}, 200

--- a/services/orchest-api/app/app/apis/namespace_services.py
+++ b/services/orchest-api/app/app/apis/namespace_services.py
@@ -72,6 +72,8 @@ class ServiceList(Resource):
             )
 
         if session_uuid_prefix_filter is not None:
+            # The session UUID for a service is the run UUID in
+            # case of a NONINTERACTIVE service.
             query_runs = query_runs.filter(
                 models.NonInteractivePipelineRun.uuid.startswith(
                     session_uuid_prefix_filter

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -104,12 +104,45 @@ service = Model(
             required=False,
             description=("If the base path should be preserved when proxying."),
         ),
+        "requires_authentication": fields.Boolean(
+            required=True,
+            description=(
+                "Can be set to False to expose the service "
+                "without authentication requirements."
+            ),
+        ),
     },
 )
 
 # Needs to be defined here, see
 # https://flask-restx.readthedocs.io/en/latest/marshalling.html#wildcard-field
 service_wildcard = fields.Wildcard(fields.Nested(service))
+
+service_description = Model(
+    "ServiceDescription",
+    {
+        "service": service_wildcard,
+        "project_uuid": fields.String(required=True, description="Project UUID"),
+        "pipeline_uuid": fields.String(required=True, description="Pipeline UUID."),
+        "job_uuid": fields.String(
+            required=False,
+            description="If the service is NONINTERACTIVE, the job_uuid.",
+        ),
+        "run_uuid": fields.String(
+            required=False,
+            description="If the service is NONINTERACTIVE, the run_uuid.",
+        ),
+        "type": fields.String(
+            required=True,
+            description="Type of the service. Either INTERACTIVE or NONINTERACTIVE.",
+        ),
+    },
+)
+
+# Needs to be defined here, see
+# https://flask-restx.readthedocs.io/en/latest/marshalling.html#wildcard-field
+service_description_wildcard = fields.Wildcard(fields.Nested(service_description))
+service_descriptions = Model("Services", {"*": service_description_wildcard})
 
 services = Model("Services", {"*": service_wildcard})
 

--- a/services/orchest-webserver/client/src/Routes.tsx
+++ b/services/orchest-webserver/client/src/Routes.tsx
@@ -1,9 +1,31 @@
-import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
+import { orderedRoutes, siteMap, toQueryString } from "./routingConfig";
 
-import { siteMap, orderedRoutes, toQueryString } from "./routingConfig";
+import React from "react";
+import { useLocation } from "react-router-dom";
+import { useOrchest } from "@/hooks/orchest";
 
 const Routes = () => {
+  let location = useLocation();
+  const context = useOrchest();
+
+  React.useEffect(() => {
+    /*
+      Always unset the pipeline for the header bar on navigation. 
+      It's up to pages to request the headerbar pipeline if they 
+      need it.
+
+      TODO: move to HeaderBar in the future.
+    */
+    context.dispatch({
+      type: "pipelineSet",
+      payload: {
+        pipelineUuid: undefined,
+        pipelineName: undefined,
+      },
+    });
+  }, [location]);
+
   return (
     <Switch>
       <Route exact path="/">

--- a/services/orchest-webserver/client/src/components/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/components/ServiceForm.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import _ from "lodash";
+
 import { Box, styled } from "@orchest/design-system";
 import {
-  MDCTextFieldReact,
-  MDCCheckboxReact,
   MDCButtonReact,
+  MDCCheckboxReact,
   MDCDialogReact,
-  MDCSelectReact,
   MDCLinearProgressReact,
+  MDCSelectReact,
+  MDCTextFieldReact,
   MDCTooltipReact,
 } from "@orchest/lib-mdc";
-import { getServiceURLs } from "../utils/webserver-utils";
-import EnvVarList from "@/components/EnvVarList";
 import {
   MultiSelect,
   MultiSelectError,
@@ -19,10 +17,14 @@ import {
   MultiSelectLabel,
 } from "./MultiSelect";
 import {
+  PromiseManager,
   makeCancelable,
   makeRequest,
-  PromiseManager,
 } from "@orchest/lib-utils";
+
+import EnvVarList from "@/components/EnvVarList";
+import _ from "lodash";
+import { getServiceURLs } from "../utils/webserver-utils";
 
 const ServiceForm: React.FC<any> = (props) => {
   const environmentPrefix = "environment@";
@@ -413,7 +415,7 @@ const ServiceForm: React.FC<any> = (props) => {
                 </h3>
                 <MDCTooltipReact
                   tooltipID="tooltip-urls"
-                  tooltip="The URLs that will be available to communicate with the service. These are all proxied by Orchest."
+                  tooltip="The URLs that will be directly available to communicate with the service. These are all proxied by Orchest."
                 />
                 {props.service.ports &&
                   getServiceURLs(

--- a/services/orchest-webserver/client/src/components/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/components/ServiceForm.tsx
@@ -364,7 +364,7 @@ const ServiceForm: React.FC<any> = (props) => {
 
             <div className="columns inner-padded">
               <div className="column">
-                <h3>
+                <h3 className="push-down">
                   Ports{" "}
                   <i
                     className="material-icons inline-icon push-left"
@@ -400,29 +400,6 @@ const ServiceForm: React.FC<any> = (props) => {
                   <MultiSelectInput />
                   <MultiSelectError />
                 </MultiSelect>
-
-                <h3 className="push-up push-down">
-                  Preserve base path{" "}
-                  <i
-                    className="material-icons inline-icon push-left"
-                    aria-describedby="tooltip-preserve-base-path"
-                  >
-                    info
-                  </i>
-                </h3>
-                <MDCTooltipReact
-                  tooltipID="tooltip-preserve-base-path"
-                  tooltip="When you preserve the base path the first component of the path https://<hostname>/1/2/... will be passed to the service when the request is proxied by Orchest."
-                />
-
-                <MDCCheckboxReact
-                  onChange={(isChecked) => {
-                    handleServiceChange("preserve_base_path", isChecked);
-                  }}
-                  disabled={props.disabled}
-                  label="Preserve base path"
-                  value={props.service?.preserve_base_path === true}
-                />
               </div>
               <div className="column">
                 <h3 className="push-down">
@@ -449,6 +426,58 @@ const ServiceForm: React.FC<any> = (props) => {
                       <a href={url}>{url}</a>
                     </div>
                   ))}
+              </div>
+              <div className="clear"></div>
+            </div>
+
+            <div className="columns inner-padded push-down">
+              <div className="column">
+                <h3 className="push-up push-down">
+                  Preserve base path{" "}
+                  <i
+                    className="material-icons inline-icon push-left"
+                    aria-describedby="tooltip-preserve-base-path"
+                  >
+                    info
+                  </i>
+                </h3>
+                <MDCTooltipReact
+                  tooltipID="tooltip-preserve-base-path"
+                  tooltip="When you preserve the base path the first component of the path https://<hostname>/1/2/... will be passed to the service when the request is proxied by Orchest."
+                />
+
+                <MDCCheckboxReact
+                  onChange={(isChecked) => {
+                    handleServiceChange("preserve_base_path", isChecked);
+                  }}
+                  disabled={props.disabled}
+                  label="Preserve base path"
+                  value={props.service?.preserve_base_path === true}
+                />
+              </div>
+              <div className="column">
+                <h3 className="push-up push-down">
+                  Authentication required{" "}
+                  <i
+                    className="material-icons inline-icon push-left"
+                    aria-describedby="tooltip-require-authentication"
+                  >
+                    info
+                  </i>
+                </h3>
+                <MDCTooltipReact
+                  tooltipID="tooltip-require-authentication"
+                  tooltip="Require authentication for the exposed service endpoints."
+                />
+
+                <MDCCheckboxReact
+                  onChange={(isChecked) => {
+                    handleServiceChange("requires_authentication", isChecked);
+                  }}
+                  disabled={props.disabled}
+                  label="Authentication required"
+                  value={props.service?.requires_authentication !== false}
+                />
               </div>
               <div className="clear"></div>
             </div>

--- a/services/orchest-webserver/client/src/hooks/orchest/provider.tsx
+++ b/services/orchest-webserver/client/src/hooks/orchest/provider.tsx
@@ -37,7 +37,7 @@ const reducer = (state: IOrchestState, action: TOrchestAction) => {
     case "projectSet":
       return { ...state, projectUuid: action.payload };
     case "projectsSet":
-      return { ...state, projects: action.payload };
+      return { ...state, projects: action.payload, hasLoadedProjects: true };
     case "sessionToggle":
       return { ...state, _sessionsToggle: action.payload };
     case "_sessionsToggleClear":
@@ -71,6 +71,7 @@ const initialState: IOrchestState = {
   pipelineUuid: undefined,
   projectUuid: undefined,
   projects: [],
+  hasLoadedProjects: false,
   sessions: [],
   sessionsIsLoading: true,
   sessionsKillAllInProgress: false,

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -69,8 +69,8 @@ const PipelineView: React.FC = () => {
       payload: readOnly,
     });
     _setIsReadOnly(readOnly);
-  }
-  
+  };
+
   const [shouldAutoStart, setShouldAutoStart] = useState(!isReadOnly);
 
   useEffect(() => {
@@ -2347,14 +2347,12 @@ const PipelineView: React.FC = () => {
                 icon="view_headline"
               />
 
-              {servicesAvailable() && (
-                <MDCButtonReact
-                  classNames={["mdc-button--raised"]}
-                  onClick={showServices}
-                  label={"Services"}
-                  icon="settings"
-                />
-              )}
+              <MDCButtonReact
+                classNames={["mdc-button--raised"]}
+                onClick={showServices}
+                label={"Services"}
+                icon="settings"
+              />
 
               <MDCButtonReact
                 classNames={["mdc-button--raised"]}
@@ -2364,10 +2362,14 @@ const PipelineView: React.FC = () => {
                 data-test-id="pipeline-settings"
               />
 
-              {state.eventVars.showServices && servicesAvailable() && (
+              {state.eventVars.showServices && (
                 <div className="services-status">
                   <h3>Running services</h3>
-                  {generateServiceEndpoints()}
+                  {servicesAvailable() ? (
+                    generateServiceEndpoints()
+                  ) : (
+                    <i>No services are running.</i>
+                  )}
 
                   <div className="edit-button-holder">
                     <MDCButtonReact

--- a/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
@@ -183,7 +183,7 @@ const ProjectsView: React.FC = () => {
         ) {
           context.dispatch({
             type: "projectSet",
-            payload: projects.length > 0 ? projects[0].uuid : null,
+            payload: projects.length > 0 ? projects[0].uuid : undefined,
           });
         }
 
@@ -266,7 +266,7 @@ const ProjectsView: React.FC = () => {
     if (context.state.projectUuid === projectUuid) {
       context.dispatch({
         type: "projectSet",
-        payload: null,
+        payload: undefined,
       });
     }
 

--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -1370,7 +1370,7 @@ span.code {
         border-top: 1px solid $borderColor;
         padding-top: calc(var(--space-5) / 2);
         margin-top: calc(var(--space-5) / 2);
-        text-align: right;
+        text-align: center;
 
         button {
           margin-bottom: 0;

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -69,6 +69,7 @@ export interface IOrchestState
   pipelineIsReadOnly: boolean;
   pipelineSaveStatus: "saved" | "saving";
   projects: Project[];
+  hasLoadedProjects: boolean;
   sessions?: IOrchestSession[] | [];
   sessionsIsLoading?: boolean;
   sessionsKillAllInProgress?: boolean;


### PR DESCRIPTION
## Description

Enable services that have no authentication. This can be useful for OAuth flows or hosting Streamlit dashboard.

Fixes: https://github.com/orchest/orchest/issues/487

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] The documentation reflects the changes.
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
