### PR TITLE
Fix/stale orchest image deletion

### DIFF
--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -167,6 +167,10 @@ def create_app(config_class=None, use_db=True, be_scheduler=False):
                 # update.
                 utils.process_stale_environment_images()
 
+                # Remove dangling Orchest images, mostly useful after an
+                # update.
+                utils.delete_dangling_orchest_images()
+
             except FileExistsError:
                 app.logger.info("/tmp/cleanup_done exists. Skipping cleanup.")
             except Exception as e:

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -592,7 +592,9 @@ class AbortJob(TwoPhaseFunction):
             res.abort()
 
         if project_uuid is not None:
-            process_stale_environment_images(project_uuid)
+            process_stale_environment_images(
+                project_uuid, only_marked_for_removal=False
+            )
 
 
 class CreateJob(TwoPhaseFunction):
@@ -841,7 +843,9 @@ class DeleteJob(TwoPhaseFunction):
 
     def _collateral(self, project_uuid: str):
         if project_uuid is not None:
-            process_stale_environment_images(project_uuid)
+            process_stale_environment_images(
+                project_uuid, only_marked_for_removal=False
+            )
 
 
 class UpdateJobPipelineRun(TwoPhaseFunction):
@@ -910,7 +914,9 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
 
     def _collateral(self, project_uuid: str, completed: bool):
         if completed and project_uuid is not None:
-            process_stale_environment_images(project_uuid)
+            process_stale_environment_images(
+                project_uuid, only_marked_for_removal=False
+            )
 
 
 class PauseCronJob(TwoPhaseFunction):

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -592,12 +592,18 @@ def get_logger() -> logging.Logger:
     return get_task_logger(__name__)
 
 
-def process_stale_environment_images(project_uuid: Optional[str] = None) -> None:
-    """Make stale environments unavailable to the user.
+def process_stale_environment_images(
+    project_uuid: Optional[str] = None, only_marked_for_removal: bool = True
+) -> None:
+    """Makes stale environments unavailable to the user.
 
     Args:
         project_uuid: If specified, only this project environment images
             will be processed.
+        only_marked_for_removal: Only consider images that have been
+            marked for removal. Setting this to False allows the caller
+            to, essentially, cleanup environments that are no longer in
+            use.
 
     After an update, all environment images are invalidated to avoid the
     user having an environment with an SDK not compatible with the
@@ -611,7 +617,7 @@ def process_stale_environment_images(project_uuid: Optional[str] = None) -> None
     removed, so that the environment will have to be rebuilt to be
     available to the user for new runs.  The invalidation semantics are
     tied with the semantics of the validation module, which considers an
-    environment as existing based on the existance of the orchest-env-*
+    environment as existing based on the existence of the orchest-env-*
     name.
 
     """
@@ -621,10 +627,10 @@ def process_stale_environment_images(project_uuid: Optional[str] = None) -> None
 
     env_imgs = docker_images_list_safe(docker_client, filters=filters)
     for img in env_imgs:
-        _process_stale_environment_image(img)
+        _process_stale_environment_image(img, only_marked_for_removal)
 
 
-def _process_stale_environment_image(img) -> None:
+def _process_stale_environment_image(img, only_marked_for_removal) -> None:
     pr_uuid = img.labels.get("_orchest_project_uuid")
     env_uuid = img.labels.get("_orchest_environment_uuid")
     build_uuid = img.labels.get("_orchest_env_build_task_uuid")
@@ -645,26 +651,33 @@ def _process_stale_environment_image(img) -> None:
         # The image has not been marked for removal. This will happen
         # everytime Orchest is started except for a start which is
         # following an update.
-        f"{removal_name}:latest" not in img.tags
+        (f"{removal_name}:latest" not in img.tags and only_marked_for_removal)
         # Note that we can't check for env_name:latest not being in
         # img.tags because it might not be there if the image has
-        # "survived" two updates in a row because a job is still
-        # using that.
+        # "survived" two updates in a row because a job is still using
+        # that.
     ):
         return
 
-    # This will just remove the orchest-env-* name/tag from the
-    # image, the image will still be available for jobs that are
-    # making use of that because the image still have the
-    # <removal_name>.
-    if f"{env_name}:latest" in img.tags:
-        docker_images_rm_safe(docker_client, env_name)
+    has_env_name = f"{env_name}:latest" in img.tags
+    if has_env_name:
+        if only_marked_for_removal:
+            # This will just remove the orchest-env-* name/tag from the
+            # image, the image will still be available for jobs that are
+            # making use of that because the image still has the
+            # <removal_name>.
+            docker_images_rm_safe(docker_client, env_name)
+        else:
+            # The image is not dangling, e.g. it has not been
+            # substituted by a more up to date version of the same
+            # environment.
+            return
 
     if not is_docker_image_in_use(img.id):
-        # Delete through id, hence deleting the image regardless
-        # of the fact that it has other tags. force=True is used to
-        # delete regardless of the existence of stopped containers, this
-        # is required because pipeline runs PUT to the orchest-api their
+        # Delete through id, hence deleting the image regardless of the
+        # fact that it has other tags. force=True is used to delete
+        # regardless of the existence of stopped containers, this is
+        # required because pipeline runs PUT to the orchest-api their
         # finished state before deleting their stopped containers.
         docker_images_rm_safe(docker_client, img.id, attempt_count=20, force=True)
 

--- a/services/orchest-ctl/app/docker_wrapper.py
+++ b/services/orchest-ctl/app/docker_wrapper.py
@@ -540,11 +540,6 @@ class OrchestResourceManager:
             label="_orchest_jupyter_build_task_uuid"
         )
 
-    def get_orchest_dangling_imgs(self):
-        return self.docker_client.list_image_ids(
-            label="maintainer=Orchest B.V. https://www.orchest.io", dangling=True
-        )
-
     def tag_environment_images_for_removal(self):
         env_build_imgs = self.get_env_build_imgs()
         for img in env_build_imgs:
@@ -578,20 +573,6 @@ class OrchestResourceManager:
     def remove_jupyter_build_imgs(self):
         jupyter_build_imgs = self.get_jupyter_build_imgs()
         self.docker_client.remove_images(jupyter_build_imgs, force=True)
-
-    def remove_orchest_dangling_imgs(self):
-        """Remove Orchest dangling images that are not in use."""
-        orchest_dangling_imgs = set(self.get_orchest_dangling_imgs())
-
-        # This will pick up both orchest-ctl (which is not in the
-        # orchest network) and the other orchest containers.
-        containers, _ = self.docker_client.get_containers(full_info=True, network=None)
-
-        # Do not try to delete images that are in use.
-        images_in_use = {c["ImageID"] for c in containers}
-        orchest_dangling_imgs = orchest_dangling_imgs - images_in_use
-
-        self.docker_client.remove_images(orchest_dangling_imgs, force=True)
 
     def containers_version(self):
         pulled_images = self.get_images(orchest_owned=True)

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -165,9 +165,6 @@ class OrchestApp:
         logger.info("Deleting user-built Jupyter image.")
         self.resource_manager.remove_jupyter_build_imgs()
 
-        # Delete Orchest dangling images.
-        self.resource_manager.remove_orchest_dangling_imgs()
-
         utils.echo(
             "Checking whether all containers are running the same version of Orchest."
         )


### PR DESCRIPTION
## Description
This PR:
- moves the responsibility of deleting dangling Orchest images from `orchest-ctl` to the `orchest-api`, so that the deletion of those images is not staggered but happens on every update.
- fixes a bug where unused environment images were not being cleaned up once a job reached an end state if they were not marked for removal.

Fixes: #422 

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

