### PR TITLE
Improv/docs on mobile

### DIFF
--- a/docs/source/_static/css/custom_styles.css
+++ b/docs/source/_static/css/custom_styles.css
@@ -27,6 +27,11 @@
   top: auto !important;
 }
 
+.algolia-autocomplete .ds-dropdown-menu {
+  min-width: 0px;
+  max-width: 100%;
+}
+
 /* Color tweaking, this is not yet possible in conf.py so !important
 overrides like below are unfortunately required. */
 :root {

--- a/docs/source/_static/css/custom_styles.css
+++ b/docs/source/_static/css/custom_styles.css
@@ -11,7 +11,7 @@
 
 .sidebar,
 .vp-sidebar {
-  position: static !important;
+  /* position: static !important; */
 }
 
 .sidebar form.search input[type="text"],
@@ -67,4 +67,10 @@ a:hover {
 .admonition.hint,
 .admonition.tip {
   border-color: var(--blue) !important;
+}
+
+@media (max-width: 800px) {
+  img {
+    width: 100% !important;
+  }
 }

--- a/docs/source/_static/css/custom_styles.css
+++ b/docs/source/_static/css/custom_styles.css
@@ -9,11 +9,6 @@
   display: block;
 }
 
-.sidebar,
-.vp-sidebar {
-  /* position: static !important; */
-}
-
 .sidebar form.search input[type="text"],
 .vp-sidebar form.search input[type="text"] {
   padding: 4px;

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -16,18 +16,6 @@
       algoliaOptions: { facetFilters: ["lang:en"] },
       debug: false, // Set debug to true if you want to inspect the dropdown
     });
-
-    // Fix absolute positioning rendering in Safari
-    let el = document.querySelector(".vp-sidebar,.sidebar");
-    let newEl = document.createElement("div");
-    newEl.style.position = "fixed";
-    newEl.style.height = "calc(100vh - 3.6rem)";
-    newEl.style.marginTop = "3.6rem";
-    newEl.style.zIndex = 99;
-    el.style.height = "100%";
-    el.insertAdjacentElement("beforebegin", newEl);
-    el.remove();
-    newEl.appendChild(el);
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

Images are not scaled down on mobile. And the sidebar is blocking the content on mobile.

### Checklist

- [x] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
