### PR TITLE
Fix read-only mode step status polling and pipeline settings

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineMetadata.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineMetadata.ts
@@ -43,18 +43,24 @@ export const useFetchPipelineMetadata = ({
 
   // Environment variables are fetched either from 1) pipeline 2) pipeline run
   const [envVariables, _setEnvVariables] = React.useState<EnvVarPair[]>([]);
-  React.useEffect(() => {
+
+  const fetchedEnvVariables = React.useMemo(() => {
     if (pipeline || pipelineRun) {
-      const envVarArray = envVariablesDictToArray(
-        pipeline
-          ? pipeline.env_variables
-          : pipelineRun
-          ? pipelineRun.env_variables
-          : {}
-      );
+      return pipeline
+        ? pipeline.env_variables
+        : pipelineRun
+        ? pipelineRun.env_variables
+        : {};
+    }
+    return null;
+  }, [pipeline, pipelineRun]);
+
+  React.useEffect(() => {
+    if (fetchedEnvVariables) {
+      const envVarArray = envVariablesDictToArray(fetchedEnvVariables);
       _setEnvVariables(envVarArray);
     }
-  }, [pipeline, pipelineRun]);
+  }, [fetchedEnvVariables]);
 
   const setEnvVariables = React.useCallback(
     (data: React.SetStateAction<EnvVarPair[]>) => {

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -2033,6 +2033,10 @@ const PipelineView: React.FC = () => {
   }, [state.currentOngoingSaves]);
 
   React.useEffect(() => {
+    dispatch({
+      type: "SET_PIPELINE_IS_READONLY",
+      payload: isReadOnly,
+    });
     const hasActiveRun = runUuid && jobUuidFromRoute;
     const isNonPipelineRun = !hasActiveRun && isReadOnly;
     if (isNonPipelineRun) {

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -120,6 +120,7 @@ export interface IPipelineViewState {
 }
 
 const PIPELINE_RUN_STATUS_ENDPOINT = "/catch/api-proxy/api/runs/";
+const PIPELINE_JOBS_STATUS_ENDPOINT = "/catch/api-proxy/api/jobs/";
 
 const PipelineView: React.FC = () => {
   const { $ } = window;
@@ -250,7 +251,7 @@ const PipelineView: React.FC = () => {
 
   const [runUuid, setRunUuid] = React.useState(runUuidFromRoute);
   const runStatusEndpoint = jobUuidFromRoute
-    ? `${PIPELINE_RUN_STATUS_ENDPOINT}${jobUuidFromRoute}/`
+    ? `${PIPELINE_JOBS_STATUS_ENDPOINT}${jobUuidFromRoute}/`
     : PIPELINE_RUN_STATUS_ENDPOINT;
 
   const { stepExecutionState, setStepExecutionState } = useStepExecutionState(
@@ -2069,7 +2070,6 @@ const PipelineView: React.FC = () => {
       $(document).off("keyup.initializePipeline");
       $(document).off("keydown.initializePipeline");
 
-      clearInterval(timersRef.current.pipelineStepStatusPollingInterval);
       clearTimeout(timersRef.current.doubleClickTimeout);
       clearTimeout(timersRef.current.saveIndicatorTimeout);
 

--- a/services/orchest-webserver/client/src/pipeline-view/useStepExecutionState.ts
+++ b/services/orchest-webserver/client/src/pipeline-view/useStepExecutionState.ts
@@ -1,4 +1,5 @@
 import { TStatus } from "@/components/Status";
+import { useAppContext } from "@/contexts/AppContext";
 import type { PipelineRun } from "@/types";
 import { serverTimeToDate } from "@/utils/webserver-utils";
 import { fetcher } from "@orchest/lib-utils";
@@ -29,7 +30,7 @@ export const useStepExecutionState = (
   url: string | null,
   callback: (status: TStatus) => void
 ) => {
-  const { data = {}, mutate } = useSWR<StepExecutionStateObj>(
+  const { data = {}, error, mutate } = useSWR<StepExecutionStateObj>(
     url,
     (url) =>
       fetcher<PipelineRun>(url).then((result) => {
@@ -38,6 +39,15 @@ export const useStepExecutionState = (
       }),
     { refreshInterval: STATUS_POLL_FREQUENCY }
   );
+
+  const { setAlert } = useAppContext();
+
+  React.useEffect(() => {
+    if (error) {
+      console.error(error);
+      setAlert("Error", "Unable to fetch step status.");
+    }
+  }, [error, setAlert]);
 
   const setStepExecutionState = React.useCallback(
     (


### PR DESCRIPTION
## Description

Fix unexpected behaviors in PipelineView read-only mode:
- run status polling was not started
- pipeline settings view was broken because env variables was still null in first several renders.

## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.
