### PR TITLE
Make MDCCheckboxReact controll-able

### DIFF
--- a/lib/javascript/mdc/src/MDCCheckboxReact.tsx
+++ b/lib/javascript/mdc/src/MDCCheckboxReact.tsx
@@ -15,6 +15,13 @@ export class MDCCheckboxReact extends React.Component<any> {
 
     this.refManager = new RefManager();
   }
+
+  componentDidUpdate() {
+    if (this.props.value !== undefined) {
+      this.mdc.checked = this.props.value;
+    }
+  }
+
   componentDidMount() {
     this.mdcField = new MDCFormField(this.refManager.refs.formField);
     this.mdc = new MDCCheckbox(this.refManager.refs.checkbox);


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

The Checkbox component does not pick up new value if the value is changed asynchronously. This results in the bug that, in Environment Edit screen, `GPU support` is actually `true`, but the checkbox looks like unchecked.

Fixes: #522 

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->


### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
