### PR TITLE
Use separate Python environment to do pipeline runs

### DIFF
--- a/services/base-images/base-kernel-julia/Dockerfile
+++ b/services/base-images/base-kernel-julia/Dockerfile
@@ -25,11 +25,21 @@ RUN chown $NB_USER -R /orchest/orchest-sdk
 RUN chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
-RUN pip install -r requirements.txt
+RUN pip install -r requirements-user.txt
+# Install Orchest dependencies in our own environment
+RUN conda create -y -n orchestdependencies && \
+    # requirements.txt includes local install and thus we need to use pip
+    conda install -y -n orchestdependencies pip && \
+    conda run -n orchestdependencies pip install -r requirements.txt
 
 COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 
 ENV HOME=/home/$NB_USER
+
+# This path is searched first to locate kernels. Without this variable
+# Jupyter will search inside the orchestdependencies environment first
+# and end up using the wrong executable to start the kernel.
+ENV JUPYTER_PATH=/opt/conda/share/jupyter
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}

--- a/services/base-images/base-kernel-julia/Dockerfile
+++ b/services/base-images/base-kernel-julia/Dockerfile
@@ -27,7 +27,7 @@ RUN chown $NB_USER -R /orchest/lib
 USER $NB_USER
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
-RUN conda create -y -n orchestdependencies && \
+RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
     # requirements.txt includes local install and thus we need to use pip
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt

--- a/services/base-images/base-kernel-julia/Dockerfile
+++ b/services/base-images/base-kernel-julia/Dockerfile
@@ -2,29 +2,31 @@
 FROM orchest/kernel-julia:2.3.0
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
+# --------------------------------------------------
+# All lines below are the same for all base-kernel-* images that we
+# have. Due to how Docker works we sadly have to copy it into every
+# Dockerfile (instead of a DRY solution), you can read more here:
+# https://github.com/moby/moby/issues/3378
+# --------------------------------------------------
 USER root
+
+RUN apt-get update \
+    && apt-get install default-libmysqlclient-dev sudo -y
+
 # enable sudo for the NB_USER by default
 RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
 
