### PR TITLE
Let all error alerts be in front of creation modal

### DIFF
--- a/services/orchest-webserver/client/src/components/PipelineList.tsx
+++ b/services/orchest-webserver/client/src/components/PipelineList.tsx
@@ -334,11 +334,24 @@ const PipelineList: React.FC<{ projectUuid: string }> = ({ projectUuid }) => {
           setState((prevState) => ({
             ...prevState,
             loading: false,
+            createModal: false,
           }));
         });
+        setState((prevState) => ({
+          ...prevState,
+          createPipelineName: INITIAL_PIPELINE_NAME,
+          createPipelinePath: INITIAL_PIPELINE_PATH,
+        }));
       })
       .catch((response) => {
         if (!response.isCanceled) {
+          // Make the alert pop up in front of the modal. So that the
+          // user isn't scared they've lost state.
+          setState((prevState) => ({
+            ...prevState,
+            loading: false,
+          }));
+
           try {
             let data = JSON.parse(response.body);
 
@@ -352,30 +365,17 @@ const PipelineList: React.FC<{ projectUuid: string }> = ({ projectUuid }) => {
               "Could not create pipeline. Reason unknown."
             );
           }
-
-          setState((prevState) => ({
-            ...prevState,
-            loading: false,
-          }));
         }
-      })
-      .finally(() => {
-        // reload list once creation succeeds
-        setState((prevState) => ({
-          ...prevState,
-          createPipelineName: INITIAL_PIPELINE_NAME,
-          createPipelinePath: INITIAL_PIPELINE_PATH,
-        }));
       });
-
-    setState((prevState) => ({
-      ...prevState,
-      createModal: false,
-    }));
   };
 
   const onCancelModal = () => {
     refManager.refs.createPipelineDialog.close();
+    setState((prevState) => ({
+      ...prevState,
+      createPipelineName: INITIAL_PIPELINE_NAME,
+      createPipelinePath: INITIAL_PIPELINE_PATH,
+    }));
   };
 
   const onCloseCreatePipelineModal = () => {


### PR DESCRIPTION
<!-- Thank you for your contribution, you rock! 💪 -->

## Description

<!-- Please provide a summary of what this PR adds or changes together with relevant motivation and context. -->

Resolves: #557 

To test it out:
1. Create a pipeline with the prefilled name and path
2. Create another pipeline without changing the name and path 
3. Press "create pipeline"

![image](https://user-images.githubusercontent.com/26223174/146598324-1278faf6-b2ab-4e0b-a855-318039b6874b.png)

