### PR TITLE
Remove unused `/api-proxy/` location from nginx conf

### DIFF
--- a/services/nginx-proxy/orchest.conf
+++ b/services/nginx-proxy/orchest.conf
@@ -19,14 +19,14 @@ server {
   server_name localhost;
 
   error_log  /var/log/nginx.error.log debug;
-  
+
   location /login {
 
     proxy_set_header Host $http_host;
 
     set $auth_server "auth-server";
     proxy_pass http://$auth_server;
-    
+
   }
 
   # Conditional SSL redirect
@@ -69,7 +69,7 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_read_timeout 86400;
-    
+
   }
 
   # Update server
@@ -82,7 +82,7 @@ server {
 
     set $update_server "update-server";
     proxy_pass http://$update_server;
-    
+
   }
 
   # File manager
@@ -94,21 +94,7 @@ server {
 
     set $file_manager "file-manager";
     proxy_pass http://$file_manager;
-    
-  }
 
-  location /api-proxy/ {
-
-    auth_request /auth;
-
-    set $orchest_host "orchest-api";
-    
-    set $suffix '';
-    access_by_lua_block {
-        ngx.var.suffix = string.gsub(ngx.var.uri, "/api%-proxy/", "")
-    }
-
-    proxy_pass http://$orchest_host/$suffix$is_args$args;
   }
 
   location ~ ^/(pbp-)?service-[0-9a-zA-Z\-]+-[\-0-9a-f]+-[\-0-9a-f]+_[0-9]+ {
@@ -119,7 +105,7 @@ server {
   location ~ ^/jupyter-server-[\-0-9a-f]+-[\-0-9a-f]+ {
 
     auth_request /auth;
-    
+
     set $dynamic_host '';
 
     access_by_lua_block {


### PR DESCRIPTION
## Description

The rule has probably been there from the early days and was never
removed once we had an api-proxy inside the webserver.

@nhaghighat This means that the [orchest-api ingress](https://github.com/orchest/orchest/blob/feat/k8s/deploy/helm/charts/orchest-api/templates/ingress.yaml) is no longer needed, right?
