### PR TITLE
Add a link to the release notes to the update prompt

### DIFF
--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -61,10 +61,19 @@ export const useCheckUpdate = () => {
   const promptUpdate = (currentVersion: string, latestVersion: string) => {
     setConfirm(
       "Update available",
-      <Typography variant="body2">
-        Orchest can be updated from <Code>{currentVersion}</Code> to{" "}
-        <Code>{latestVersion}</Code>. Would you like to update now?
-      </Typography>,
+      <>
+        <Typography variant="body2">
+          Orchest can be updated from <Code>{currentVersion}</Code> to{" "}
+          <Code>{latestVersion}</Code> . Would you like to update now?
+        </Typography>
+        <Typography variant="body2" sx={{ marginTop: 4 }}>
+          Check out the{" "}
+          <a href="https://github.com/orchest/orchest/releases/latest">
+            release notes
+          </a>
+          .
+        </Typography>
+      </>,
       {
         onConfirm: async (resolve) => {
           updateView();


### PR DESCRIPTION
## Description

Who doesn't want to know why they should update? So to inform the user, link to the latest release on our GitHub releases page: https://github.com/orchest/orchest/releases/latest

![image](https://user-images.githubusercontent.com/26223174/152338093-38cd8efc-30f5-4c04-acac-b650e281bab8.png)
(Note: an update prompt would not actually be displayed if you have these versions. Just for testing purposes.)