### PR TITLE
Improv/api initialization speed

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional, Tuple
 import docker
 import requests
 from docker.types import DeviceRequest
+from werkzeug.serving import is_running_from_reloader as _irfr
 
 from _orchest.internals import config as _config
 from _orchest.internals import errors as _errors
@@ -485,6 +486,21 @@ def docker_images_list_safe(docker_client, *args, attempt_count=10, **kwargs):
         except Exception as e:
             logging.debug("Failed to call docker_client.images.list(): %s" % e)
             return []
+
+
+def is_running_from_reloader():
+    """Is this thread running from a werkzeug reloader.
+
+    When Flask is running in development mode, the application is
+    first initialized and then restarted again in a child process. This
+    means that code will run (concurrently) again inside the reloader,
+    which can case issues with code that should only run once.
+
+    By using this gate, we can prevent from rerunning certain code in
+    the child process.
+
+    """
+    return _irfr()
 
 
 def is_werkzeug_parent():

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -481,9 +481,10 @@ def docker_images_list_safe(docker_client, *args, attempt_count=10, **kwargs):
                 "Internal race condition triggered in docker_client.images.list(): %s"
                 % e
             )
+            return []
         except Exception as e:
             logging.debug("Failed to call docker_client.images.list(): %s" % e)
-            return None
+            return []
 
 
 def is_werkzeug_parent():

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -18,8 +18,8 @@ from flask_migrate import Migrate, upgrade
 from sqlalchemy_utils import create_database, database_exists
 
 from _orchest.internals import config as _config
+from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor
-from _orchest.internals.utils import is_werkzeug_parent
 from app import utils
 from app.apis import blueprint as api
 from app.apis.namespace_environment_builds import AbortEnvironmentBuild
@@ -60,12 +60,13 @@ def create_app(config_class=None, use_db=True, be_scheduler=False):
     app = Flask(__name__)
     app.config.from_object(config_class)
 
-    init_logging()
-
     # Cross-origin resource sharing. Allow API to be requested from the
     # different microservices such as the webserver.
     CORS(app, resources={r"/*": {"origins": "*"}})
 
+    init_logging()
+
+    # In development we want more verbose logging of every request.
     if os.getenv("FLASK_ENV") == "development":
         app = register_teardown_request(app)
 
@@ -76,111 +77,146 @@ def create_app(config_class=None, use_db=True, be_scheduler=False):
             create_database(app.config["SQLALCHEMY_DATABASE_URI"])
 
         db.init_app(app)
-        # necessary for migration
+
+        # Necessary for db migrations.
         Migrate().init_app(app, db)
 
-        with app.app_context():
+    # Early stopping in case we are running inside a werkzeug reloader
+    # to prevent running the initialization code below more than once.
+    if _utils.is_running_from_reloader():
+        app.register_blueprint(api, url_prefix="/api")
+        return app
 
-            # Alembic does not support calling upgrade() concurrently
-            if not is_werkzeug_parent():
-                # Upgrade to the latest revision. This also takes
-                # care of bringing an "empty" db (no tables) on par.
+    if use_db:
+        with app.app_context():
+            # In case of running multiple gunicorn workers, we need to
+            # ensure that cleanup is only run once. Therefore, we
+            # attempt to create a directory first (which is an atomic
+            # operation). The edge case of Flask development mode
+            # running multiple threads is handled above using the
+            # `is_running_from_reloader()` check.
+            try:
+                if app.config.get("TESTING", False):
+                    # Do nothing.
+                    # In case of tests we always want to upgrade the db
+                    # and run cleanup. Because every test will get a
+                    # clean app, the same code should run for all tests.
+                    # In addition, tests get an empty db (no tables) and
+                    # thus the `upgrade` needs to bring the db on par.
+                    pass
+                else:
+                    app.logger.debug("Trying to create /tmp/cleanup_done")
+                    os.mkdir("/tmp/cleanup_done")
+                    app.logger.info("/tmp/cleanup_done successfully created.")
+            except FileExistsError:
+                app.logger.info(
+                    f"/tmp/cleanup_done exists. Skipping cleanup: {os.getpid()}."
+                )
+            else:
+                # Upgrade to the latest revision. This also takes care
+                # of bringing an "empty" db (no tables) on par.
                 try:
                     upgrade()
                 except Exception as e:
                     logging.error("Failed to run upgrade() %s [%s]" % (e, type(e)))
 
-            # In case of an ungraceful shutdown, these entities could be
-            # in an invalid state, so they are deleted, since for sure
-            # they are not running anymore.
-            # To avoid the issue of entities being deleted because of a
-            # flask app reload triggered by a --dev code change, we
-            # attempt to create a directory first. Since this is an
-            # atomic operation that will result in an error if the
-            # directory is already there, this cleanup operation will
-            # run only once per container.
-            try:
-                os.mkdir("/tmp/cleanup_done")
-                InteractiveSession.query.delete()
+                # NOTE: This cleanup code blocks the gunicorn worker
+                # from handling requests, because it is required for the
+                # app to be initialized. So make sure the cleanup is
+                # quick! (Especially when running only a single gunicorn
+                # worker as the entire orchest-api will become
+                # unresponsive.)
+                # In case of an ungraceful shutdown, these entities
+                # could be in an invalid state, so they are deleted,
+                # since for sure they are not running anymore.
+                try:
+                    InteractiveSession.query.delete()
 