-WORKDIR /
-
-# mysql_config is required for orchest-sdk
-COPY ./base-kernel-julia/*.sh /
-
-# Run augment script
-RUN ./augment-root.sh
-
-# Install our internal libraries
+# Get all requirements in place.
+COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/
 COPY ./lib/python /orchest/lib/python
 COPY ./orchest-sdk /orchest/orchest-sdk
-
-COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
-WORKDIR /orchest/services/base-images/runnable-shared/runner
-
-RUN chown $NB_USER -R /orchest/orchest-sdk
-RUN chown $NB_USER -R /orchest/lib
+RUN chown $NB_USER -R /orchest/orchest-sdk \
+    && chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
+
+# Install requirements.
+WORKDIR /orchest/services/base-images/runnable-shared/runner
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
 RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
@@ -32,16 +34,17 @@ RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdepen
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt
 
-COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
-
-ENV HOME=/home/$NB_USER
+# Get application files.
+COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
 
 # This path is searched first to locate kernels. Without this variable
 # Jupyter will search inside the orchestdependencies environment first
 # and end up using the wrong executable to start the kernel.
 ENV JUPYTER_PATH=/opt/conda/share/jupyter
+ENV HOME=/home/$NB_USER
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}
 
+COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 CMD [ "/orchest/bootscript.sh" ]

--- a/services/base-images/base-kernel-julia/augment-root.sh
+++ b/services/base-images/base-kernel-julia/augment-root.sh
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install default-libmysqlclient-dev sudo -y

--- a/services/base-images/base-kernel-py-gpu/Dockerfile
+++ b/services/base-images/base-kernel-py-gpu/Dockerfile
@@ -23,11 +23,21 @@ RUN chown $NB_USER -R /orchest/orchest-sdk
 RUN chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
-RUN pip install -r requirements.txt
+RUN pip install -r requirements-user.txt
+# Install Orchest dependencies in our own environment
+RUN conda create -y -n orchestdependencies && \
+    # requirements.txt includes local install and thus we need to use pip
+    conda install -y -n orchestdependencies pip && \
+    conda run -n orchestdependencies pip install -r requirements.txt
 
 COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 
 ENV HOME=/home/$NB_USER
+
+# This path is searched first to locate kernels. Without this variable
+# Jupyter will search inside the orchestdependencies environment first
+# and end up using the wrong executable to start the kernel.
+ENV JUPYTER_PATH=/opt/conda/share/jupyter
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}

--- a/services/base-images/base-kernel-py-gpu/Dockerfile
+++ b/services/base-images/base-kernel-py-gpu/Dockerfile
@@ -25,7 +25,7 @@ RUN chown $NB_USER -R /orchest/lib
 USER $NB_USER
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
-RUN conda create -y -n orchestdependencies && \
+RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
     # requirements.txt includes local install and thus we need to use pip
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt

--- a/services/base-images/base-kernel-py-gpu/Dockerfile
+++ b/services/base-images/base-kernel-py-gpu/Dockerfile
@@ -1,28 +1,31 @@
 # Base root container on cuda/cudnn enabled image
 FROM orchest/kernel-py:2.3.0-gpu
 
+# --------------------------------------------------
+# All lines below are the same for all base-kernel-* images that we
+# have. Due to how Docker works we sadly have to copy it into every
+# Dockerfile (instead of a DRY solution), you can read more here:
+# https://github.com/moby/moby/issues/3378
+# --------------------------------------------------
 USER root
+
+RUN apt-get update \
+    && apt-get install default-libmysqlclient-dev sudo -y
+
 # enable sudo for the NB_USER by default
 RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
 
-WORKDIR /
-
-COPY ./base-kernel-py-gpu/*.sh /
-
-# Run augment script
-RUN ./augment-root.sh
-
-# Install our internal libraries
+# Get all requirements in place.
+COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/
 COPY ./lib/python /orchest/lib/python
 COPY ./orchest-sdk /orchest/orchest-sdk
-
-COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
-WORKDIR /orchest/services/base-images/runnable-shared/runner
-
-RUN chown $NB_USER -R /orchest/orchest-sdk
-RUN chown $NB_USER -R /orchest/lib
+RUN chown $NB_USER -R /orchest/orchest-sdk \
+    && chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
+
+# Install requirements.
+WORKDIR /orchest/services/base-images/runnable-shared/runner
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
 RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
@@ -30,16 +33,17 @@ RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdepen
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt
 
-COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
-
-ENV HOME=/home/$NB_USER
+# Get application files.
+COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
 
 # This path is searched first to locate kernels. Without this variable
 # Jupyter will search inside the orchestdependencies environment first
 # and end up using the wrong executable to start the kernel.
 ENV JUPYTER_PATH=/opt/conda/share/jupyter
+ENV HOME=/home/$NB_USER
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}
 
+COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 CMD [ "/orchest/bootscript.sh" ]

--- a/services/base-images/base-kernel-py-gpu/augment-root.sh
+++ b/services/base-images/base-kernel-py-gpu/augment-root.sh
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install default-libmysqlclient-dev sudo -y

--- a/services/base-images/base-kernel-py/Dockerfile
+++ b/services/base-images/base-kernel-py/Dockerfile
@@ -26,7 +26,7 @@ RUN chown $NB_USER -R /orchest/lib
 USER $NB_USER
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
-RUN conda create -y -n orchestdependencies && \
+RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
     # requirements.txt includes local install and thus we need to use pip
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt

--- a/services/base-images/base-kernel-py/Dockerfile
+++ b/services/base-images/base-kernel-py/Dockerfile
@@ -24,11 +24,21 @@ RUN chown $NB_USER -R /orchest/orchest-sdk
 RUN chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
-RUN pip install -r requirements.txt
+RUN pip install -r requirements-user.txt
+# Install Orchest dependencies in our own environment
+RUN conda create -y -n orchestdependencies && \
+    # requirements.txt includes local install and thus we need to use pip
+    conda install -y -n orchestdependencies pip && \
+    conda run -n orchestdependencies pip install -r requirements.txt
 
 COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 
 ENV HOME=/home/$NB_USER
+
+# This path is searched first to locate kernels. Without this variable
+# Jupyter will search inside the orchestdependencies environment first
+# and end up using the wrong executable to start the kernel.
+ENV JUPYTER_PATH=/opt/conda/share/jupyter
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}

--- a/services/base-images/base-kernel-py/Dockerfile
+++ b/services/base-images/base-kernel-py/Dockerfile
@@ -2,28 +2,31 @@
 FROM elyra/kernel-py:2.3.0
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
+# --------------------------------------------------
+# All lines below are the same for all base-kernel-* images that we
+# have. Due to how Docker works we sadly have to copy it into every
+# Dockerfile (instead of a DRY solution), you can read more here:
+# https://github.com/moby/moby/issues/3378
+# --------------------------------------------------
 USER root
+
+RUN apt-get update \
+    && apt-get install default-libmysqlclient-dev sudo -y
+
 # enable sudo for the NB_USER by default
 RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
 
-WORKDIR /
-
-COPY ./base-kernel-py/*.sh /
-
-# Run augment script
-RUN ./augment-root.sh
-
-# Install our internal libraries
+# Get all requirements in place.
+COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/
 COPY ./lib/python /orchest/lib/python
 COPY ./orchest-sdk /orchest/orchest-sdk
-
-COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
-WORKDIR /orchest/services/base-images/runnable-shared/runner
-
-RUN chown $NB_USER -R /orchest/orchest-sdk
-RUN chown $NB_USER -R /orchest/lib
+RUN chown $NB_USER -R /orchest/orchest-sdk \
+    && chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
+
+# Install requirements.
+WORKDIR /orchest/services/base-images/runnable-shared/runner
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
 RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
@@ -31,16 +34,17 @@ RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdepen
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt
 
-COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
-
-ENV HOME=/home/$NB_USER
+# Get application files.
+COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
 
 # This path is searched first to locate kernels. Without this variable
 # Jupyter will search inside the orchestdependencies environment first
 # and end up using the wrong executable to start the kernel.
 ENV JUPYTER_PATH=/opt/conda/share/jupyter
+ENV HOME=/home/$NB_USER
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}
 
+COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 CMD [ "/orchest/bootscript.sh" ]

--- a/services/base-images/base-kernel-py/augment-root.sh
+++ b/services/base-images/base-kernel-py/augment-root.sh
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install default-libmysqlclient-dev sudo -y

--- a/services/base-images/base-kernel-r/Dockerfile
+++ b/services/base-images/base-kernel-r/Dockerfile
@@ -25,11 +25,21 @@ RUN chown $NB_USER -R /orchest/orchest-sdk
 RUN chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
-RUN pip install -r requirements.txt
+RUN pip install -r requirements-user.txt
+# Install Orchest dependencies in our own environment
+RUN conda create -y -n orchestdependencies && \
+    # requirements.txt includes local install and thus we need to use pip
+    conda install -y -n orchestdependencies pip && \
+    conda run -n orchestdependencies pip install -r requirements.txt
 
 COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 
 ENV HOME=/home/$NB_USER
+
+# This path is searched first to locate kernels. Without this variable
+# Jupyter will search inside the orchestdependencies environment first
+# and end up using the wrong executable to start the kernel.
+ENV JUPYTER_PATH=/opt/conda/share/jupyter
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}

--- a/services/base-images/base-kernel-r/Dockerfile
+++ b/services/base-images/base-kernel-r/Dockerfile
@@ -27,7 +27,7 @@ RUN chown $NB_USER -R /orchest/lib
 USER $NB_USER
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
-RUN conda create -y -n orchestdependencies && \
+RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
     # requirements.txt includes local install and thus we need to use pip
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt

--- a/services/base-images/base-kernel-r/Dockerfile
+++ b/services/base-images/base-kernel-r/Dockerfile
@@ -2,29 +2,31 @@
 FROM elyra/kernel-r:2.3.0
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
+# --------------------------------------------------
+# All lines below are the same for all base-kernel-* images that we
+# have. Due to how Docker works we sadly have to copy it into every
+# Dockerfile (instead of a DRY solution), you can read more here:
+# https://github.com/moby/moby/issues/3378
+# --------------------------------------------------
 USER root
+
+RUN apt-get update \
+    && apt-get install default-libmysqlclient-dev sudo -y
+
 # enable sudo for the NB_USER by default
 RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
 
-WORKDIR /
-
-# mysql_config is required for orchest-sdk
-COPY ./base-kernel-r/*.sh /
-
-# Run augment script
-RUN ./augment-root.sh
-
-# Install our internal libraries
+# Get all requirements in place.
+COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/
 COPY ./lib/python /orchest/lib/python
 COPY ./orchest-sdk /orchest/orchest-sdk
-
-COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
-WORKDIR /orchest/services/base-images/runnable-shared/runner
-
-RUN chown $NB_USER -R /orchest/orchest-sdk
-RUN chown $NB_USER -R /orchest/lib
+RUN chown $NB_USER -R /orchest/orchest-sdk \
+    && chown $NB_USER -R /orchest/lib
 
 USER $NB_USER
+
+# Install requirements.
+WORKDIR /orchest/services/base-images/runnable-shared/runner
 RUN pip install -r requirements-user.txt
 # Install Orchest dependencies in our own environment
 RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdependencies && \
@@ -32,16 +34,17 @@ RUN conda create -y python=$(python --version | tr -d "Python ") -n orchestdepen
     conda install -y -n orchestdependencies pip && \
     conda run -n orchestdependencies pip install -r requirements.txt
 
-COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
-
-ENV HOME=/home/$NB_USER
+# Get application files.
+COPY ./runnable-shared/runner /orchest/services/base-images/runnable-shared/runner
 
 # This path is searched first to locate kernels. Without this variable
 # Jupyter will search inside the orchestdependencies environment first
 # and end up using the wrong executable to start the kernel.
 ENV JUPYTER_PATH=/opt/conda/share/jupyter
+ENV HOME=/home/$NB_USER
 
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}
 
+COPY ./runnable-shared/bootscript.sh /orchest/bootscript.sh
 CMD [ "/orchest/bootscript.sh" ]

--- a/services/base-images/base-kernel-r/augment-root.sh
+++ b/services/base-images/base-kernel-r/augment-root.sh
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install default-libmysqlclient-dev sudo -y

--- a/services/base-images/runnable-shared/bootscript.sh
+++ b/services/base-images/runnable-shared/bootscript.sh
@@ -5,8 +5,8 @@
 
 umask 002
 
-if [ "$1" = "runnable" ]; then 
-    python run.py "$2" "$3"
+if [ "$1" = "runnable" ]; then
+    /opt/conda/envs/orchestdependencies/bin/python run.py "$2" "$3"
 else
     /usr/local/bin/bootstrap-kernel.sh
 fi

--- a/services/base-images/runnable-shared/runner/pyrightconfig.json
+++ b/services/base-images/runnable-shared/runner/pyrightconfig.json
@@ -1,0 +1,19 @@
+{
+  "extraPaths": ["../../lib/python/orchest-internals/"],
+
+  "exclude": ["**/node_modules", "**/__pycache__", ".venv"],
+
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false,
+
+  "pythonVersion": "3.8",
+  "pythonPlatform": "Linux",
+  "venvPath": "../../../../.venvs",
+  "venv": "base-images-runnable",
+
+  "executionEnvironments": [
+    {
+      "root": "app"
+    }
+  ]
+}

