### PR TITLE
Display message to users on invalid login credentials

### DIFF
--- a/services/auth-server/client/src/views/Login.tsx
+++ b/services/auth-server/client/src/views/Login.tsx
@@ -47,7 +47,7 @@ const Login: React.FC<{
         throw { error: "Failed to redirect" };
       }
     } catch (error) {
-      setLoginFailure(error.body.error);
+      setLoginFailure(error.error);
     }
   };
 


### PR DESCRIPTION
## Description

Fix parsing the response so that users get prompted the reason why they could not login with the provided credentials

@ricklamers @iannbing Wouldn't it be better to always give the same reason? Because now an attacker could learn whether he/she provided an existing username.