-                # Delete old JupyterBuilds on start to avoid
-                # accumulation in the DB. Leave the latest such that the
-                # user can see details about the last executed build
-                # after restarting Orchest.
-                jupyter_builds = (
-                    JupyterBuild.query.order_by(JupyterBuild.requested_time.desc())
-                    .offset(1)
-                    .all()
-                )
+                    # Delete old JupyterBuilds on start to avoid
+                    # accumulation in the DB. Leave the latest such that
+                    # the user can see details about the last executed
+                    # build after restarting Orchest.
+                    jupyter_builds = (
+                        JupyterBuild.query.order_by(JupyterBuild.requested_time.desc())
+                        .offset(1)
+                        .all()
+                    )
 
-                # Can't use offset and .delete in conjunction in
-                # sqlalchemy unfortunately.
-                for jupyer_build in jupyter_builds:
-                    db.session.delete(jupyer_build)
+                    # Can't use offset and .delete in conjunction in
+                    # sqlalchemy unfortunately.
+                    for jupyer_build in jupyter_builds:
+                        db.session.delete(jupyer_build)
 
-                db.session.commit()
+                    db.session.commit()
 
-                # Fix interactive runs.
-                runs = InteractivePipelineRun.query.filter(
-                    InteractivePipelineRun.status.in_(["PENDING", "STARTED"])
-                ).all()
-                with TwoPhaseExecutor(db.session) as tpe:
-                    for run in runs:
-                        AbortPipelineRun(tpe).transaction(run.uuid)
+                    # Fix interactive runs.
+                    runs = InteractivePipelineRun.query.filter(
+                        InteractivePipelineRun.status.in_(["PENDING", "STARTED"])
+                    ).all()
+                    with TwoPhaseExecutor(db.session) as tpe:
+                        for run in runs:
+                            AbortPipelineRun(tpe).transaction(run.uuid)
 
-                # Fix one off jobs (and their pipeline runs).
-                jobs = Job.query.filter_by(schedule=None, status="STARTED").all()
-                with TwoPhaseExecutor(db.session) as tpe:
-                    for job in jobs:
-                        AbortJob(tpe).transaction(job.uuid)
+                    # Fix one off jobs (and their pipeline runs).
+                    jobs = Job.query.filter_by(schedule=None, status="STARTED").all()
+                    with TwoPhaseExecutor(db.session) as tpe:
+                        for job in jobs:
+                            AbortJob(tpe).transaction(job.uuid)
 
-                # This is to fix the state of cron jobs pipeline runs.
-                runs = NonInteractivePipelineRun.query.filter(
-                    NonInteractivePipelineRun.status.in_(["STARTED"])
-                ).all()
-                with TwoPhaseExecutor(db.session) as tpe:
-                    for run in runs:
-                        AbortPipelineRun(tpe).transaction(run.uuid)
+                    # This is to fix the state of cron jobs pipeline
+                    # runs.
+                    runs = NonInteractivePipelineRun.query.filter(
+                        NonInteractivePipelineRun.status.in_(["STARTED"])
+                    ).all()
+                    with TwoPhaseExecutor(db.session) as tpe:
+                        for run in runs:
+                            AbortPipelineRun(tpe).transaction(run.uuid)
 
-                # Fix env builds.
-                builds = EnvironmentBuild.query.filter(
-                    EnvironmentBuild.status.in_(["PENDING", "STARTED"])
-                ).all()
-                with TwoPhaseExecutor(db.session) as tpe:
-                    for build in builds:
-                        AbortEnvironmentBuild(tpe).transaction(build.uuid)
+                    # Fix env builds.
+                    builds = EnvironmentBuild.query.filter(
+                        EnvironmentBuild.status.in_(["PENDING", "STARTED"])
+                    ).all()
+                    with TwoPhaseExecutor(db.session) as tpe:
+                        for build in builds:
+                            AbortEnvironmentBuild(tpe).transaction(build.uuid)
 
-                # Fix jupyter builds.
-                builds = JupyterBuild.query.filter(
-                    JupyterBuild.status.in_(["PENDING", "STARTED"])
-                ).all()
-                with TwoPhaseExecutor(db.session) as tpe:
-                    for build in builds:
-                        AbortJupyterBuild(tpe).transaction(build.uuid)
+                    # Fix jupyter builds.
+                    builds = JupyterBuild.query.filter(
+                        JupyterBuild.status.in_(["PENDING", "STARTED"])
+                    ).all()
+                    with TwoPhaseExecutor(db.session) as tpe:
+                        for build in builds:
+                            AbortJupyterBuild(tpe).transaction(build.uuid)
 
