### PR TITLE
Improve environment build telemetry

### DIFF
--- a/lib/javascript/utils/src/typed.ts
+++ b/lib/javascript/utils/src/typed.ts
@@ -78,6 +78,8 @@ export const LANGUAGE_MAP = {
 };
 
 // used in orchest-webserver only
+// Related to the analytics.py module, "environment_build_start" event,
+// which checks for the base image to start with "orchest/".
 export const DEFAULT_BASE_IMAGES = [
   "orchest/base-kernel-py",
   "orchest/base-kernel-py-gpu",

--- a/services/orchest-webserver/app/app/analytics.py
+++ b/services/orchest-webserver/app/app/analytics.py
@@ -58,7 +58,8 @@ class Event(Enum):
         Args:
             event_properties: The properties that describe the event.
                 The exact properties that need to be anonymized are then
-                cherry-picked.
+                cherry-picked. The passed object will be modified in
+                order to anonymize it, as needed.
 
         Returns:
             Optionally returns derived properties from the anonymized
@@ -207,7 +208,12 @@ def _get_telemetry_uuid(app: Flask) -> str:
 
 
 class _Anonymizer:
-    """Anonymizes the event properties of the given event."""
+    """Anonymizes the event properties of the given event.
+
+    !Note: if you are implementing a function to anonymize some event
+    propeties be aware that you are in charge of modifying the passed
+    `event_properties` object to anonymize it.
+    """
 
     @staticmethod
     def job_create(event_properties: dict) -> dict:
@@ -263,6 +269,16 @@ class _Anonymizer:
         derived_properties = {
             "pipeline_definition": _anonymize_pipeline_definition(pdef),
         }
+        return derived_properties
+
+    @staticmethod
+    def environment_build_start(event_properties: dict) -> dict:
+        base_image = event_properties.pop("base_image", None)
+        derived_properties = {}
+        if isinstance(base_image, str):
+            derived_properties["uses_orchest_base_image"] = base_image.startswith(
+                "orchest/"
+            )
         return derived_properties
 
 

--- a/services/orchest-webserver/app/app/analytics.py
+++ b/services/orchest-webserver/app/app/analytics.py
@@ -211,7 +211,7 @@ class _Anonymizer:
     """Anonymizes the event properties of the given event.
 
     !Note: if you are implementing a function to anonymize some event
-    propeties be aware that you are in charge of modifying the passed
+    properties be aware that you are in charge of modifying the passed
     `event_properties` object to anonymize it.
     """
 

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -5,6 +5,7 @@ from app import analytics, error
 from app.core import jobs
 from app.models import Pipeline, Project
 from app.utils import (
+    get_environment,
     get_environments,
     get_pipeline_json,
     get_project_directory,
@@ -117,12 +118,18 @@ def register_orchest_api_views(app, db):
         )
 
         for environment_build_request in environment_build_requests:
+            environment_uuid = environment_build_request["environment_uuid"]
+            project_uuid = environment_build_request["project_uuid"]
+            env = get_environment(environment_uuid, project_uuid)
             analytics.send_event(
                 app,
                 analytics.Event.ENVIRONMENT_BUILD_START,
                 {
-                    "environment_uuid": environment_build_request["environment_uuid"],
-                    "project_uuid": environment_build_request["project_uuid"],
+                    "environment_uuid": environment_uuid,
+                    "project_uuid": project_uuid,
+                    "language": env.language,
+                    "gpu_support": env.gpu_support,
+                    "base_image": env.base_image,
                 },
             )
         return resp.content, resp.status_code, resp.headers.items()


### PR DESCRIPTION
## Description

Improves the telemetry of an environment build event by including the following information:
- language (str)
- gpu_support (boolean)
- uses_orchest_base_image (boolean)

<!-- You can check a box by adding an X, i.e. "- [X]", or by clicking on the check box after opening the PR. -->

- [X] I have manually tested the application to make sure the changes don’t cause any downstream issues, which includes making sure `./orchest status --ext` is not reporting failures when Orchest is running.
