### PR TITLE
Reduce snapshot size by ignoring patterns defined in the `.gitignore`

### DIFF
--- a/services/orchest-webserver/Dockerfile
+++ b/services/orchest-webserver/Dockerfile
@@ -2,7 +2,9 @@ FROM tiangolo/meinheld-gunicorn-flask:python3.8
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Install required system packages and refresh certs
-RUN apt-get update && apt-get install -y ca-certificates git && update-ca-certificates --fresh
+RUN apt-get update \
+    && apt-get install -y ca-certificates git rsync \
+    && update-ca-certificates --fresh
 
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -61,7 +61,18 @@ class Config:
         "setup_script": _config.DEFAULT_SETUP_SCRIPT,
     }
 
-    PROJECT_ORCHEST_GIT_IGNORE_CONTENT = "\n".join(["logs/", "data/"])
+    # Content for `.orchest/.gitignore` in project dir.
+    # `pipelines/*/logs/` excludes `logs/` directories that are two
+    # levels below the `.pipelines/` directory.
+    GIT_IGNORE_PROJECT_HIDDEN_ORCHEST = ["pipelines/*/logs/", "pipelines/*/data/"]
+    # On project creation through Orchest, we want the patterns from the
+    # `.orchest/.gitignore` to be present in the root-level `.gitignore`
+    # so that when creating a new job the files are not copied to the
+    # snapshot.
+    GIT_IGNORE_PROJECT_ROOT = [
+        *[".orchest/" + pattern for pattern in GIT_IGNORE_PROJECT_HIDDEN_ORCHEST],
+        ".ipynb_checkpoints/",
+    ]
 
     FLASK_ENV = os.environ.get("FLASK_ENV", "production")
 

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -513,7 +513,10 @@ def rmtree(path, ignore_errors=False):
 
 
 def copytree(source: str, target: str):
-    """A wrapped cp -r that ignores source/.gitignore patterns.
+    """Copies content from source to target.
+
+    As part of the copying process it ignores patterns from the
+    top-level `.gitignore` in `source`.
 
     If eventlet is being used and it's either patching all modules or
     patchng subprocess, this function is not going to block the thread.

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -495,10 +495,12 @@ def create_job_directory(job_uuid, pipeline_uuid, project_uuid):
     )
 
     copytree(project_dir, snapshot_path)
+    # TODO: check whether we can indeed remove this.
     # Ignore the ".orchest/pipelines" directory containing the logs and
     # data directories. Ignore errors because the directory might not be
     # there.
-    rmtree(os.path.join(snapshot_path, ".orchest/pipelines"), ignore_errors=True)
+    # rmtree(os.path.join(snapshot_path,
+    # ".orchest/pipelines"), ignore_errors=True)
 
 
 def rmtree(path, ignore_errors=False):
@@ -517,7 +519,7 @@ def rmtree(path, ignore_errors=False):
 
 
 def copytree(source: str, target: str):
-    """A wrapped cp -r.
+    """A wrapped cp -r that ignores source/.gitignore patterns.
 
     If eventlet is being used and it's either patching all modules or
     patchng subprocess, this function is not going to block the thread.
@@ -526,8 +528,24 @@ def copytree(source: str, target: str):
         OSError if it failed to copy.
 
     """
+    # With a trailing `/` rsync copies the content of the directory
+    # instead of the directory itself.
+    if not source.endswith("/"):
+        source += "/"
+
+    # Construct copy command.
+    # Using rsync with `-W` copies files as a whole which drastically
+    # improves its performance, making it almost as fast as the `cp`
+    # command. The other options (`-aHAX`) are to preserve all kinds
+    # of attributes, e.g. symlinks, `-a` also automatically copies
+    # recursively.
+    copy_cmd = ["rsync", "-aWHAX"]
+    if os.path.isfile(f"{source}.gitignore"):  # source has trailing `/`
+        copy_cmd += [f"--exclude-from={source}.gitignore"]
+    copy_cmd += [f"{source} {target}"]
+
     exit_code = subprocess.call(
-        f"cp -r {source} {target}", stderr=subprocess.STDOUT, shell=True
+        " ".join(copy_cmd), stderr=subprocess.STDOUT, shell=True
     )
     if exit_code != 0:
         raise OSError(f"Failed to copy {source} to {target}, :{exit_code}.")

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -495,12 +495,6 @@ def create_job_directory(job_uuid, pipeline_uuid, project_uuid):
     )
 
     copytree(project_dir, snapshot_path)
-    # TODO: check whether we can indeed remove this.
-    # Ignore the ".orchest/pipelines" directory containing the logs and
-    # data directories. Ignore errors because the directory might not be
-    # there.
-    # rmtree(os.path.join(snapshot_path,
-    # ".orchest/pipelines"), ignore_errors=True)
 
 
 def rmtree(path, ignore_errors=False):


### PR DESCRIPTION
## Description

Fixes: #599 

The changes can be summarized as:
* Swap out `cp -r` for an `rsync` command.
* Populate a root-level `.gitignore` file that can be passed to `rsync` to ignore the files when copying.

### Performance `rsync`
It makes sense that `cp` is generally more performant since it doesn't do any intelligent checking whether files have to be copied. However, now that we don't use `cp` we can skip copying large files (e.g. `logs` and `data` generated by the steps). In addition, a project directory is probably limited in size and its number of files.

The experimentation below showed promising results.
 
```bash
head -c 10GB /dev/zero > bigfile

time cp bigfile largefile
-> cp bigfile largefile  0,07s user 4,64s system 95% cpu 4,935 total

rm largefile

time rsync -aWHAX bigfile largefile
-> rsync -aWHAX bigfile largefile  3,34s user 8,00s system 133% cpu 8,498 total

time cp -R ~/Documents/Orchest/orchest cptmp
-> cp -R ~/Documents/Orchest/orchest cptmp  0,97s user 6,13s system 33% cpu 21,115 total

time rsync -aWHAX ~/Documents/Orchest/orchest rsynctmp
-> rsync -aWHAX ~/Documents/Orchest/orchest rsynctmp  2,99s user 7,37s system 153% cpu 6,736 total
```

## Checklist

- [X] The PR branch is set up to merge into `dev` instead of `master`.
