### PR TITLE
Increased run parallelism for jobs and interactive runs

### DIFF
--- a/docs/source/user_guide/other.rst
+++ b/docs/source/user_guide/other.rst
@@ -21,8 +21,8 @@ Orchest stores a global configuration file in JSON format at ``~/.config/orchest
 
    {
      "AUTH_ENABLED": false,
-     "MAX_JOB_RUNS_PARALLELISM": 1,
-     "MAX_INTERACTIVE_RUNS_PARALLELISM": 1,
+     "MAX_JOB_RUNS_PARALLELISM": 4,
+     "MAX_INTERACTIVE_RUNS_PARALLELISM": 4,
      "TELEMETRY_DISABLED": false,
      "TELEMETRY_UUID": "69b40767-e315-4953-8a2b-355833e344b8"
    }
@@ -33,14 +33,14 @@ Explanation of all configuration settings:
     Enable authentication, see :ref:`authentication <authentication>`.
 
 ``MAX_JOB_RUNS_PARALLELISM``
-    Controls the level of parallelism of job runs. By default, only one run at a time will be
-    executed, across all jobs. You need to restart Orchest for this change to take effect.
+    Controls the level of parallelism of job runs. By default, four runs at a time will be
+    executed, across all jobs. You need to restart Orchest for changes to take effect.
 
 ``MAX_INTERACTIVE_RUNS_PARALLELISM``
     Controls the level of parallelism of interactive runs of different pipelines (by definition only
     one interactive run can be running for a particular pipeline at a given time). For example, by
     setting this value to ``2`` you can (interactively) run two different pipelines (through the
-    pipeline editor) at the same time. You need to restart Orchest for this change to take effect.
+    pipeline editor) at the same time. You need to restart Orchest for changes to take effect.
 
 ``TELEMETRY_DISABLED``
     Option to disable telemetry completely.

--- a/docs/source/user_guide/other.rst
+++ b/docs/source/user_guide/other.rst
@@ -22,6 +22,7 @@ Orchest stores a global configuration file in JSON format at ``~/.config/orchest
    {
      "AUTH_ENABLED": false,
      "MAX_JOB_RUNS_PARALLELISM": 1,
+     "MAX_INTERACTIVE_RUNS_PARALLELISM": 1,
      "TELEMETRY_DISABLED": false,
      "TELEMETRY_UUID": "69b40767-e315-4953-8a2b-355833e344b8"
    }
@@ -32,9 +33,14 @@ Explanation of all configuration settings:
     Enable authentication, see :ref:`authentication <authentication>`.
 
 ``MAX_JOB_RUNS_PARALLELISM``
-    Controls the level of parallelism of job runs. By default, only one
-    run at a time will be executed, across all jobs. You need to restart
-    Orchest for this change to take effect.
+    Controls the level of parallelism of job runs. By default, only one run at a time will be
+    executed, across all jobs. You need to restart Orchest for this change to take effect.
+
+``MAX_INTERACTIVE_RUNS_PARALLELISM``
+    Controls the level of parallelism of interactive runs of different pipelines (by definition only
+    one interactive run can be running for a particular pipeline at a given time). For example, by
+    setting this value to ``2`` you can (interactively) run two different pipelines (through the
+    pipeline editor) at the same time. You need to restart Orchest for this change to take effect.
 
 ``TELEMETRY_DISABLED``
     Option to disable telemetry completely.

--- a/docs/source/user_guide/other.rst
+++ b/docs/source/user_guide/other.rst
@@ -8,12 +8,14 @@ Configuration
 
 Global configurations
 ~~~~~~~~~~~~~~~~~~~~~
+.. tip::
 
-Orchest stores a global configuration file at ``~/.config/orchest/config.json`` (or at
-``$XDG_CONFIG_HOME/orchest/config.json`` if defined). The content of the file can be changed from
-within in the UI through *Settings*.
+    Change the global configuration through Orchest, by going to *Settings*.  If you change the
+    content of the file through the filesystem of the host, then you need to restart Orchest for the
+    changes to take effect.
 
-Example content:
+Orchest stores a global configuration file in JSON format at ``~/.config/orchest/config.json`` (or at
+``$XDG_CONFIG_HOME/orchest/config.json`` if defined). Example content:
 
 .. code-block:: json
 
@@ -24,7 +26,7 @@ Example content:
      "TELEMETRY_UUID": "69b40767-e315-4953-8a2b-355833e344b8"
    }
 
