### PR TITLE
Substitute invalid characters on project name creation

### DIFF
--- a/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
@@ -464,7 +464,9 @@ const ProjectsView: React.FC = () => {
                     classNames={["fullwidth"]}
                     label="Project name"
                     value={projectName}
-                    onChange={setProjectName}
+                    onChange={(value) => {
+                      setProjectName(value.replace(/[^\w\.]/g, "-"));
+                    }}
                     data-test-id="project-name-textfield"
                   />
                 }


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description
Resolves: #555, #521 

## Question about implementation
I left the `validateProjectNameAndAlert` code in there as I figured it is defensive programming. However, with this change that code should never run so removing it is also not a bad idea.

What do you think? @iannbing 