### PR TITLE
Feat/paginated job runs

### DIFF
--- a/cypress/cypress/integration/services.spec.ts
+++ b/cypress/cypress/integration/services.spec.ts
@@ -188,15 +188,21 @@ describe("services", () => {
     cy.readFile(`${DATA_DIR}/test1.txt`);
     cy.wait("@jobData")
       .its("response.body")
-      .then((data) => {
-        let dirPath = getJobProjectDirPath(
-          data.project_uuid,
-          data.pipeline_uuid,
-          // uuid of the job.
-          data.uuid,
-          data.pipeline_runs[0].uuid
-        );
-        cy.readFile(`${dirPath}/test2.txt`);
+      .then((job_data) => {
+        cy.request(
+          "GET",
+          `/catch/api-proxy/api/jobs/${job_data.uuid}/pipeline_runs`
+        ).then((response) => {
+          let job_runs_data = response.body;
+          let dirPath = getJobProjectDirPath(
+            job_data.project_uuid,
+            job_data.pipeline_uuid,
+            // uuid of the job.
+            job_data.uuid,
+            job_runs_data.pipeline_runs[0].uuid
+          );
+          cy.readFile(`${dirPath}/test2.txt`);
+        });
       });
   });
 

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -7,7 +7,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 from croniter import croniter
 from docker import errors
 from flask import abort, current_app, request
-from flask_restx import Namespace, Resource, marshal
+from flask_restx import Namespace, Resource, marshal, reqparse
 from sqlalchemy import desc, func
 from sqlalchemy.orm import joinedload, load_only, undefer
 
@@ -23,6 +23,7 @@ from app.utils import (
     get_env_uuids_missing_image,
     get_proj_pip_env_variables,
     lock_environment_images_for_job,
+    page_to_pagination_data,
     process_stale_environment_images,
     register_schema,
     update_status_db,
@@ -201,6 +202,91 @@ class Job(Resource):
             return {"message": "Job termination was successful."}, 200
         else:
             return {"message": "Job does not exist or is already completed."}, 404
+
+
+@api.route(
+    "/<string:job_uuid>/pipeline_runs",
+    doc={"description": ("Retrieve list of job runs.")},
+)
+@api.param("job_uuid", "UUID of Job")
+@api.response(404, "Job not found")
+class PipelineRunsList(Resource):
+    @api.doc(
+        "get_job_pipeline_runs",
+        params={
+            "page": {
+                "description": (
+                    "Which page to query, 1 indexed. Must be specified if page_size is "
+                    "specified."
+                ),
+                "type": int,
+            },
+            "page_size": {
+                "description": (
+                    "Size of the page. Must be specified if page is specified."
+                ),
+                "type": int,
+            },
+        },
+    )
+    @api.response(200, "Success", schema.paginated_job_pipeline_runs)
+    @api.response(200, "Success", schema.job_pipeline_runs)
+    def get(self, job_uuid):
+        """Fetch pipeline runs of a job, sorted newest first.
+
+        Runs are ordered by job_run_index DESC,
+        job_run_pipeline_run_index DESC.
+
+        The endpoint has optional pagination. If pagination is used the
+        returned json also contains pagination data.
+        """
+        parser = reqparse.RequestParser()
+        parser.add_argument("page", type=int, location="args")
+        parser.add_argument("page_size", type=int, location="args")
+        args = parser.parse_args()
+        page = args.page
+        page_size = args.page_size
+        if (page is not None and page_size is None) or (
+            page is None and page_size is not None
+        ):
+            return {
+                "message": "Either both page and page_size are defined or none of them."
+            }, 400
+        if page is not None and page <= 0:
+            return {"message": "page must be >= 1."}, 400
+        if page_size is not None and page_size <= 0:
+            return {"message": "page_size must be >= 1."}, 400
+
+        models.Job.query.get_or_404(ident=(job_uuid), description="Job not found.")
+
+        job_runs_query = (
+            models.NonInteractivePipelineRun.query.options(
+                undefer(models.NonInteractivePipelineRun.env_variables)
+            )
+            .filter_by(
+                job_uuid=job_uuid,
+            )
+            .order_by(
+                desc(models.NonInteractivePipelineRun.job_run_index),
+                desc(models.NonInteractivePipelineRun.job_run_pipeline_run_index),
+            )
+        )
+        if args.page is not None and args.page_size is not None:
+            job_runs_pagination = job_runs_query.paginate(
+                args.page, args.page_size, False
+            )
+            job_runs = job_runs_pagination.items
+            pagination_data = page_to_pagination_data(job_runs_pagination)
+            return (
+                marshal(
+                    {"pipeline_runs": job_runs, "pagination_data": pagination_data},
+                    schema.paginated_job_pipeline_runs,
+                ),
+                200,
+            )
+        else:
+            job_runs = job_runs_query.all()
+            return marshal({"pipeline_runs": job_runs}, schema.job_pipeline_runs), 200
 
 
 @api.route(

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -10,6 +10,21 @@ import datetime
 
 from flask_restx import Model, fields
 
+pagination_data = Model(
+    "PaginationData",
+    {
+        "has_next_page": fields.Boolean(required=True),
+        "has_prev_page": fields.Boolean(required=True),
+        "next_page_num": fields.Integer(required=True),
+        "prev_page_num": fields.Integer(required=True),
+        "items_per_page": fields.Integer(required=True),
+        "items_in_this_page": fields.Integer(required=True),
+        "total_items": fields.Integer(required=True),
+        "total_pages": fields.Integer(required=True),
+    },
+)
+
+
 # Namespace: Sessions
 server = Model(
     "Server",
@@ -386,6 +401,27 @@ non_interactive_run = pipeline_run.inherit(
             attribute=lambda x: datetime.datetime.now(datetime.timezone.utc),
             description="Server time to be used when calculating run durations.",
         ),
+    },
+)
+
+job_pipeline_runs = Model(
+    "JobPipelineRuns",
+    {
+        "pipeline_runs": fields.List(
+            fields.Nested(non_interactive_run),
+            description="Collection of pipeline runs part of a job",
+        ),
+    },
+)
+
+paginated_job_pipeline_runs = Model(
+    "PaginatedJobPipelineRuns",
+    {
+        "pipeline_runs": fields.List(
+            fields.Nested(non_interactive_run),
+            description="Collection of pipeline runs part of a job",
+        ),
+        "pagination_data": fields.Nested(pagination_data, required=False),
     },
 )
 

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -8,6 +8,7 @@ from celery.utils.log import get_task_logger
 from docker import errors
 from flask import current_app
 from flask_restx import Model, Namespace
+from flask_sqlalchemy import Pagination
 from sqlalchemy.orm import undefer
 
 import app.models as models
@@ -776,3 +777,20 @@ def is_orchest_idle() -> dict:
     result = {"details": data}
     result["idle"] = not any(data.values())
     return result
+
+
+def page_to_pagination_data(pagination: Pagination) -> dict:
+    """Pagination to a dictionary containing data of interest.
+
+    Essentially a preprocessing step before marshalling.
+    """
+    return {
+        "has_next_page": pagination.has_next,
+        "has_prev_page": pagination.has_prev,
+        "next_page_num": pagination.next_num,
+        "prev_page_num": pagination.prev_num,
+        "items_per_page": pagination.per_page,
+        "items_in_this_page": len(pagination.items),
+        "total_items": pagination.total,
+        "total_pages": pagination.pages,
+    }


### PR DESCRIPTION
## Description
Adds a paginated job pipeline runs API endpoint that can be later used by the FE.

Related to : #434 

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
.
