### PR TITLE
Feat/idle checking

### DIFF
--- a/services/orchest-api/app/app/apis/__init__.py
+++ b/services/orchest-api/app/app/apis/__init__.py
@@ -3,6 +3,7 @@ from flask_restx import Api
 
 from app.apis.namespace_environment_builds import api as ns_env_builds
 from app.apis.namespace_environment_images import api as ns_env_images
+from app.apis.namespace_info import api as ns_info
 from app.apis.namespace_jobs import api as ns_jobs
 from app.apis.namespace_jupyter_builds import api as ns_jupyter_builds
 from app.apis.namespace_pipelines import api as ns_pipelines
@@ -31,3 +32,4 @@ api.add_namespace(ns_runs)
 api.add_namespace(ns_sessions)
 api.add_namespace(ns_services)
 api.add_namespace(ns_validations)
+api.add_namespace(ns_info)

--- a/services/orchest-api/app/app/apis/namespace_info.py
+++ b/services/orchest-api/app/app/apis/namespace_info.py
@@ -28,7 +28,7 @@ class IdleCheck(Resource):
             state is reported by JupyterLab, and reflects the fact that
             a kernel is not actively doing some compute.
         """
-        idleness_data = utils.is_orchest_api_idle()
+        idleness_data = utils.is_orchest_idle()
         return idleness_data, 200
 
 

--- a/services/orchest-api/app/app/apis/namespace_info.py
+++ b/services/orchest-api/app/app/apis/namespace_info.py
@@ -1,0 +1,32 @@
+"""API endpoints for unspecified orchest-api level information."""
+
+from flask_restx import Namespace, Resource
+
+from app import schema, utils
+
+api = Namespace("info", description="Orchest-api information.")
+api = utils.register_schema(api)
+
+
+@api.route("/idle")
+class IdleCheck(Resource):
+    @api.doc("orchest_api_idle")
+    @api.marshal_with(
+        schema.idleness_check_result,
+        code=200,
+        description="Orchest-api idleness check.",
+    )
+    def get(self):
+        """Checks if the Orchest-api is idle.
+
+        The Orchest-api is considered idle if:
+        - no environments are being built
+        - no jupyter images are being built
+        - there are no ongoing interactive-runs
+        - there are no ongoing job runs
+        - there are no busy kernels among running sessions, said busy
+            state is reported by JupyterLab, and reflects the fact that
+            a kernel is not actively doing some compute.
+        """
+        idleness_data = utils.is_orchest_api_idle()
+        return idleness_data, 200

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -518,7 +518,7 @@ class InteractiveSession(Session):
         # 'last_activity': '2021-11-10T09:04:10.508031Z',
         # 'execution_state': 'idle', 'connections': 2}]
         kernels: List[dict] = response.json()
-        return any([kernel.get("execution_state") == "busy" for kernel in kernels])
+        return any(kernel.get("execution_state") == "busy" for kernel in kernels)
 
     def shutdown(self) -> None:
         """Shuts down the launch.

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -491,18 +491,19 @@ class InteractiveSession(Session):
         """
         IP = self.get_containers_IP()
 
-        self._notebook_server_info = {
-            "port": 8888,
-            "base_url": "/"
-            + _config.JUPYTER_SERVER_NAME.format(
-                project_uuid=session_config["project_uuid"][
-                    : _config.TRUNCATED_UUID_LENGTH
-                ],
-                pipeline_uuid=session_config["pipeline_uuid"][
-                    : _config.TRUNCATED_UUID_LENGTH
-                ],
-            ),
-        }
+        if self._notebook_server_info is None:
+            self._notebook_server_info = {
+                "port": 8888,
+                "base_url": "/"
+                + _config.JUPYTER_SERVER_NAME.format(
+                    project_uuid=session_config["project_uuid"][
+                        : _config.TRUNCATED_UUID_LENGTH
+                    ],
+                    pipeline_uuid=session_config["pipeline_uuid"][
+                        : _config.TRUNCATED_UUID_LENGTH
+                    ],
+                ),
+            }
 
         # https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html
         url = (

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -6,7 +6,7 @@ import traceback
 from abc import abstractmethod
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 from uuid import uuid4
 
 import docker
@@ -480,6 +480,44 @@ class InteractiveSession(Session):
                 break
 
         return
+
+    def has_busy_kernels(self, session_config: Dict[str, Any]) -> bool:
+        """Tells if the session has busy kernels.
+
+        Args:
+            session_config: Requires a "project_uuid" and a
+            "pipeline_uuid".
+
+        """
+        IP = self.get_containers_IP()
+
+        self._notebook_server_info = {
+            "port": 8888,
+            "base_url": "/"
+            + _config.JUPYTER_SERVER_NAME.format(
+                project_uuid=session_config["project_uuid"][
+                    : _config.TRUNCATED_UUID_LENGTH
+                ],
+                pipeline_uuid=session_config["pipeline_uuid"][
+                    : _config.TRUNCATED_UUID_LENGTH
+                ],
+            ),
+        }
+
+        # https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html
+        url = (
+            f"http://{IP.jupyter_server}"
+            f":8888{self._notebook_server_info['base_url']}/api/kernels"
+        )
+        response = requests.get(url, timeout=2.0)
+
+        # Expected format: a list of dictionaries.
+        # [{'id': '3af6f3b9-4358-43b9-b2dd-03b51c4f7881', 'name':
+        # 'orchest-kernel-c56ab762-539c-4cce-9b1e-c4b00300ec6f',
+        # 'last_activity': '2021-11-10T09:04:10.508031Z',
+        # 'execution_state': 'idle', 'connections': 2}]
+        kernels: List[dict] = response.json()
+        return any([kernel.get("execution_state") == "busy" for kernel in kernels])
 
     def shutdown(self) -> None:
         """Shuts down the launch.

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -8,9 +8,10 @@ TODO:
 
 """
 import copy
+import datetime
 from typing import Any, Dict
 
-from sqlalchemy import ForeignKeyConstraint, Index, UniqueConstraint, text
+from sqlalchemy import ForeignKeyConstraint, Index, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
 from sqlalchemy.orm import deferred
 
@@ -709,3 +710,19 @@ ForeignKeyConstraint(
     [InteractiveSession.project_uuid, InteractiveSession.pipeline_uuid],
     ondelete="CASCADE",
 )
+
+
+class ClientHeartbeat(BaseModel):
+    """Clients heartbeat for idle checking."""
+
+    __tablename__ = "client_heartbeats"
+
+    id = db.Column(db.BigInteger, primary_key=True)
+
+    timestamp = db.Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        index=True,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        server_default=func.now(),
+    )

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -8,7 +8,6 @@ TODO:
 
 """
 import copy
