### PR TITLE
Improv/limit integration tests concurrency

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,11 +3,16 @@ name: Integration tests
 on:
   push:
     branches:
-      - master
       - dev
   pull_request:
     branches:
       - master
+
+# Pending or running workflows for the same branch will be cancelled,
+# always keep the latest.
+concurrency:
+  group: integration-tests-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
 # Pending or running workflows for the same branch will be cancelled,
 # always keep the latest.
 concurrency:
-  group: integration-tests-${{ github.head_ref }}
+  group: integration-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

This PR limits the number of integration tests runs that are launched, this was an issue on releases, where multiple integration tests runs would be triggered, easily getting to 4 or 5 queued runs.

Current changes:
- No new runs on commits to `master`
- Existing (pending, running) integration tests runs **for the same PR or branch** are cancelled, keeping only the latest

This is what a release would now look like:
- PR to `dev` is opened -> integration tests
- PR to `dev` is merged -> integration tests
- a release PR to `master` is opened -> integration tests


