### PR TITLE
Enable jupyterlab widgets by default

### DIFF
--- a/services/jupyter-server/Dockerfile
+++ b/services/jupyter-server/Dockerfile
@@ -27,6 +27,8 @@ RUN git clone https://github.com/orchest/visual-tags.git /jupyter-extensions/vis
         --no-build \
         --BaseExtensionApp.app_dir=$extension_dir \
     && pip3 install jupyterlab-git==0.30.1 \
+    # Requires `ipywidgets` to be installed in the kernels, which it is
+    # by default because we depend on the Jupyter Stacks.
     && pip3 install jupyterlab-widgets==1.0.2 \
     && cp -rfT $pip_jupyter_extension_dir $extension_dir/extensions \
     && jupyter lab build --dev-build=False --LabBuildApp.app_dir=$extension_dir \

--- a/services/jupyter-server/Dockerfile
+++ b/services/jupyter-server/Dockerfile
@@ -27,6 +27,7 @@ RUN git clone https://github.com/orchest/visual-tags.git /jupyter-extensions/vis
         --no-build \
         --BaseExtensionApp.app_dir=$extension_dir \
     && pip3 install jupyterlab-git==0.30.1 \
+    && pip3 install jupyterlab-widgets==1.0.2 \
     && cp -rfT $pip_jupyter_extension_dir $extension_dir/extensions \
     && jupyter lab build --dev-build=False --LabBuildApp.app_dir=$extension_dir \
     && jupyter lab clean --LabCleanApp.app_dir=$extension_dir


### PR DESCRIPTION
## Description

Enables JupyterLab widgets by default.

It is a feature many people use and configuring JupyterLab through our UI is something not that many people do, so instead of users having to add:
```bash
pip install jupyterlab-widgets
```
it is baked into the image.