-import datetime
 from typing import Any, Dict
 
 from sqlalchemy import ForeignKeyConstraint, Index, UniqueConstraint, func, text
@@ -723,6 +722,5 @@ class ClientHeartbeat(BaseModel):
         TIMESTAMP(timezone=True),
         nullable=False,
         index=True,
-        default=lambda: datetime.datetime.now(datetime.timezone.utc),
         server_default=func.now(),
     )

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -659,3 +659,39 @@ validation_environments_result = Model(
         ),
     },
 )
+
+_idleness_check_result_details = Model(
+    "IdlenessCheckResultDetails",
+    {
+        "no_ongoing_environment_builds": fields.Boolean(
+            required=True,
+        ),
+        "no_ongoing_jupyterlab_builds": fields.Boolean(
+            required=True,
+        ),
+        "no_ongoing_interactive_runs": fields.Boolean(
+            required=True,
+        ),
+        "no_ongoing_job_runs": fields.Boolean(
+            required=True,
+        ),
+        "no_busy_kernels": fields.Boolean(
+            required=True,
+        ),
+    },
+)
+
+idleness_check_result = Model(
+    "IdlenessCheckResult",
+    {
+        "idle": fields.Boolean(
+            required=True,
+            description="True if the Orchest-api is idle.",
+        ),
+        "details": fields.Nested(
+            _idleness_check_result_details,
+            required=True,
+            description="Details of the idleness check.",
+        ),
+    },
+)

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -663,6 +663,9 @@ validation_environments_result = Model(
 _idleness_check_result_details = Model(
     "IdlenessCheckResultDetails",
     {
+        "no_active_clients": fields.Boolean(
+            required=True,
+        ),
         "no_ongoing_environment_builds": fields.Boolean(
             required=True,
         ),

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -663,22 +663,22 @@ validation_environments_result = Model(
 _idleness_check_result_details = Model(
     "IdlenessCheckResultDetails",
     {
-        "no_active_clients": fields.Boolean(
+        "active_clients": fields.Boolean(
             required=True,
         ),
-        "no_ongoing_environment_builds": fields.Boolean(
+        "ongoing_environment_builds": fields.Boolean(
             required=True,
         ),
-        "no_ongoing_jupyterlab_builds": fields.Boolean(
+        "ongoing_jupyterlab_builds": fields.Boolean(
             required=True,
         ),
-        "no_ongoing_interactive_runs": fields.Boolean(
+        "ongoing_interactive_runs": fields.Boolean(
             required=True,
         ),
-        "no_ongoing_job_runs": fields.Boolean(
+        "ongoing_job_runs": fields.Boolean(
             required=True,
         ),
-        "no_busy_kernels": fields.Boolean(
+        "busy_kernels": fields.Boolean(
             required=True,
         ),
     },

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -751,8 +751,8 @@ def is_orchest_idle() -> dict:
                 "pipeline_uuid": session.pipeline_uuid,
             }
         )
-        data["busy_kernels"] = data["busy_kernels"] or session_has_busy_kernels
-        if data["busy_kernels"]:
+        if session_has_busy_kernels:
+            data["busy_kernels"] = True
             break
 
     # Assumes the model has a uuid field and its lifecycle contains the

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -16,6 +16,7 @@ from _orchest.internals.utils import docker_images_list_safe, docker_images_rm_s
 from app import errors as self_errors
 from app import schema
 from app.connections import db, docker_client
+from app.core import sessions
 
 
 def register_schema(api: Namespace) -> Namespace:
@@ -711,3 +712,56 @@ def delete_dangling_orchest_images() -> None:
         env_uuid = img.labels.get("_orchest_environment_uuid")
         if env_uuid is None:
             docker_images_rm_safe(docker_client, img.id)
+
+
+def is_orchest_api_idle() -> dict:
+    """Checks if the orchest-api is idle.
+
+    Returns:
+        See schema.idleness_check_result for details.
+    """
+    result = {"idle": True, "details": {"no_busy_kernels": True}}
+
+    # Find busy kernels.
+    isessions = models.InteractiveSession.query.filter(
+        models.InteractiveSession.status.in_(["RUNNING"])
+    ).all()
+    for session in isessions:
+        session_obj = sessions.InteractiveSession.from_container_IDs(
+            docker_client,
+            container_IDs=session.container_ids,
+            network=_config.DOCKER_NETWORK,
+            notebook_server_info=session.notebook_server_info,
+        )
+        session_has_busy_kernels = session_obj.has_busy_kernels(
+            {
+                "project_uuid": session.project_uuid,
+                "pipeline_uuid": session.pipeline_uuid,
+            }
+        )
+        result["details"]["no_busy_kernels"] = (
+            result["details"]["no_busy_kernels"] and not session_has_busy_kernels
+        )
+    result["idle"] = result["idle"] and result["details"]["no_busy_kernels"]
+
+    # Assumes the model has a uuid field and its lifecycle contains the
+    # PENDING and STARTED statuses. NOTE: we could be stopping earlier
+    # on truthy values since we already know the orchest-api is idle at
+    # this point, but providing all details might allow to further build
+    # on this "feature" in the future without fragmenting users due to
+    # different versions.
+    for name, model in [
+        ("no_ongoing_environment_builds", models.EnvironmentBuild),
+        ("no_ongoing_jupyterlab_builds", models.JupyterBuild),
+        ("no_ongoing_interactive_runs", models.InteractivePipelineRun),
+        ("no_ongoing_job_runs", models.NonInteractivePipelineRun),
+    ]:
+        result["details"][name] = not db.session.query(
+            db.session.query(model)
+            .filter(model.status.in_(["PENDING", "STARTED"]))
+            .exists()
+        ).scalar()
+        result["idle"] = result["idle"] and result["details"][name]
+
+    current_app.logger.info(result)
+    return result

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -714,7 +714,7 @@ def delete_dangling_orchest_images() -> None:
             docker_images_rm_safe(docker_client, img.id)
 
 
-def is_orchest_api_idle() -> dict:
+def is_orchest_idle() -> dict:
     """Checks if the orchest-api is idle.
 
     Returns:
@@ -727,7 +727,6 @@ def is_orchest_api_idle() -> dict:
         datetime.now(timezone.utc)
         - current_app.config["CLIENT_HEARTBEATS_IDLENESS_THRESHOLD"]
     )
-    current_app.logger.error(threshold)
     data["active_clients"] = db.session.query(
         db.session.query(models.ClientHeartbeat)
         .filter(models.ClientHeartbeat.timestamp > threshold)
@@ -753,6 +752,8 @@ def is_orchest_api_idle() -> dict:
             }
         )
         data["busy_kernels"] = data["busy_kernels"] or session_has_busy_kernels
+        if data["busy_kernels"]:
+            break
 
     # Assumes the model has a uuid field and its lifecycle contains the
     # PENDING and STARTED statuses. NOTE: we could be stopping earlier

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -1,3 +1,5 @@
+import datetime
+
 from _orchest.internals import config as _config
 
 
@@ -19,6 +21,10 @@ class Config:
     SCHEDULER_INTERVAL = 10
 
     GPU_ENABLED_INSTANCE = _config.GPU_ENABLED_INSTANCE
+
+    # Used to decide when client heartbeats are too old to represent
+    # activity.
+    CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=5)
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -24,7 +24,7 @@ class Config:
 
     # Used to decide when client heartbeats are too old to represent
     # activity.
-    CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=5)
+    CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=30)
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-api/app/migrations/versions/00e31eec40c6_.py
+++ b/services/orchest-api/app/migrations/versions/00e31eec40c6_.py
@@ -1,0 +1,43 @@
+"""empty message
+
+Revision ID: 00e31eec40c6
+Revises: 8feeb577ca3f
+Create Date: 2021-11-10 12:35:38.097364
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "00e31eec40c6"
+down_revision = "8feeb577ca3f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "client_heartbeats",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "timestamp",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_client_heartbeats")),
+    )
+    op.create_index(
+        op.f("ix_client_heartbeats_timestamp"),
+        "client_heartbeats",
+        ["timestamp"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_client_heartbeats_timestamp"), table_name="client_heartbeats"
+    )
+    op.drop_table("client_heartbeats")

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -625,3 +625,10 @@ def register_orchest_api_views(app, db):
         except Exception as e:
             msg = f"Error during job deletion:{e}"
             return {"message": msg}, 500
+
+    @app.route("/catch/api-proxy/idle", methods=["GET"])
+    def catch_idle_check_get():
+        resp = requests.get(
+            (f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/info/idle')
+        )
+        return resp.content, resp.status_code, resp.headers.items()

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -199,6 +199,15 @@ def register_views(app, db):
 
     @app.route("/heartbeat", methods=["GET"])
     def heartbeat():
+        # Don't bubble up the fact that the heartbeat is proxied to the
+        # orchest-api to the client.
+        requests.get(
+            (
+                f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/info/'
+                "client-heartbeat"
+            )
+        )
+
         return ""
 
     @app.route("/async/restart", methods=["POST"])

--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -1,5 +1,7 @@
 import { useOrchest } from "@/hooks/orchest";
+import { useInterval } from "@/hooks/use-interval";
 import { Routes } from "@/Routes";
+import { makeRequest } from "@orchest/lib-utils";
 import $ from "jquery";
 import React, { useRef } from "react";
 import { BrowserRouter as Router, Prompt } from "react-router-dom";
@@ -42,6 +44,12 @@ const App = () => {
 
   // load server side config populated by flask template
   const { config, user_config } = context.state;
+
+  // Each client provides an heartbeat, used for telemetry and idle
+  // checking.
+  useInterval(() => {
+    makeRequest("GET", "/heartbeat");
+  }, 5000);
 
   React.useEffect(() => {
     if (config.FLASK_ENV === "development") {


### PR DESCRIPTION
## Description

This PR introduces an endpoint in the `orchest-api` (also proxied by the `orchest-webserver`) that allows knowing if Orchest is idle or not.
The requirement for Orchest being considered idle are:
- no active clients, meaning no heartbeat from a client for 5 minutes
- no ongoing environment builds
- no ongoing JupyterLab builds
- no ongoing interactive runs
- no ongoing job runs
- no busy kernels, according to the JupyterLab API

Example of the returned data.
```json
{
    "idle": false,
    "details": {
        "no_active_clients": false, 
        "no_ongoing_environment_builds": true, 
        "no_ongoing_jupyterlab_builds": true, 
        "no_ongoing_interactive_runs": true, 
        "no_ongoing_job_runs": true,
        "no_busy_kernels": true
        }
}
```
Client heartbeats are kept track of with a database entry.

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database migrations.

@iannbing I ended up using `useInterval` since it looked like a simple solution, let me know what you think :). 

NOTE: the branch contains a schema migration