### PR TITLE
Specify submodule when using orchest functions

### DIFF
--- a/docs/source/user_guide/sdk/R.rst
+++ b/docs/source/user_guide/sdk/R.rst
@@ -36,7 +36,7 @@ passing, for example, you would do the following:
  python_path <- system("which python", intern=TRUE);
  use_python(python_path);
  orchest <- import("orchest");
- orchest$output(2, name="Test");
+ orchest$transfer$output(2, name="Test");
 
 In a child step you will be able to retrieve the output:
 
@@ -46,5 +46,5 @@ In a child step you will be able to retrieve the output:
  python_path <- system("which python", intern=TRUE);
  use_python(python_path);
  orchest <- import("orchest")
- step_inputs = orchest$get_inputs()
+ step_inputs = orchest$transfer$get_inputs()
  step_inputs$Test


### PR DESCRIPTION
Otherwise throws an error like: `Error in py_get_attr_impl(x, name, silent): AttributeError: module 'orchest' has no attribute 'output_to_disk'`