### PR TITLE
Orchest core containers cpu priority over user Orchest containers

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -10,6 +10,15 @@ PIPELINE_FILE = "/pipeline.json"
 PIPELINE_PARAMETERS_RESERVED_KEY = "pipeline_parameters"
 CLOUD = os.environ.get("CLOUD") == "True"
 GPU_ENABLED_INSTANCE = os.environ.get("ORCHEST_GPU_ENABLED_INSTANCE") == "True"
+# This represents a container priority w.r.t. CPU time. By default,
+# containers run with a value of 1024. User code/containers such as
+# steps, services, kernels, environment builds are made to run with a
+# lower value so that in conditions of high cpu contention core Orchest
+# services have priority, which helps in being responsive under high
+# load. This is only enforced when CPU cycles are constrained. For more
+# information, see
+# https://docs.docker.com/config/containers/resource_constraints/.
+USER_CONTAINERS_CPU_SHARES = 500
 
 # Databases
 database_naming_convention = {

--- a/services/orchest-api/app/app/core/docker_utils.py
+++ b/services/orchest-api/app/app/core/docker_utils.py
@@ -4,6 +4,7 @@ import time
 
 import docker
 
+from _orchest.internals import config as _config
 from _orchest.internals.utils import docker_images_list_safe
 from app import utils
 from app.connections import docker_client
@@ -63,6 +64,7 @@ def build_docker_image(
             tag=image_name,
             rm=True,
             nocache=True,
+            container_limits={"cpushares": _config.USER_CONTAINERS_CPU_SHARES},
         )
 
         flag = __DOCKERFILE_RESERVED_FLAG + "\n"

--- a/services/orchest-api/app/app/core/pipelines.py
+++ b/services/orchest-api/app/app/core/pipelines.py
@@ -298,6 +298,7 @@ class PipelineStepRunner:
             # NOTE: the `'tests-uuid'` key is only used for tests and
             # gets ignored by the `docker_client`.
             "tests-uuid": self.properties["uuid"],
+            "CpuShares": _config.USER_CONTAINERS_CPU_SHARES,
         }
 
         # Starts the container asynchronously, however, it does not wait

--- a/services/orchest-api/app/app/core/sessions.py
+++ b/services/orchest-api/app/app/core/sessions.py
@@ -932,6 +932,7 @@ def _get_user_services_specs(
                     "tag": f"user-service-{service_name}-metadata-end",
                 },
             ),
+            "cpu_shares": _config.USER_CONTAINERS_CPU_SHARES,
         }
 
         if "entrypoint" in service:

--- a/services/orchest-webserver/app/app/res/kernels/launch_docker.py
+++ b/services/orchest-webserver/app/app/res/kernels/launch_docker.py
@@ -80,6 +80,7 @@ def launch_docker_kernel(kernel_id, response_addr, spark_context_init_mode):
     kwargs["network"] = docker_network
     kwargs["group_add"] = [param_env.get("ORCHEST_HOST_GID")]
     kwargs["detach"] = True
+    kwargs["cpu_shares"] = _config.USER_CONTAINERS_CPU_SHARES
     if param_env.get("KERNEL_WORKING_DIR"):
         kwargs["working_dir"] = param_env.get("KERNEL_WORKING_DIR")
 


### PR DESCRIPTION
## Description
This will make it so that, during periods of CPU contention, core Orchest services are given priority over containers that the user has launched through Orchest. This is a minor QOL improvement especially aimed at the cloud. The PR is a single commit and the content is intentionally simple given the not too far k8s migration that might condition or be conditioned by such changes.

### Checklist

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
s.