-Explanation of possible configuration settings:
+Explanation of all configuration settings:
 
 ``AUTH_ENABLED``
     Enable authentication, see :ref:`authentication <authentication>`.

--- a/lib/python/orchest-internals/_orchest/internals/errors.py
+++ b/lib/python/orchest-internals/_orchest/internals/errors.py
@@ -1,0 +1,4 @@
+class CorruptedFileError(Exception):
+    """The content of the file is corrupted."""
+
+    pass

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -27,8 +27,8 @@ class GlobalOrchestConfig:
 
     # Defines default values for all supported configuration options.
     _default_values = {
-        "MAX_JOB_RUNS_PARALLELISM": 1,
-        "MAX_INTERACTIVE_RUNS_PARALLELISM": 1,
+        "MAX_JOB_RUNS_PARALLELISM": 4,
+        "MAX_INTERACTIVE_RUNS_PARALLELISM": 4,
         "AUTH_ENABLED": False,
         "TELEMETRY_DISABLED": False,
         "TELEMETRY_UUID": str(uuid.uuid4()),

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -209,13 +209,8 @@ class GlobalOrchestConfig:
                 try:
                     unmodifiable_config[k] = deepcopy(current_config[k])
                 except KeyError:
-                    # Otherwise you could get a default value of
-                    # `AUTH_ENABLED` being `False`. This is probably not
-                    # what you want.
-                    raise _errors.CorruptedFileError(
-                        "When running Orchest with '--cloud' all of"
-                        f" {self._cloud_unmodifiable_config_values} have to be defined."
-                    )
+                    # Fall back on default values.
+                    ...
 
         return unmodifiable_config, current_config
 

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -28,6 +28,7 @@ class GlobalOrchestConfig:
     # Defines default values for all supported configuration options.
     _default_values = {
         "MAX_JOB_RUNS_PARALLELISM": 1,
+        "MAX_INTERACTIVE_RUNS_PARALLELISM": 1,
         "AUTH_ENABLED": False,
         "TELEMETRY_DISABLED": False,
         "TELEMETRY_UUID": str(uuid.uuid4()),
@@ -172,6 +173,15 @@ class GlobalOrchestConfig:
         if max_job_runs_parallelism is not None and max_job_runs_parallelism <= 0:
             raise ValueError(
                 "MAX_JOB_RUNS_PARALLELISM has to be strictly larger than zero."
+            )
+
+        max_interactive_runs_parallelism = d.get("MAX_INTERACTIVE_RUNS_PARALLELISM")
+        if (
+            max_interactive_runs_parallelism is not None
+            and max_interactive_runs_parallelism <= 0
+        ):
+            raise ValueError(
+                "MAX_INTERACTIVE_RUNS_PARALLELISM has to be strictly larger than zero."
             )
 
     def _get_current_configs(self) -> Tuple[dict, dict]:

--- a/services/auth-server/app/add_user.py
+++ b/services/auth-server/app/add_user.py
@@ -6,7 +6,6 @@ from werkzeug.security import generate_password_hash
 from app import create_app
 from app.connections import db
 from app.models import User
-from app.utils import get_user_conf
 from config import CONFIG_CLASS
 
 if __name__ == "__main__":
@@ -26,7 +25,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    conf_data = get_user_conf()
     app = create_app(config_class=CONFIG_CLASS)
 
     username = args.username[0]

--- a/services/auth-server/app/app/utils.py
+++ b/services/auth-server/app/app/utils.py
@@ -1,8 +1,5 @@
 import datetime
 import hashlib
-import json
-
-from flask import current_app
 
 
 def get_hash(path):
@@ -15,31 +12,6 @@ def get_hash(path):
             buf = afile.read(BLOCKSIZE)
 
     return hasher.hexdigest()
-
-
-def get_user_conf():
-    conf_data = {}
-
-    # configure default value
-    conf_data["AUTH_ENABLED"] = False
-
-    try:
-        with open("/config/config.json", "r") as f:
-            config = json.load(f)
-
-        conf_data.update(config)
-    except Exception as e:
-        try:
-            current_app.logger.debug(e)
-        except RuntimeError:
-            # Is hit in case the function is called without an
-            # application context, e.g. in the `main.py` module.
-            import logging
-
-            logger = logging.getLogger(__name__)
-            logger.debug(e)
-
-    return conf_data
 
 
 def set_auth_cache(

--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -7,8 +7,6 @@ import requests
 from flask import jsonify, redirect, request, send_from_directory
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from _orchest.internals import errors as _errors
-from _orchest.internals import utils as _utils
 from app.connections import db
 from app.models import Token, User
 from app.utils import get_auth_cache, set_auth_cache
@@ -46,22 +44,10 @@ def register_views(app):
         )
 
     def is_authenticated(request):
-        # If authenticated is not enabled then the request is always
+        # If authentication is not enabled then the request is always
         # authenticated (by definition).
-        try:
-            global_orchest_config = _utils.GlobalOrchestConfig()
-        except _errors.CorruptedFileError:
-            app.logger.error(
-                "Failed to load global orchest config file.", exc_info=True
-            )
-
-            # Fall back on the cached value.
-            if not app.config["AUTH_ENABLED"]:
-                return True
-        else:
-            global_orchest_config.save(flask_app=app)
-            if not global_orchest_config["AUTH_ENABLED"]:
-                return True
+        if not app.config["AUTH_ENABLED"]:
+            return True
 
         cookie_token = request.cookies.get("auth_token")
         username = request.cookies.get("auth_username")

--- a/services/auth-server/app/app/views.py
+++ b/services/auth-server/app/app/views.py
@@ -7,9 +7,10 @@ import requests
 from flask import jsonify, redirect, request, send_from_directory
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from _orchest.internals import utils as _utils
 from app.connections import db
 from app.models import Token, User
-from app.utils import get_auth_cache, get_user_conf, set_auth_cache
+from app.utils import get_auth_cache, set_auth_cache
 
 # This auth_cache is shared between requests
 # within the same Flask process
@@ -46,8 +47,8 @@ def register_views(app):
     def is_authenticated(request):
 
         # if auth_enabled request is always authenticated
-        config_data = get_user_conf()
-        if not config_data["AUTH_ENABLED"]:
+        config = _utils.GlobalOrchestConfig()
+        if not config["AUTH_ENABLED"]:
             return True
 
         cookie_token = request.cookies.get("auth_token")

--- a/services/auth-server/app/main.py
+++ b/services/auth-server/app/main.py
@@ -1,10 +1,16 @@
+from _orchest.internals import errors as _errors
 from _orchest.internals import utils as _utils
 from app import create_app
 from config import CONFIG_CLASS
 
 app = create_app(config_class=CONFIG_CLASS)
-config = _utils.GlobalOrchestConfig()
-config.save(flask_app=app)
+
+try:
+    global_orchest_config = _utils.GlobalOrchestConfig()
+except _errors.CorruptedFileError:
+    app.logger.error("Failed to load global orchest config file.", exc_info=True)
+else:
+    global_orchest_config.save(flask_app=app)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=80)

--- a/services/auth-server/app/main.py
+++ b/services/auth-server/app/main.py
@@ -10,7 +10,7 @@ try:
 except _errors.CorruptedFileError:
     app.logger.error("Failed to load global orchest config file.", exc_info=True)
 else:
-    global_orchest_config.save(flask_app=app)
+    app.config.update(global_orchest_config.as_dict())
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=80)

