### PR TITLE
Disable user-select in pipeline editor

### DIFF
--- a/services/orchest-webserver/client/src/styles/main.scss
+++ b/services/orchest-webserver/client/src/styles/main.scss
@@ -1511,6 +1511,7 @@ span.code {
     height: 100%;
     position: absolute;
     user-select: none;
+    -webkit-user-select: none;
     background-image: url("/image/cross-fill.svg");
     background-repeat: repeat;
     border: 1px solid #e5e5e5;


### PR DESCRIPTION
## Description

- This PR sets CSS property `user-select` to `none` for all the elements susceptible to be selected in the Pipeline editor during a user interaction for selecting several nodes. 
- Adding also the prefixed version for the WebKit-based browsers including Safari.

Fixes: https://github.com/orchest/orchest/issues/511

### Checklist
- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
