### PR TITLE
Improv/update logging

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -103,3 +103,10 @@ DOCKER_NETWORK = "orchest"
 MEMORY_SERVER_SOCK_PATH = TEMP_DIRECTORY_PATH
 
 SIDECAR_PORT = 1111
+
+# update-server
+
+# This is used to force docker to flush the logs buffer, which won't
+# happen without a newline. This way the update server knows when a
+# newline is "genuine" vs a newline being put there to flush the buffer.
+DOCKER_LOGS_BUFFER_FLUSH_FLAG = "F|!!!|\n"

--- a/services/orchest-ctl/app/docker_wrapper.py
+++ b/services/orchest-ctl/app/docker_wrapper.py
@@ -94,7 +94,7 @@ class DockerWrapper:
             # unresponsive. Use !!\n so that the update server knows
             # what to look for when deleting the extra newline.
             if mode == "web":
-                bar_format = bar_format + "!!\n"
+                bar_format = bar_format + _config.DOCKER_LOGS_BUFFER_FLUSH_FLAG
             pulls = tqdm.as_completed(
                 pulls,
                 total=len(pulls),

--- a/services/orchest-ctl/app/docker_wrapper.py
+++ b/services/orchest-ctl/app/docker_wrapper.py
@@ -82,11 +82,19 @@ class DockerWrapper:
         self,
         images: Iterable[str],
         prog_bar: bool = True,
+        mode: Optional[str] = None,
         force: bool = False,
     ):
         pulls = [self._pull_image(image, force=force) for image in images]
 
         if prog_bar:
+            bar_format = "{desc}: {n}/{total}|{bar}|"
+            # This is necessary because docker won't flush the log until
+            # it has seen a newline, making the web update feel
+            # unresponsive. Use !!\n so that the update server knows
+            # what to look for when deleting the extra newline.
+            if mode == "web":
+                bar_format = bar_format + "!!\n"
             pulls = tqdm.as_completed(
                 pulls,
                 total=len(pulls),
@@ -95,7 +103,7 @@ class DockerWrapper:
                 ascii=True,
                 position=0,
                 leave=True,
-                bar_format="{desc}: {n}/{total}|{bar}|",
+                bar_format=bar_format,
             )
 
         for pull in pulls:
@@ -117,6 +125,7 @@ class DockerWrapper:
         self,
         images: Iterable[str],
         prog_bar: bool = True,
+        mode: Optional[str] = None,
         force: bool = False,
     ):
         """Pulls an iterable of images.
@@ -125,11 +134,21 @@ class DockerWrapper:
             images: The images to pull.
             prog_bar: Whether or not to show a progress bar to
                 indicate progress.
+            mode: What mode is orchest-ctl running e.g. "web". This
+                affects how some lower level components act, like the
+                progress bar.
             force: If True, then pulls an image even when it is already
                 present and thus replacing it.
 
         """
-        return asyncio.run(self._pull_images(images, prog_bar=prog_bar, force=force))
+        return asyncio.run(
+            self._pull_images(
+                images,
+                prog_bar=prog_bar,
+                mode=mode,
+                force=force,
+            )
+        )
 
     async def _does_image_exist(self, image: str) -> bool:
         try:

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -180,7 +180,7 @@ class OrchestApp:
             )
         try:
             version_exit_code = 0
-            self.version(ext=True, verbose=False)
+            self.version(ext=True)
         except typer.Exit as e:
             version_exit_code = e.exit_code
 

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -150,7 +150,12 @@ class OrchestApp:
         pulled_images = self.resource_manager.get_images()
         to_pull_images = set(config.ORCHEST_IMAGES["minimal"]) | set(pulled_images)
         logger.info("Updating images:\n" + "\n".join(to_pull_images))
-        self.docker_client.pull_images(to_pull_images, prog_bar=True, force=True)
+        self.docker_client.pull_images(
+            to_pull_images,
+            prog_bar=True,
+            mode=mode,
+            force=True,
+        )
 
         # Add a tag to user environment images to mark them for removal.
         # The orchest-api will deal with the rest of the logic related

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -104,13 +104,22 @@ def do_proxy_certs_exist_on_host() -> bool:
     return crt_exists and key_exists
 
 
-def update_git_repo():
+def update_git_repo(verbose: bool = True):
     """Pulls the latest changes from the Orchest git repository."""
     logger.info("Updating Orchest git repository to get the latest userdir changes...")
     script_path = os.path.join(
         "/orchest", "services", "orchest-ctl", "app", "scripts", "git-update.sh"
     )
-    script_process = subprocess.Popen([script_path], cwd="/orchest-host", bufsize=0)
+    if verbose:
+        script_process = subprocess.Popen([script_path], cwd="/orchest-host", bufsize=0)
+    else:
+        script_process = subprocess.Popen(
+            [script_path],
+            cwd="/orchest-host",
+            bufsize=0,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
     exit_code = script_process.wait()
 
     return exit_code

--- a/services/orchest-ctl/tests/test_orchestapp.py
+++ b/services/orchest-ctl/tests/test_orchestapp.py
@@ -203,7 +203,7 @@ def test_update(installed_images, update_exit_code, mode, expected_stdout, capsy
 
     to_pull_images = set(config.ORCHEST_IMAGES["minimal"]) | set(installed_images)
     docker_client.pull_images.assert_called_once_with(
-        to_pull_images, prog_bar=True, force=True
+        to_pull_images, prog_bar=True, force=True, mode=mode
     )
 
 

--- a/services/update-server/app/app/views.py
+++ b/services/update-server/app/app/views.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 import docker
 from flask import jsonify
 
+from _orchest.internals import config as _config
 from _orchest.internals.utils import run_orchest_ctl
 from app.config import CONFIG_CLASS
 
@@ -19,7 +20,7 @@ def log_update(message):
     try:
         # Remove extra spaces from the progress bar. See the orchest-ctl
         # progress bar implementation for more info.
-        message = message.replace("!!\n", "")
+        message = message.replace(_config.DOCKER_LOGS_BUFFER_FLUSH_FLAG, "")
         with open(UPDATE_FILE_LOG, "a") as log_file:
             log_file.write(message)
 

--- a/services/update-server/app/app/views.py
+++ b/services/update-server/app/app/views.py
@@ -17,6 +17,7 @@ UPDATE_COMPLETE_FILE = "/tmp/update-complete"
 
 def log_update(message):
     try:
+        message = message.replace("!!\n", "")
         with open(UPDATE_FILE_LOG, "a") as log_file:
             log_file.write(message)
 

--- a/services/update-server/app/app/views.py
+++ b/services/update-server/app/app/views.py
@@ -17,6 +17,8 @@ UPDATE_COMPLETE_FILE = "/tmp/update-complete"
 
 def log_update(message):
     try:
+        # Remove extra spaces from the progress bar. See the orchest-ctl
+        # progress bar implementation for more info.
         message = message.replace("!!\n", "")
         with open(UPDATE_FILE_LOG, "a") as log_file:
             log_file.write(message)


### PR DESCRIPTION
## Description

This PR reduces the verbosity of the updater when in `web` mode, along with making the progress bar unbuffered.

Fixes #464
Fixes #465

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

For reference, here are the old update logs

![reference](https://user-images.githubusercontent.com/19429509/140288678-8ebea77c-f7ae-4e8a-a736-93dddc6db571.png)

while these are the new ones

![image](https://user-images.githubusercontent.com/19429509/140288906-26c4285f-5f5e-419f-a173-5edaab9922ae.png)