--- a/services/auth-server/app/main.py
+++ b/services/auth-server/app/main.py
@@ -1,12 +1,10 @@
+from _orchest.internals import utils as _utils
+from app import create_app
 from config import CONFIG_CLASS
 
-from app import create_app
-from app.utils import get_user_conf
-
-conf_data = get_user_conf()
-
 app = create_app(config_class=CONFIG_CLASS)
-app.config.update(conf_data)
+config = _utils.GlobalOrchestConfig()
+config.save(flask_app=app)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=80)

--- a/services/orchest-api/celery_daemon_configs/worker_interactive.conf
+++ b/services/orchest-api/celery_daemon_configs/worker_interactive.conf
@@ -13,5 +13,5 @@ command=celery worker
 	-Q celery
 	-n worker-interactive
 	-f celery_interactive.log
-	--concurrency=1
+	--concurrency=%(ENV_MAX_INTERACTIVE_RUNS_PARALLELISM)s
 	--pidfile="worker-interactive.pid"

--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -7,6 +7,7 @@ from typing import List, Set
 from docker.errors import NotFound
 
 from _orchest.internals import config as _config
+from _orchest.internals import errors as _errors
 from _orchest.internals import utils as _utils
 from app import utils
 from app.config import _on_start_images
@@ -333,8 +334,16 @@ def containers_version_dump(
 def orchest_config_dump(path: str) -> None:
     """Get the Orchest config file, with telemetry UUID removed"""
 
-    config = _utils.GlobalOrchestConfig()
-    config = config.read_raw_current_config()
+    try:
+        config = _utils.GlobalOrchestConfig()
+    except _errors.CorruptedFileError as e:
+        utils.echo(e)
+        config = _utils.GlobalOrchestConfig.read_raw_current_config(
+            _utils.GlobalOrchestConfig
+        )
+    else:
+        config = config.read_raw_current_config()
+
     # Removed for privacy.
     del config["TELEMETRY_UUID"]
 

--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -7,6 +7,7 @@ from typing import List, Set
 from docker.errors import NotFound
 
 from _orchest.internals import config as _config
+from _orchest.internals import utils as _utils
 from app import utils
 from app.config import _on_start_images
 from app.docker_wrapper import OrchestResourceManager
@@ -332,7 +333,8 @@ def containers_version_dump(
 def orchest_config_dump(path: str) -> None:
     """Get the Orchest config file, with telemetry UUID removed"""
 
-    config = utils.get_orchest_config()
+    config = _utils.GlobalOrchestConfig()
+    config = config.read_raw_current_config()
     # Removed for privacy.
     del config["TELEMETRY_UUID"]
 

--- a/services/orchest-ctl/app/debug.py
+++ b/services/orchest-ctl/app/debug.py
@@ -338,11 +338,11 @@ def orchest_config_dump(path: str) -> None:
         config = _utils.GlobalOrchestConfig()
     except _errors.CorruptedFileError as e:
         utils.echo(e)
-        config = _utils.GlobalOrchestConfig.read_raw_current_config(
+        config = _utils.GlobalOrchestConfig._read_raw_current_config(
             _utils.GlobalOrchestConfig
         )
     else:
-        config = config.read_raw_current_config()
+        config = config._read_raw_current_config()
 
     # Removed for privacy.
     del config["TELEMETRY_UUID"]

--- a/services/orchest-ctl/app/spec.py
+++ b/services/orchest-ctl/app/spec.py
@@ -168,11 +168,9 @@ def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
     if env is None:
         env = utils.get_env()
 
-    max_job_runs_parallelism = utils.get_orchest_config().get(
-        "MAX_JOB_RUNS_PARALLELISM", 1
-    )
-
     GPU_ENABLED_INSTANCE = _utils.docker_has_gpu_capabilities()
+    orchest_config = _utils.GlobalOrchestConfig()
+    max_job_runs_parallelism = orchest_config["MAX_JOB_RUNS_PARALLELISM"]
 
     # name -> request body
     container_config = {

--- a/services/orchest-ctl/app/spec.py
+++ b/services/orchest-ctl/app/spec.py
@@ -171,6 +171,9 @@ def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
     GPU_ENABLED_INSTANCE = _utils.docker_has_gpu_capabilities()
     orchest_config = _utils.GlobalOrchestConfig()
     max_job_runs_parallelism = orchest_config["MAX_JOB_RUNS_PARALLELISM"]
+    max_interactive_runs_parallelism = orchest_config[
+        "MAX_INTERACTIVE_RUNS_PARALLELISM"
+    ]
 
     # name -> request body
     container_config = {
@@ -217,6 +220,7 @@ def get_reg_container_config(port: int, env: Optional[dict] = None) -> dict:
             "Env": [
                 f'ORCHEST_HOST_GID={env["ORCHEST_HOST_GID"]}',
                 f"MAX_JOB_RUNS_PARALLELISM={max_job_runs_parallelism}",
+                f"MAX_INTERACTIVE_RUNS_PARALLELISM={max_interactive_runs_parallelism}",
                 # Set a default log level because supervisor can't deal
                 # with non assigned env variables.
                 "ORCHEST_LOG_LEVEL=INFO",

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -172,18 +172,6 @@ def retry_func(func, _retries=10, _sleep_duration=1, _wait_msg=None, **kwargs) -
     return func_result
 
 
-def get_orchest_config() -> dict:
-    try:
-        with open("/config/config.json") as input_json_file:
-            return json.load(input_json_file)
-    except FileNotFoundError:
-        logger.info("Could not find Orchest's global configuration file.")
-        return {}
-    except json.decoder.JSONDecodeError:
-        logger.info("Malformed Orchest global configuration file.")
-        return {}
-
-
 # orchest <arguments> cmd <arguments>, excluding the use of cmd as an
 # argument, so that "orchest --update update" would match but
 # "orchest update update" would not.

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -64,11 +64,11 @@ def create_app():
 
     # read directory mount based config into Flask config
     try:
-        global_user_config = _utils.GlobalOrchestConfig()
+        global_orchest_config = _utils.GlobalOrchestConfig()
     except _errors.CorruptedFileError:
         app.logger.error("Failed to load global orchest config file.", exc_info=True)
     else:
-        global_user_config.save(app)
+        app.config.update(global_orchest_config.as_dict())
 
     app.config["ORCHEST_REPO_TAG"] = get_repo_tag()
 

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -24,18 +24,14 @@ from flask_socketio import SocketIO
 from sqlalchemy_utils import create_database, database_exists
 
 from _orchest.internals import config as _config
-from _orchest.internals.utils import is_werkzeug_parent
+from _orchest.internals import errors as _errors
+from _orchest.internals import utils as _utils
 from app import analytics, config
 from app.connections import db, ma
 from app.kernel_manager import populate_kernels
 from app.models import Project
 from app.socketio_server import register_socketio_broadcast
-from app.utils import (
-    fetch_orchest_examples_json_to_disk,
-    get_repo_tag,
-    get_user_conf,
-    migrate_user_config,
-)
+from app.utils import fetch_orchest_examples_json_to_disk, get_repo_tag
 from app.views.analytics import register_analytics_views
 from app.views.background_tasks import register_background_tasks_view
 from app.views.orchest_api import register_orchest_api_views
@@ -68,11 +64,10 @@ def create_app():
 
     # read directory mount based config into Flask config
     try:
-        migrate_user_config()
-        conf_data = get_user_conf()
-        app.config.update(conf_data)
-    except Exception:
-        app.logger.warning("Failed to load config.json")
+        global_user_config = _utils.GlobalOrchestConfig()
+        global_user_config.save(app)
+    except _errors.CorruptedFileError:
+        app.logger.error("Failed to load global user config file.")
 
     app.config["ORCHEST_REPO_TAG"] = get_repo_tag()
 
@@ -107,7 +102,7 @@ def create_app():
     with app.app_context():
 
         # Alembic does not support calling upgrade() concurrently
-        if not is_werkzeug_parent():
+        if not _utils.is_werkzeug_parent():
             # Upgrade to the latest revision. This also takes care of
             # bringing an "empty" db (no tables) on par.
             try:
@@ -193,7 +188,7 @@ def create_app():
 
     processes = []
 
-    if not is_werkzeug_parent():
+    if not _utils.is_werkzeug_parent():
 
         file_dir = os.path.dirname(os.path.realpath(__file__))
 

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -65,9 +65,10 @@ def create_app():
     # read directory mount based config into Flask config
     try:
         global_user_config = _utils.GlobalOrchestConfig()
-        global_user_config.save(app)
     except _errors.CorruptedFileError:
-        app.logger.error("Failed to load global user config file.")
+        app.logger.error("Failed to load global orchest config file.", exc_info=True)
+    else:
+        global_user_config.save(app)
 
     app.config["ORCHEST_REPO_TAG"] = get_repo_tag()
 

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -310,48 +310,6 @@ def get_repo_tag():
     return os.getenv("ORCHEST_VERSION")
 
 
-def get_user_conf():
-    conf_data = {}
-
-    # configure default value
-    conf_data["AUTH_ENABLED"] = False
-    conf_data["INTERCOM_USER_EMAIL"] = "johndoe@example.org"
-
-    try:
-        with open("/config/config.json", "r") as f:
-            conf_data = json.load(f)
-    except Exception as e:
-        current_app.logger.debug(e)
-
-    return conf_data
-
-
-def get_user_conf_raw():
-    try:
-        with open("/config/config.json", "r") as f:
-            return f.read()
-    except Exception as e:
-        current_app.logger.debug(e)
-
-
-def migrate_user_config():
-    config = get_user_conf_raw()
-    if config is None:
-        return
-    config = json.loads(config)
-    if "MAX_JOB_RUNS_PARALLELISM" not in config:
-        config["MAX_JOB_RUNS_PARALLELISM"] = 1
-        save_user_conf_raw(json.dumps(config))
-
-
-def save_user_conf_raw(config):
-    try:
-        with open("/config/config.json", "w") as f:
-            f.write(config)
-    except Exception as e:
-        current_app.logger.debug(e)
-
-
 def clear_folder(folder):
     try:
         for filename in os.listdir(folder):

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -248,7 +248,7 @@ def register_views(app, db):
                 app.logger.debug(e, exc_info=True)
                 return user_config.get()
 
-            user_config.update(config)
+            user_config.set(config)
             user_config.save(flask_app=app)
 
         return user_config.get()

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -12,6 +12,8 @@ from nbconvert import HTMLExporter
 from sqlalchemy.orm.exc import NoResultFound
 
 from _orchest.internals import config as _config
+from _orchest.internals import errors as _errors
+from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor
 from _orchest.internals.utils import run_orchest_ctl
 from app import analytics, error
@@ -45,14 +47,11 @@ from app.utils import (
     get_project_snapshot_size,
     get_repo_tag,
     get_session_counts,
-    get_user_conf,
-    get_user_conf_raw,
     is_valid_project_relative_path,
     normalize_project_relative_path,
     pipeline_set_notebook_kernels,
     project_entity_counts,
     project_exists,
-    save_user_conf_raw,
     serialize_environment_to_disk,
 )
 
@@ -167,9 +166,10 @@ def register_views(app, db):
             "PIPELINE_PARAMETERS_RESERVED_KEY",
         ]
 
+        user_config = _utils.GlobalOrchestConfig()
         return jsonify(
             {
-                "user_config": get_user_conf(),
+                "user_config": user_config.get(),
                 "config": {
                     **{key: app.config[key] for key in front_end_config},
                     **{key: getattr(_config, key) for key in front_end_config_internal},
@@ -228,47 +228,30 @@ def register_views(app, db):
     def user_config():
 
         # Current user config, from disk.
-        current_config = json.loads(get_user_conf_raw())
+        try:
+            user_config = _utils.GlobalOrchestConfig()
+        except _errors.CorruptedFileError as e:
+            app.logger.error(e, exc_info=True)
+            return {"message": "Global user configuration could not be read."}, 500
 
         if request.method == "POST":
-
             # Updated config, from client.
             config = request.form.get("config")
+
+            if config is None:
+                return user_config.get()
 
             try:
                 # Only save if parseable JSON.
                 config = json.loads(config)
             except json.JSONDecodeError as e:
                 app.logger.debug(e, exc_info=True)
-                return current_config
+                return user_config.get()
 
-            max_job_runs_parallelism = config.get("MAX_JOB_RUNS_PARALLELISM")
-            if (
-                not isinstance(max_job_runs_parallelism, int)
-                or max_job_runs_parallelism <= 0
-            ):
-                config["MAX_JOB_RUNS_PARALLELISM"] = 1
+            user_config.update(config)
+            user_config.save(flask_app=app)
 
-            auth_enabled = config.get("AUTH_ENABLED")
-            if not isinstance(auth_enabled, bool):
-                config["AUTH_ENABLED"] = False
-
-            # Do not allow some settings to be modified or removed while
-            # running with --cloud, by overwriting whatever value was
-            # set (or unset) by checking it against the current
-            # configuration.
-            if StaticConfig.CLOUD:
-                for setting in StaticConfig.CLOUD_UNMODIFIABLE_CONFIG_VALUES:
-                    if setting in current_config:
-                        config[setting] = current_config[setting]
-                    else:
-                        config.pop(setting, None)
-
-            # Save the updated configuration.
-            save_user_conf_raw(json.dumps(config))
-            current_config = config
-
-        return current_config
+        return user_config.get()
 
     @app.route("/async/host-info", methods=["GET"])
     def host_info():

--- a/services/orchest-webserver/app/tests/conftest.py
+++ b/services/orchest-webserver/app/tests/conftest.py
@@ -36,7 +36,12 @@ def test_app():
     yield app
 
     drop_database(app.config["SQLALCHEMY_DATABASE_URI"])
-    os.remove(os.path.join(TEMP_DIR, "config.json"))
+    try:
+        os.remove(os.path.join(TEMP_DIR, "config.json"))
+    except FileNotFoundError:
+        # Config file was never created because default values were
+        # never updated.
+        ...
 
 
 @pytest.fixture()

--- a/services/orchest-webserver/app/tests/conftest.py
+++ b/services/orchest-webserver/app/tests/conftest.py
@@ -4,9 +4,13 @@ import pytest
 from sqlalchemy_utils import drop_database
 from tests.test_utils import Pipeline, Project
 
+from _orchest.internals import utils as _utils
 from _orchest.internals.test_utils import gen_uuid
 from app import config, create_app
 from app.connections import db
+
+BASEPATH = os.path.dirname(__file__)
+TEMP_DIR = os.path.join(BASEPATH, "tmp-artifacts")
 
 
 @pytest.fixture(scope="module")
@@ -27,10 +31,12 @@ def test_app():
     SQLALCHEMY_DATABASE_URI = f"postgresql://postgres@{db_host}:{db_port}/{db_name}"
     config.TestingConfig.SQLALCHEMY_DATABASE_URI = SQLALCHEMY_DATABASE_URI
     config.CONFIG_CLASS = config.TestingConfig
+    _utils.GlobalOrchestConfig._path = os.path.join(TEMP_DIR, "config.json")
     app, _, _ = create_app()
     yield app
 
     drop_database(app.config["SQLALCHEMY_DATABASE_URI"])
+    os.remove(os.path.join(TEMP_DIR, "config.json"))
 
 
 @pytest.fixture()

--- a/services/orchest-webserver/app/tests/tmp-artifacts/.gitignore
+++ b/services/orchest-webserver/app/tests/tmp-artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -59,7 +59,10 @@ const SettingsView: React.FC = () => {
       .catch(console.error);
   };
 
-  const REQUIRES_RESTART_ON_CHANGE = ["MAX_JOB_RUNS_PARALLELISM"];
+  const REQUIRES_RESTART_ON_CHANGE = [
+    "MAX_JOB_RUNS_PARALLELISM",
+    "MAX_INTERACTIVE_RUNS_PARALLELISM",
+  ];
 
   const getConfig = () => {
     let getConfigPromise = makeCancelable(

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -31,7 +31,8 @@ const SettingsView: React.FC = () => {
     configJSON: undefined,
     version: undefined,
     hostInfo: undefined,
-    requiresRestart: false,
+    // changed config options that require an Orchest restart
+    requiresRestart: [],
   });
 
   const [promiseManager] = React.useState(new PromiseManager());
@@ -213,7 +214,7 @@ const SettingsView: React.FC = () => {
           ...prevState,
           restarting: true,
           status: "restarting",
-          requiresRestart: false,
+          requiresRestart: [],
         }));
 
         makeRequest("POST", "/async/restart")
@@ -327,11 +328,14 @@ const SettingsView: React.FC = () => {
                       }
                     })()}
                     {(() => {
-                      if (state.requiresRestart) {
+                      if (state.requiresRestart.length > 0) {
+                        let vals = state.requiresRestart.map(
+                          (val) => `"${val}" `
+                        );
                         return (
                           <div className="warning push-up">
                             <i className="material-icons">info</i> Restart
-                            Orchest to have the changes take effect.
+                            Orchest for the changes to {vals} to take effect.
                           </div>
                         );
                       }

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -273,13 +273,6 @@ const SettingsView: React.FC = () => {
         <h2>Orchest settings</h2>
         <div className="push-down">
           <div>
-            <p className="push-down">
-              Enabling authentication through{" "}
-              <span className="code">AUTH_ENABLED</span> will automatically
-              redirect you to the login page, so make sure you have set up a
-              user first!
-            </p>
-
             {(() => {
               if (state.config === undefined) {
                 return <p>Loading config...</p>;
@@ -326,6 +319,17 @@ const SettingsView: React.FC = () => {
                               ))}{" "}
                               cannot be modified when running in the{" "}
                               <span className="code">cloud</span>.
+                            </p>
+                          </div>
+                        );
+                      } else {
+                        return (
+                          <div className="push-up notice">
+                            <p>
+                              Enabling authentication through{" "}
+                              <span className="code">AUTH_ENABLED</span> will
+                              automatically redirect you to the login page, so
+                              make sure you have set up a user first!
                             </p>
                           </div>
                         );


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Fixes: #501 

This PR also introduces the `GlobalOrchestConfig` class and refactors all access to the global Orchest config file (`~/.config/orchest/config.json` on the host) to use the class. The class ensures all configuration options have a default value and are validated when changed, and certain preset options in the file cannot be changed when running with `--cloud`.

### Checklist

- [X] The documentation reflects the changes.
- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.

### Other

@fruttasecca Can you back up your current config file and then build the branch and try to use Orchest? That would be great, thank you!