-                # Trigger a build of JupyterLab if no JupyterLab image
-                # is found for this version and JupyterLab setup_script
-                # is non-empty.
-                trigger_conditional_jupyter_build(app)
+                    # Trigger a build of JupyterLab if no JupyterLab
+                    # image is found for this version and JupyterLab
+                    # setup_script is non-empty.
+                    trigger_conditional_jupyter_build(app)
 
-                # Make environments unavailable to a user after an
-                # update.
-                utils.process_stale_environment_images()
+                    # Make environments unavailable to a user after an
+                    # update.
+                    utils.process_stale_environment_images()
 
-                # Remove dangling Orchest images, mostly useful after an
-                # update.
-                utils.delete_dangling_orchest_images()
+                    # Remove dangling Orchest images, mostly useful
+                    # after an update.
+                    utils.delete_dangling_orchest_images()
 
-            except FileExistsError:
-                app.logger.info("/tmp/cleanup_done exists. Skipping cleanup.")
-            except Exception as e:
-                app.logger.error("Cleanup failed")
-                app.logger.error(e)
+                except Exception as e:
+                    app.logger.error("Cleanup failed")
+                    app.logger.error(e)
 
-    if be_scheduler and not is_werkzeug_parent():
+    # Create a background scheduler (in a daemon thread) for every
+    # gunicorn worker. The individual schedulers do not cause duplicate
+    # execution because all jobs of the all the schedulers read state
+    # from the same DB and lock rows they are handling (using a
+    # `with_for_update`).
+    # In case of Flask development mode, only the parent process will
+    # run a scheduler which will survive reloads as that only restarts
+    # the child process.
+    if be_scheduler:
         # Create a scheduler and have the scheduling logic running
         # periodically.
-
+        app.logger.info("Creating a backgroundscheduler in a daemon thread.")
         scheduler = BackgroundScheduler(
             job_defaults={
                 # Infinite amount of grace time, so that if a task
@@ -194,16 +230,20 @@ def create_app(config_class=None, use_db=True, be_scheduler=False):
                 "max_instances": 2 ** 31,
             },
         )
+
         app.config["SCHEDULER"] = scheduler
         scheduler.start()
         scheduler.add_job(
+            # Locks rows it is processing.
             Scheduler.check_for_jobs_to_be_scheduled,
             "interval",
             seconds=app.config["SCHEDULER_INTERVAL"],
             args=[app],
         )
 
-    # Register blueprints.
+    # Register blueprints at the end to avoid issues when migrating the
+    # DB. When registering a blueprint the DB schema is also registered
+    # and so the DB migration should happen before it..
     app.register_blueprint(api, url_prefix="/api")
 
     return app
@@ -310,6 +350,8 @@ def trigger_conditional_jupyter_build(app):
 
 
 def register_teardown_request(app):
+    """Register functions to happen after every request to the app."""
+
     @app.after_request
     def teardown(response):
         app.logger.debug(

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -705,14 +705,14 @@ def delete_dangling_orchest_images() -> None:
         # environment, even a dangling one, will not be removed.
         "dangling": True,
     }
-    env_imgs = docker_images_list_safe(docker_client, filters=filters)
+    env_imgs = docker_images_list_safe(docker_client, filters=filters, attempt_count=1)
     for img in env_imgs:
         # Since environment images might be built using Orchest base
         # images, make sure to not delete environment images by mistake
         # because of the filtering.
         env_uuid = img.labels.get("_orchest_environment_uuid")
         if env_uuid is None:
-            docker_images_rm_safe(docker_client, img.id)
+            docker_images_rm_safe(docker_client, img.id, attempt_count=1)
 
 
 def is_orchest_idle() -> dict:

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -1,3 +1,4 @@
+import collections
 import hashlib
 import json
 import os
@@ -400,22 +401,18 @@ def get_api_entity_counts(endpoint, entity_key, project_uuid=None):
         f'http://{current_app.config["ORCHEST_API_ADDRESS"]}{endpoint}', params=params
     )
 
-    data = resp.json()
-    counts = {}
-
     if resp.status_code != 200:
         current_app.logger.error(
             "Failed to fetch entity count "
             "from orchest-api. Endpoint [%s] Entity key[%s]. Status code: %d"
             % (endpoint, entity_key, resp.status_code)
         )
-        return counts
+        return {}
 
+    data = resp.json()
+    counts = collections.defaultdict(int)
     for entity in data[entity_key]:
-        if entity["project_uuid"] in counts:
-            counts[entity["project_uuid"]] += 1
-        else:
-            counts[entity["project_uuid"]] = 1
+        counts[entity["project_uuid"]] += 1
 
     return counts
 


### PR DESCRIPTION
## Description

In the edge case where a dangling image could not be deleted (e.g. the
parent image failed to start but is never removed using
`docker rm $(docker ps -a -q)`) we would sleep for 1 second and retry
this 10 times. This would cause the orchest-api to be unresponsive and
thereby making the FE feel unresponsive for views (e.g. `/projects`)
that query the orchest-api.

Ideally the host machine has a clean docker environment, i.e. no
dangling images, but we can't guarantee this. Luckily, this edge case
should be rare for users and only happen for developers of Orchest.
