### PR TITLE
Set g+s to directories not having g+s already set

### DIFF
--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -64,7 +64,7 @@ def fix_userdir_permissions() -> None:
         # NOTE: The exit code is only returned on Unix systems
         # (which includes macOS).
         exit_code = os.system(
-            "find /orchest-host/userdir -type d -exec chmod g+s {} \;"
+            "find /orchest-host/userdir -type d -not -perm -g+s -exec chmod g+s {} \;"
         )
     except Exception as e:
         logger.warning("Could not set gid permissions on '/orchest-host/userdir'.")


### PR DESCRIPTION
This is a rather small fix to improve the speed of `find` in our particular case. Essentially, we are filtering out directories for which the `g+s` flag is already set before setting it.


This has been tested on a cloud instance that was affected by this issue, and the difference is substantial, i.e. 10 minutes vs 6 seconds. I have also tested it locally with around `1600000` directories living in the `/data` directory, and it took 14 seconds. Of course, this is because we are leveraging the fact that most or all directories already have the flag.

I also took some time to test [fd](https://github.com/sharkdp/fd), its batched execution is way faster while the non batched execution did not bring much difference when testing with a single thread. The batched execution can't currently be used because of [this issue](https://github.com/sharkdp/fd/issues/410), making it unreliable in our case. Note that it does not provide a way to filter out directories for which `g+s` is already set, making it slower than `find` using the `-not` filter, despite the batching. On a cloud instance with 30k directories already having the `g+s` flag the `find` command took around 7s, while the `fd` one took around 11s.

To summarize
- it would be ideal if `fd` provided a fix for the aforementioned issue and a filter for permissions, along with `--not`. Until that's the case, the `find` command will be faster when we start talking about a massive amount of directories that are already flagged and a machine with limited compute.
- in the case where there are a massive amount of unflagged directories  `fd` is the winner, but this case is unusual given what we are doing.
- the moment `fd` fixes the aforementioned batching issue we could replace `find` with `fd`, catching the edge case in point 2, while providing ok performance for point 1.  @yannickperrenet @ricklamers Based on the discussion/outcome of the PR we can create an issue to remind us about it.

Reference command `time sudo fdfind --hidden --show-errors --no-ignore --no-ignore-vcs --type d --exec-batch chmod g+s {} \; --search-path userdir`

Fixes: #572 


### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
