### PR TITLE
Add celery-worker and orchest-api cluster permissions

### DIFF
--- a/deploy/helm/charts/orchest-api/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-api/templates/deployment.yaml
@@ -13,6 +13,7 @@ deployment
           hostPath:
             path: /var/lib/orchest/userdir
             type: DirectoryOrCreate
+      serviceAccountName: {{ template "library.metadata.name" . }}      
       containers:
       - name: orchest-api
         image: orchest/orchest-api:latest

--- a/deploy/helm/charts/orchest-api/templates/rbac.yaml
+++ b/deploy/helm/charts/orchest-api/templates/rbac.yaml
@@ -1,0 +1,17 @@
+{{/*
+ClusterRole
+*/}}
+---
+{{ include "library.cluster.roles" . }}
+---
+{{/*
+ClusterRoleBinding
+*/}}
+---
+{{ include "library.cluster.rolebindings" . }}
+---
+{{/*
+ServiceAccounts
+*/}}
+---
+{{ include "library.cluster.serviceaccounts" . }}

--- a/deploy/helm/templates/_cluster-role.tpl
+++ b/deploy/helm/templates/_cluster-role.tpl
@@ -8,9 +8,18 @@ metadata:
   labels:
     {{- include "library.labels.selector" . | nindent 4 }}
 rules:
-  - apiGroups: ["argoproj.io"]
+  - apiGroups: ["argoproj.io", "", "apps"]
     resources:
       - workflows
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - services
+      - services/status
+      - namespaces
+      - namespaces/status
+      - pods
+      - pods/log
     verbs:
       - create
       - get


### PR DESCRIPTION
## Description

Adds permissions to the `celery-worker` and `orchest-api` that are required for their tasks.
