### PR TITLE
Improv/move sessions poller to HeaderBar

### DIFF
--- a/services/orchest-webserver/client/src/components/HeaderBar.tsx
+++ b/services/orchest-webserver/client/src/components/HeaderBar.tsx
@@ -1,6 +1,7 @@
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import { siteMap } from "@/Routes";
 import StyledButtonOutlined from "@/styled-components/StyledButton";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
@@ -32,9 +33,20 @@ export const HeaderBar = ({
   isDrawerOpen: boolean;
 }) => {
   const { navigateTo } = useCustomRoute();
-  const { state, dispatch } = useProjectsContext();
   const location = useLocation();
+
+  const {
+    state: {
+      projectUuid,
+      pipelineUuid,
+      pipelineName,
+      pipelineSaveStatus,
+      pipelineIsReadOnly,
+    },
+    dispatch,
+  } = useProjectsContext();
   const appContext = useAppContext();
+  useSessionsPoller();
 
   React.useEffect(() => {
     /*
@@ -69,7 +81,6 @@ export const HeaderBar = ({
   };
 
   const showPipeline = (e: React.MouseEvent) => {
-    const { projectUuid, pipelineUuid } = state;
     navigateTo(
       siteMap.pipeline.path,
       { query: { projectUuid, pipelineUuid } },
@@ -78,8 +89,6 @@ export const HeaderBar = ({
   };
 
   const showJupyter = (e: React.MouseEvent) => {
-    const { projectUuid, pipelineUuid } = state;
-
     navigateTo(
       siteMap.jupyterLab.path,
       { query: { projectUuid, pipelineUuid } },
@@ -128,14 +137,14 @@ export const HeaderBar = ({
         <ProjectSelector />
         <LinearProgress />
         <Box sx={{ flex: 1 }}>
-          {state.pipelineName && (
+          {pipelineName && (
             <Stack
               direction="row"
               alignItems="center"
               justifyContent="center"
               spacing={2}
             >
-              {state.pipelineSaveStatus === "saved" ? (
+              {pipelineSaveStatus === "saved" ? (
                 <Tooltip title="Pipeline saved">
                   <CheckCircleIcon />
                 </Tooltip>
@@ -150,21 +159,21 @@ export const HeaderBar = ({
                   overflow: "hidden",
                   whiteSpace: "nowrap",
                 }}
-                title={state.pipelineName}
+                title={pipelineName}
               >
-                {state.pipelineName}
+                {pipelineName}
               </Typography>
             </Stack>
           )}
         </Box>
         <Stack spacing={2} direction="row">
-          {state.pipelineName && !state.pipelineIsReadOnly && (
+          {pipelineName && !pipelineIsReadOnly && (
             <SessionToggleButton
-              pipelineUuid={state.pipelineUuid}
-              projectUuid={state.projectUuid}
+              pipelineUuid={pipelineUuid}
+              projectUuid={projectUuid}
             />
           )}
-          {state.pipelineName && matchJupyter && (
+          {pipelineName && matchJupyter && (
             <StyledButtonOutlined
               variant="outlined"
               color="secondary"
@@ -175,7 +184,7 @@ export const HeaderBar = ({
               Switch to Pipeline
             </StyledButtonOutlined>
           )}
-          {state.pipelineName && !state.pipelineIsReadOnly && matchPipeline && (
+          {pipelineName && !pipelineIsReadOnly && matchPipeline && (
             <StyledButtonOutlined
               variant="outlined"
               color="secondary"

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -34,7 +34,7 @@ function convertKeyToCamelCase<T>(data: T | undefined, keys?: string[]) {
 }
 
 /**
- * useSessionsPoller should only be placed in HeaderBar
+ * NOTE: useSessionsPoller should only be placed in HeaderBar
  */
 export const useSessionsPoller = () => {
   const { dispatch } = useSessionsContext();
@@ -44,7 +44,6 @@ export const useSessionsPoller = () => {
   } = useProjectsContext();
 
   const location = useLocation();
-
   const matches = matchPath(location.pathname, [
     siteMap.pipelines.path,
     siteMap.pipelineSettings.path,
@@ -55,11 +54,11 @@ export const useSessionsPoller = () => {
     siteMap.jupyterLab.path,
   ]);
 
-  // sessions are only needed when
+  // sessions are only needed when both conditions are met
   // 1. pipelineUuid is given, and is not read-only
-  // 2. in the pipeline list
+  // 2. in the list above
   const shouldPoll =
-    (!pipelineIsReadOnly && hasValue(pipelineUuid)) || hasValue(matches);
+    !pipelineIsReadOnly && hasValue(pipelineUuid) && matches?.isExact;
 
   const { cache } = useSWRConfig();
 
@@ -95,7 +94,7 @@ export const useSessionsPoller = () => {
       cache.get(ENDPOINT)?.sessions || // in case sessions are needed when polling is not active
       []
     );
-  }, [data]);
+  }, [data, cache]);
 
   React.useEffect(() => {
     dispatch({

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -44,21 +44,25 @@ export const useSessionsPoller = () => {
   } = useProjectsContext();
 
   const location = useLocation();
-  const matches = matchPath(location.pathname, [
+  const matchRooViews = matchPath(location.pathname, [
+    siteMap.configureJupyterLab.path,
     siteMap.pipelines.path,
+  ]);
+  const matchPipelineViews = matchPath(location.pathname, [
     siteMap.pipelineSettings.path,
     siteMap.logs.path,
     siteMap.pipeline.path,
-    siteMap.pipelines.path,
-    siteMap.configureJupyterLab.path,
     siteMap.jupyterLab.path,
   ]);
 
   // sessions are only needed when both conditions are met
-  // 1. pipelineUuid is given, and is not read-only
-  // 2. in the list above
+  // 1. in the PipelinesView or ConfigureJupyterLabView (they are root views without a pipeline_uuid)
+  // 2. in the above views AND pipelineUuid is given AND is not read-only
   const shouldPoll =
-    !pipelineIsReadOnly && hasValue(pipelineUuid) && matches?.isExact;
+    matchRooViews?.isExact ||
+    (!pipelineIsReadOnly &&
+      hasValue(pipelineUuid) &&
+      matchPipelineViews?.isExact);
 
   const { cache } = useSWRConfig();
 

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -85,7 +85,7 @@ export const useSessionsPoller = () => {
       data?.sessions.map((session) =>
         convertKeyToCamelCase(session, ["project_uuid", "pipeline_uuid"])
       ) ||
-      cache.get(ENDPOINT)?.sessions || // in case sessions are need when polling is not active
+      cache.get(ENDPOINT)?.sessions || // in case sessions are needed when polling is not active
       []
     );
   }, [data]);

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -66,7 +66,7 @@ export const useSessionsPoller = () => {
 
   const { cache } = useSWRConfig();
 
-  const { data, error } = useSWR<{
+  const { data, error, mutate } = useSWR<{
     sessions: (IOrchestSession & {
       project_uuid: string;
       pipeline_uuid: string;
@@ -80,6 +80,10 @@ export const useSessionsPoller = () => {
     // in order to facilitate multiple users working at the same time, FE needs to check pipeline sessions at all times
     refreshInterval: 1000,
   });
+
+  React.useEffect(() => {
+    if (shouldPoll) mutate();
+  }, [location, shouldPoll, mutate]);
 
   const isLoading = !data && !error;
 

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -6,7 +6,7 @@ import { IOrchestSession } from "@/types";
 import { fetcher, hasValue } from "@orchest/lib-utils";
 import pascalcase from "pascalcase";
 import React from "react";
-import { useRouteMatch } from "react-router-dom";
+import { matchPath, useLocation } from "react-router-dom";
 import useSWR, { useSWRConfig } from "swr";
 
 type TSessionStatus = IOrchestSession["status"];
@@ -43,16 +43,23 @@ export const useSessionsPoller = () => {
     state: { pipelineUuid, pipelineIsReadOnly },
   } = useProjectsContext();
 
-  const matchPipelines = useRouteMatch({
-    path: siteMap.pipelines.path,
-    exact: true,
-  });
+  const location = useLocation();
+
+  const matches = matchPath(location.pathname, [
+    siteMap.pipelines.path,
+    siteMap.pipelineSettings.path,
+    siteMap.logs.path,
+    siteMap.pipeline.path,
+    siteMap.pipelines.path,
+    siteMap.configureJupyterLab.path,
+    siteMap.jupyterLab.path,
+  ]);
 
   // sessions are only needed when
   // 1. pipelineUuid is given, and is not read-only
   // 2. in the pipeline list
   const shouldPoll =
-    (!pipelineIsReadOnly && hasValue(pipelineUuid)) || hasValue(matchPipelines);
+    (!pipelineIsReadOnly && hasValue(pipelineUuid)) || hasValue(matches);
 
   const { cache } = useSWRConfig();
 

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -16,7 +16,6 @@ import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import { siteMap } from "@/Routes";
 import type {
   PipelineJson,
@@ -134,7 +133,6 @@ const PipelineSettingsView: React.FC = () => {
   } = useCustomRoute();
 
   const { getSession } = useSessionsContext();
-  useSessionsPoller();
 
   const isReadOnly =
     (hasValue(runUuid) && hasValue(jobUuid)) || isReadOnlyFromQueryString;

--- a/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
@@ -4,7 +4,6 @@ import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import LogViewer from "@/pipeline-view/LogViewer";
 import { siteMap } from "@/Routes";
 import type {
@@ -56,7 +55,6 @@ const LogsView: React.FC = () => {
   } = useCustomRoute();
 
   const { getSession } = useSessionsContext();
-  useSessionsPoller();
 
   const [promiseManager] = React.useState(new PromiseManager());
 

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -8,7 +8,6 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useHotKeys } from "@/hooks/useHotKeys";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import StyledButtonOutlined from "@/styled-components/StyledButton";
 import type { PipelineJson } from "@/types";
 import { layoutPipeline } from "@/utils/pipeline-layout";
@@ -167,7 +166,6 @@ const PipelineView: React.FC = () => {
     state: { sessionsIsLoading },
     getSession,
   } = sessionContext;
-  useSessionsPoller();
 
   const [isReadOnly, _setIsReadOnly] = useState(isReadOnlyFromQueryString);
   const setIsReadOnly = (readOnly: boolean) => {

--- a/services/orchest-webserver/client/src/pipelines-view/PipelineList.tsx
+++ b/services/orchest-webserver/client/src/pipelines-view/PipelineList.tsx
@@ -6,7 +6,6 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useAsync } from "@/hooks/useAsync";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useFetchPipelines } from "@/hooks/useFetchPipelines";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import { siteMap } from "@/Routes";
 import type { PipelineMetaData } from "@/types";
 import { IOrchestSession } from "@/types";
@@ -267,8 +266,6 @@ export const PipelineList: React.FC<{ projectUuid: string }> = ({
     fetchPipelines,
     isFetchingPipelines,
   } = useFetchPipelines(projectUuid);
-
-  useSessionsPoller();
 
   React.useEffect(() => {
     if (error) {

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -4,7 +4,6 @@ import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import { siteMap } from "@/routingConfig";
 import CloseIcon from "@mui/icons-material/Close";
 import MemoryIcon from "@mui/icons-material/Memory";
@@ -32,8 +31,6 @@ const ConfigureJupyterLabView: React.FC = () => {
     deleteAllSessions,
     state: { sessionsKillAllInProgress, sessions },
   } = useSessionsContext();
-
-  useSessionsPoller();
 
   useSendAnalyticEvent("view load", { name: siteMap.configureJupyterLab.path });
 

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -195,16 +195,17 @@ const ConfigureJupyterLabView: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
-    if (!sessionsKillAllInProgress && state.sessionKillStatus === "WAITING") {
-      const hasActiveSessions = sessions.length > 0;
+    const isAllSessionsDeletedForBuildingImage =
+      state.sessionKillStatus === "WAITING" && // an attempt to delete all sessions was initiated
+      !sessionsKillAllInProgress && // the operation of deleting sessions was started
+      sessions.length === 0; // all sessions are finally cleaned up;
 
-      if (!hasActiveSessions) {
-        setState((prevState) => ({
-          ...prevState,
-          sessionKillStatus: undefined,
-        }));
-        buildImage();
-      }
+    if (isAllSessionsDeletedForBuildingImage) {
+      setState((prevState) => ({
+        ...prevState,
+        sessionKillStatus: undefined,
+      }));
+      buildImage();
     }
   }, [sessions, sessionsKillAllInProgress, state.sessionKillStatus]);
 

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -5,7 +5,6 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useInterval } from "@/hooks/use-interval";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import { siteMap } from "@/Routes";
 import type { TViewPropsWithRequiredQueryArgs } from "@/types";
 import { checkGate, getPipelineJSONEndpoint } from "@/utils/webserver-utils";
@@ -35,7 +34,6 @@ const JupyterLabView: React.FC = () => {
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();
 
   const { getSession, toggleSession, state } = useSessionsContext();
-  useSessionsPoller();
 
   // local states
   const [verifyKernelsInterval, setVerifyKernelsInterval] = React.useState(


### PR DESCRIPTION
## Description

Move useSessionsPoller into HeaderBar to easier session polling management.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
