### PR TITLE
Don't try to fix userdir permissions in `--cloud`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,14 +60,16 @@ jobs:
           [ ! -z "$(docker ps -a -q)" ] && docker rm -fv $(docker ps -a -q)
           docker image prune -f
           [ ! -z "$(docker images --filter 'label=_orchest_project_uuid' -q)" ] && docker rmi -f $(docker images --filter "label=_orchest_project_uuid" -q)
-          bash scripts/clean_userdir.sh
 
       # Orchest won't be able to write files that are part of a project
       # that was copied in the existing project directory otherwise.
       # NOTE: the permissions have to be `2775` to make sure the sticky
-      # bit is set on the userdir.
+      # bit is set on the userdir which is done as part of the
+      # `clean_userdir.sh` script.
       - name: Fix group w/x permissions.
-        run: chmod 775 -R ${{ github.workspace }} && chmod 2775 -R userdir
+        run: |
+          chmod 775 -R ${{ github.workspace }}
+          bash scripts/clean_userdir.sh
 
       - name: Build and Start Orchest
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,8 +64,10 @@ jobs:
 
       # Orchest won't be able to write files that are part of a project
       # that was copied in the existing project directory otherwise.
+      # NOTE: the permissions have to be `2775` to make sure the sticky
+      # bit is set on the userdir.
       - name: Fix group w/x permissions.
-        run: chmod 775 -R ${{ github.workspace }}
+        run: chmod 775 -R ${{ github.workspace }} && chmod 2775 -R userdir
 
       - name: Build and Start Orchest
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,6 +60,7 @@ jobs:
           [ ! -z "$(docker ps -a -q)" ] && docker rm -fv $(docker ps -a -q)
           docker image prune -f
           [ ! -z "$(docker images --filter 'label=_orchest_project_uuid' -q)" ] && docker rmi -f $(docker images --filter "label=_orchest_project_uuid" -q)
+          exit 0
 
       # Orchest won't be able to write files that are part of a project
       # that was copied in the existing project directory otherwise.

--- a/scripts/clean_userdir.sh
+++ b/scripts/clean_userdir.sh
@@ -14,3 +14,6 @@ sudo rm -rf $DIR/../userdir
 git checkout $DIR/../userdir
 
 echo "[Cleaning up userdir]: success"
+
+echo "Setting the right permissions on the userdir..."
+chmod g+s $DIR/../userdir

--- a/scripts/clean_userdir.sh
+++ b/scripts/clean_userdir.sh
@@ -15,5 +15,7 @@ git checkout $DIR/../userdir
 
 echo "[Cleaning up userdir]: success"
 
+# The find command includes setting the sticky bit on the userdir
+# directory itself.
 echo "Setting the right permissions on the userdir..."
-chmod g+s $DIR/../userdir
+find $DIR/../userdir -type d -not -perm -g+s -exec chmod g+s {} \;

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -8,7 +8,7 @@ import typer
 from app.cli import start as cli_start
 from app.orchest import OrchestApp
 from app.spec import get_container_config
-from app.utils import echo
+from app.utils import echo, fix_userdir_permissions
 
 
 # TODO: utils.py
@@ -192,6 +192,10 @@ def install(
     Installation might take some time depending on your network
     bandwidth.
     """
+    # Make sure the permissions of the userdir are correctly set in case
+    # Orchest will always be started using `--cloud` in the future (as
+    # in other modes the permissions are fixed on start).
+    fix_userdir_permissions()
     app.install(language, gpu=gpu)
 
 

--- a/services/orchest-ctl/app/cli/start.py
+++ b/services/orchest-ctl/app/cli/start.py
@@ -98,4 +98,4 @@ def reg(
             "to monitor for source code changes."
         )
 
-    app.start(container_config)
+    app.start(container_config, cloud=cloud)

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -201,7 +201,7 @@ class OrchestApp:
             utils.echo("Update completed. To start Orchest again, run:")
             utils.echo("\torchest start")
 
-    def start(self, container_config: dict, cloud=False):
+    def start(self, container_config: dict, cloud: bool = False):
         """Starts Orchest.
 
         Raises:

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -201,7 +201,7 @@ class OrchestApp:
             utils.echo("Update completed. To start Orchest again, run:")
             utils.echo("\torchest start")
 
-    def start(self, container_config: dict):
+    def start(self, container_config: dict, cloud=False):
         """Starts Orchest.
 
         Raises:
@@ -257,8 +257,12 @@ class OrchestApp:
         ids, exited_containers = self.resource_manager.get_containers(state="exited")
         self.docker_client.remove_containers(ids)
 
-        utils.fix_userdir_permissions()
-        logger.info("Fixing permissions on the 'userdir/'.")
+        # When running Orchest in cloud mode it is not necessary to
+        # fix permissions of files on start because users can only
+        # manipulate and add files through Orchest directly.
+        if not cloud:
+            utils.fix_userdir_permissions()
+            logger.info("Fixing permissions on the 'userdir/'.")
 
         utils.echo("Starting Orchest...")
         logger.info("Starting containers:\n" + "\n".join(start_req_images))

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -261,8 +261,8 @@ class OrchestApp:
         # fix permissions of files on start because users can only
         # manipulate and add files through Orchest directly.
         if not cloud:
-            utils.fix_userdir_permissions()
             logger.info("Fixing permissions on the 'userdir/'.")
+            utils.fix_userdir_permissions()
 
         utils.echo("Starting Orchest...")
         logger.info("Starting containers:\n" + "\n".join(start_req_images))


### PR DESCRIPTION
## Description

It shouldn't be needed to fix permissions anyways and for large userdirs this `find` command can take very long.

##### TODO
- [x] Fix integration tests
- [x] Depending on the fix for the tests we need to add `chmod g+s` to `./orchest install` to make sure the sticky bit is always set on the userdir.