### PR TITLE
Fix/main drawer unable to track deeper view

### DIFF
--- a/services/orchest-webserver/client/src/components/MainDrawer.tsx
+++ b/services/orchest-webserver/client/src/components/MainDrawer.tsx
@@ -17,7 +17,7 @@ import { CSSObject, styled, Theme } from "@mui/material/styles";
 import Toolbar from "@mui/material/Toolbar";
 import React from "react";
 import { matchPath, useLocation } from "react-router-dom";
-import { siteMap, toQueryString } from "../routingConfig";
+import { getOrderedRoutes, siteMap, toQueryString } from "../routingConfig";
 
 type ItemData = { label: string; icon: JSX.Element; path: string };
 
@@ -114,6 +114,8 @@ const ListItemText = (props: ListItemTextProps) => {
   );
 };
 
+const routes = getOrderedRoutes();
+
 export const AppDrawer: React.FC<{ isOpen?: boolean }> = ({ isOpen }) => {
   const {
     state: { projectUuid },
@@ -136,7 +138,13 @@ export const AppDrawer: React.FC<{ isOpen?: boolean }> = ({ isOpen }) => {
   }, [isOpen]);
 
   const isSelected = (path: string, exact = false) => {
-    return matchPath(pathname, { path: path.split("?")[0], exact }) !== null;
+    const route = routes.find((route) => route.path === pathname);
+    return (
+      matchPath(route?.root || route?.path || pathname, {
+        path: path.split("?")[0],
+        exact,
+      }) !== null
+    );
   };
 
   return (

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -46,6 +46,7 @@ type RouteName =
 
 type RouteData = {
   path: string;
+  root?: string;
   component: React.FunctionComponent;
   order: number;
 };
@@ -70,12 +71,14 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
     {
       name: "examples",
       path: "/examples",
+      root: "/projects",
       title: getTitle("Examples"),
       component: ExamplesView,
     },
     {
       name: "projectSettings",
       path: "/project-settings",
+      root: "/projects",
       title: getTitle("Project Settings"),
       component: ProjectSettingsView,
     },
@@ -88,30 +91,35 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
     {
       name: "pipeline",
       path: "/pipeline",
+      root: "/pipelines",
       title: getTitle("Pipeline"),
       component: PipelineView,
     },
     {
       name: "jupyterLab",
       path: "/jupyter-lab",
+      root: "/pipelines",
       title: getTitle("JupyterLab"),
       component: JupyterLabView,
     },
     {
       name: "pipelineSettings",
       path: "/pipeline-settings",
+      root: "/pipelines",
       title: getTitle("Pipeline Settings"),
       component: PipelineSettingsView,
     },
     {
       name: "filePreview",
       path: "/file-preview",
+      root: "/pipelines",
       title: getTitle("Step File Preview"),
       component: FilePreviewView,
     },
     {
       name: "logs",
       path: "/logs",
+      root: "/pipelines",
       title: getTitle("Logs"),
       component: LogsView,
     },
@@ -124,6 +132,7 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
     {
       name: "environment",
       path: "/environment",
+      root: "/environments",
       title: getTitle("Environment"),
       component: EnvironmentEditView,
     },
@@ -136,12 +145,14 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
     {
       name: "job",
       path: "/job",
+      root: "/jobs",
       title: getTitle("Job"),
       component: JobView,
     },
     {
       name: "editJob",
       path: "/edit-job",
+      root: "/jobs",
       title: getTitle("Edit Job"),
       component: EditJobView,
     },
@@ -160,18 +171,21 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
     {
       name: "configureJupyterLab",
       path: "/configure-jupyter-lab",
+      root: "/settings",
       title: getTitle("Configure JupyterLab"),
       component: ConfigureJupyterLabView,
     },
     {
       name: "update",
       path: "/update",
+      root: "/settings",
       title: getTitle("Update"),
       component: UpdateView,
     },
     {
       name: "manageUsers",
       path: "/manage-users",
+      root: "/settings",
       title: getTitle("Manage Users"),
       component: ManageUsersView,
     },
@@ -197,6 +211,7 @@ export const siteMap = getOrderedRoutes().reduce<Record<RouteName, RouteData>>(
     ...all,
     [curr.name]: {
       path: curr.path,
+      root: curr.root,
       component: curr.component,
       order: i,
     } as RouteData,


### PR DESCRIPTION
## Description

With this PR, the main navigation bar always highlights the root item that user is currently browsing.

Fixes: #614 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
