### PR TITLE
Fix/#546 open in edit mode after build completes

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -80,14 +80,12 @@ const App = () => {
   const requestBuild = (
     project_uuid: string,
     environmentValidationData,
-    requestedFromView,
-    onBuildComplete,
+    requestedFromView: string,
+    onBuildComplete: () => void,
     onCancel: () => void
   ) => {
     // Analytics call
-    sendEvent("build request", {
-      requestedFromView: requestedFromView,
-    });
+    sendEvent("build request", { requestedFromView });
 
     dialogsRef.current.requestBuild(
       project_uuid,

--- a/services/orchest-webserver/client/src/components/Dialogs.tsx
+++ b/services/orchest-webserver/client/src/components/Dialogs.tsx
@@ -33,8 +33,8 @@ const Dialogs = (_, ref) => {
   const requestBuild = (
     project_uuid,
     environmentValidationData,
-    requestedFromView,
-    onBuildComplete,
+    requestedFromView: string,
+    onBuildComplete: () => void,
     onCancel
   ) => {
     let uuid = uuidv4();

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -24,7 +24,7 @@ export interface IPipelineStepProps {
 const PipelineStep = (props: IPipelineStepProps, ref: TPipelineStepRef) => {
   const [refManager] = React.useState(new RefManager());
 
-  const updatePosition = (position) => {
+  const updatePosition = (position: [number, number]) => {
     // note: DOM update outside of normal React loop for performance
     refManager.refs.container.style.transform =
       "translateX(" + position[0] + "px) translateY(" + position[1] + "px)";

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -132,12 +132,13 @@ const PipelineView: React.FC = () => {
   } = useCustomRoute();
 
   const [isReadOnly, _setIsReadOnly] = useState(isReadOnlyFromQueryString);
-  const setIsReadOnly = (readOnly) => {
+  const setIsReadOnly = (readOnly: boolean) => {
     dispatch({
       type: "pipelineUpdateReadOnlyState",
       payload: readOnly,
     });
     _setIsReadOnly(readOnly);
+    if (!readOnly) initializePipelineEditListeners();
   };
 
   const [shouldAutoStart, setShouldAutoStart] = useState(!isReadOnly);
@@ -2519,7 +2520,7 @@ const PipelineView: React.FC = () => {
                 {state.eventVars.stepSelector.active && (
                   <Rectangle
                     {...getStepSelectorRectangle(state.eventVars.stepSelector)}
-                  ></Rectangle>
+                  />
                 )}
                 {pipelineSteps}
                 <div className="connections">{connectionComponents}</div>

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -173,14 +173,12 @@ export function getServiceURLs(
   return urls;
 }
 
-export function checkGate(project_uuid) {
+export function checkGate(project_uuid: string) {
   return new Promise((resolve, reject) => {
     // we validate whether all environments have been built on the server
     makeRequest("POST", `/catch/api-proxy/api/validations/environments`, {
       type: "json",
-      content: {
-        project_uuid: project_uuid,
-      },
+      content: { project_uuid },
     })
       .then((response: string) => {
         try {


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Fixes: #546 

### Checklist

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