--- a/services/base-images/runnable-shared/runner/requirements-user.txt
+++ b/services/base-images/runnable-shared/runner/requirements-user.txt
@@ -1,0 +1,1 @@
+-e ../../../../orchest-sdk/python/

--- a/services/base-images/runnable-shared/runner/requirements.txt
+++ b/services/base-images/runnable-shared/runner/requirements.txt
@@ -2,5 +2,4 @@ nbformat
 nbconvert
 IPython
 ipykernel
--e ../../../../orchest-sdk/python/
 -e ../../../../lib/python/orchest-internals

--- a/services/base-images/runnable-shared/runner/requirements.txt
+++ b/services/base-images/runnable-shared/runner/requirements.txt
@@ -1,5 +1,5 @@
-nbformat
-nbconvert
-IPython
-ipykernel
+ipykernel==6.6.0
+ipython==7.30.0
+nbconvert==6.3.0
+nbformat==5.1.3
 -e ../../../../lib/python/orchest-internals

--- a/services/base-images/runnable-shared/runner/run.py
+++ b/services/base-images/runnable-shared/runner/run.py
@@ -52,7 +52,10 @@ def main():
     elif file_extension in ["py", "r", "sh", "jl", ""]:
 
         extension_script_mapping = {
-            "py": "python3",
+            # Explicitely use the Python that contains the user
+            # dependencies (otherwise Popen could resolve to the Python
+            # inside the "orchestdependencies" environment).
+            "py": "/opt/conda/bin/python",
             "r": "Rscript",
             "sh": "sh",
             "jl": "julia",

--- a/services/base-images/runnable-shared/runner/runner/preprocessors.py
+++ b/services/base-images/runnable-shared/runner/runner/preprocessors.py
@@ -1,9 +1,12 @@
+import logging
 import typing as t
 
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
 from nbformat.v4 import output_from_msg
+
+logger = logging.getLogger(__name__)
 
 
 class PartialExecutePreprocessor(ExecutePreprocessor):
@@ -130,6 +133,7 @@ class PartialExecutePreprocessor(ExecutePreprocessor):
 
             except CellExecutionError as e:
 
+                logger.error(f"Cell failed to execute with kernel: {self.kernel_name}")
                 self.log_file.write("%s" % e)
                 self.log_file.flush()
 


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description
Fixes: #425 

You can try it out by importing: https://github.com/yannickperrenet/orchest-notebook-runner-pr

### Todo
- [X] Run tests: inside Jupyter, as interactive runs and using other environments e.g. R and Python.
- [X] ~~Have a look at Docker's multi-stage builds to have a cleaner build process for the runnable images (now they contain a lot of duplicate code)~~ Not possible, see: https://github.com/moby/moby/issues/3378
- [x] Version lock the `requirements.txt` files in the runnable
- [x] (Optional) Make sure the `orchestdependencies` environment uses the same Python version instead of using `3.10`. This might lead to unexpected errors down the road.
- [x] I came across an alternative way to make sure we can skip cells tagged with `skip` (although this would make us dependent on the implementation of Jupyter's `NotebookClient`): `NotebookClient` which we subclass has an attribute `self.skip_cells_with_tags = ["skip"]`.