### PR TITLE
Feat/k8s kaniko caching

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -199,7 +199,7 @@ class DeleteBaseImagesCache(TwoPhaseFunction):
             models.JupyterBuild.status.in_(["PENDING", "STARTED"])
         )
         for jb in jupyter_builds:
-            AbortJupyterBuild(self.tpe)._transaction(jb.uuid)
+            AbortJupyterBuild(self.tpe).transaction(jb.uuid)
 
     def _collateral(self):
         image_utils.delete_base_images_cache()

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -13,7 +13,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 from _orchest.internals import config as _config
 from _orchest.internals.utils import copytree, rmtree
 from app.connections import k8s_custom_obj_api
-from app.core.image_utils import build_docker_image, cleanup_docker_artifacts
+from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from config import CONFIG_CLASS
 
@@ -311,7 +311,7 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
 
             status = SioStreamedTask.run(
                 # What we are actually running/doing in this task,
-                task_lambda=lambda user_logs_fo: build_docker_image(
+                task_lambda=lambda user_logs_fo: build_image(
                     task_uuid,
                     docker_image_name,
                     build_context,

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -112,7 +112,6 @@ def write_environment_dockerfile(
     flag = __DOCKERFILE_RESERVED_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
-        f'&& echo "{flag}" '
         # The ! in front of echo is there so that the script will fail
         # since the statements in the "if" have failed, the echo is a
         # way of injecting the help message.

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -65,13 +65,14 @@ def write_environment_dockerfile(
     statements.append(f"FROM {base_image}")
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
+    statements.append(f'WORKDIR {os.path.join("/", work_dir)}')
 
     # Copy the entire context, that is, given the current use case, that
     # we are copying the project directory (from the snapshot) into the
     # docker image that is to be built, this allows the user defined
     # script defined through orchest to make use of files that are part
     # of its project, e.g. a requirements.txt or other scripts.
-    statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
+    statements.append("COPY . .")
 
     # Permission statements.
     ps = [
@@ -101,11 +102,10 @@ def write_environment_dockerfile(
     flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
     error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
-        f'RUN cd "{os.path.join("/", work_dir)}" '
         # The ! in front of echo is there so that the script will fail
         # since the statements in the "if" have failed, the echo is a
         # way of injecting the help message.
-        f'&& ((if [ $(id -u) = 0 ]; then {ps}; else {sps}; fi) || ! echo "{msg}") '
+        f'RUN ((if [ $(id -u) = 0 ]; then {ps}; else {sps}; fi) || ! echo "{msg}") '
         f"&& bash {bash_script} "
         # Needed to inject the rm statement this way, black was
         # introducing an error.

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -17,8 +17,6 @@ from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from config import CONFIG_CLASS
 
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
 __ENV_BUILD_FULL_LOGS_DIRECTORY = "/tmp/environment_builds_logs"
 
 
@@ -109,7 +107,8 @@ def write_environment_dockerfile(
         f"sudo rm {bash_script}; fi)"
     )
 
-    flag = __DOCKERFILE_RESERVED_FLAG
+    flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+    error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
         # The ! in front of echo is there so that the script will fail
@@ -123,7 +122,7 @@ def write_environment_dockerfile(
         # The || <error flag> allows to avoid kaniko errors logs making
         # into it the user logs and tell us that there has been an
         # error.
-        f"|| (echo {__DOCKERFILE_RESERVED_ERROR_FLAG} && PRODUCE_AN_ERROR)"
+        f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
     statements.append("LABEL _orchest_env_build_is_intermediate=0")
 

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -340,7 +340,14 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
             raise e
         finally:
             # We get here either because the task was successful or was
-            # aborted, in any case, delete the workflow.
+            # aborted, in any case, delete the workflows.
+            k8s_custom_obj_api.delete_namespaced_custom_object(
+                "argoproj.io",
+                "v1alpha1",
+                "orchest",
+                "workflows",
+                f"image-cache-task-{task_uuid}",
+            )
             k8s_custom_obj_api.delete_namespaced_custom_object(
                 "argoproj.io",
                 "v1alpha1",

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -63,14 +63,6 @@ def write_environment_dockerfile(
     """
     statements = []
     statements.append(f"FROM {base_image}")
-    # These labels are coupled with the logic that marks environment
-    # images for removal on update and the deletion of said stale
-    # images.
-    # The task uuid is applied first so that if a build is aborted early
-    # any produced artifact will at least have this label and will thus
-    # "searchable" through this label, e.g for cleanups.
-    statements.append(f"LABEL _orchest_env_build_task_uuid={task_uuid}")
-    statements.append("LABEL _orchest_env_build_is_intermediate=1")
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
 
@@ -123,7 +115,6 @@ def write_environment_dockerfile(
         # error.
         f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
-    statements.append("LABEL _orchest_env_build_is_intermediate=0")
 
     statements = "\n".join(statements)
 

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -113,6 +113,12 @@ def _get_image_build_workflow_manifest(
                             "--cache=true",
                             "--cache-dir=/cache",
                             "--use-new-run",
+                            # Note: make sure this runs at least with
+                            # kaniko 1.7, see
+                            # https://github.com/GoogleContainerTools/kaniko/pull/1735.
+                            # Essentially pre 1.7 there are some false
+                            # positive cache hits.
+                            "--cache-copy-layers",
                             # This allows us to simplify the logging
                             # logic by knowing that kaniko will not
                             # produce logs. If you need to restore the

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -263,14 +263,16 @@ def _build_image(
     task_uuid,
     image_name,
     build_context,
-    dockerfile_path,
     user_logs_file_object,
     complete_logs_file_object,
 ):
     """Triggers an argo workflow to build an image and follows it."""
     pod_name = f"image-build-task-{task_uuid}"
     manifest = _get_image_build_workflow_manifest(
-        pod_name, image_name, build_context["snapshot_host_path"], dockerfile_path
+        pod_name,
+        image_name,
+        build_context["snapshot_host_path"],
+        build_context["dockerfile_path"],
     )
 
     msg = "Building image...\n"
@@ -351,7 +353,6 @@ def build_image(
     task_uuid,
     image_name,
     build_context,
-    dockerfile_path,
     user_logs_file_object,
     complete_logs_path,
 ):
@@ -365,7 +366,6 @@ def build_image(
         task_uuid:
         image_name:
         build_context:
-        dockerfile_path:
         user_logs_file_object: file object to which logs from the user
             script are written.
         complete_logs_path: path to where to store the full logs are
@@ -387,7 +387,6 @@ def build_image(
                 task_uuid,
                 image_name,
                 build_context,
-                dockerfile_path,
                 user_logs_file_object,
                 complete_logs_file_object,
             )

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -106,6 +106,14 @@ def _get_image_build_workflow_manifest(
                             "--use-new-run",
                             "--verbosity=debug",
                             "--snapshotMode=redo",
+                            # From the docs: "This flag takes a single
+                            # snapshot of the filesystem at the end of
+                            # the build, so only one layer will be
+                            # appended to the base image."  We use this
+                            # flag since we can't cache layers due to
+                            # now knoting how aggressive in caching we
+                            # can be.
+                            "--single-snapshot",
                         ],
                         "volumeMounts": [
                             {"name": "build-context", "mountPath": "/build-context"},

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -342,7 +342,7 @@ def _build_image(
         raise errors.ImageBuildFailedError()
 
 
-def build_docker_image(
+def build_image(
     task_uuid,
     image_name,
     build_context,
@@ -350,8 +350,11 @@ def build_docker_image(
     user_logs_file_object,
     complete_logs_path,
 ):
-    """Build a docker image with the given tag, context_path and docker
-        file.
+    """Builds an image with the given tag, context_path and docker file.
+
+    The image build is done through the creation of k8s argo workflows,
+    which needs to be deleted by the caller, the workflows are named as
+    "image-cache-task-{task_uuid}" and "image-build-task-{task_uuid}".
 
     Args:
         task_uuid:

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from typing import Optional
 
@@ -24,6 +25,11 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
             "templates": [
                 {
                     "name": "cache-image",
+                    "securityContext": {
+                        "runAsUser": 0,
+                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/warmer:latest",
@@ -93,6 +99,11 @@ def _get_image_build_workflow_manifest(
             "templates": [
                 {
                     "name": "build-env",
+                    "securityContext": {
+                        "runAsUser": 0,
+                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/executor:latest",

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -9,9 +9,7 @@ from _orchest.internals import config as _config
 from _orchest.internals.utils import docker_images_list_safe, docker_images_rm_safe
 from app import errors, models, utils
 from app.connections import docker_client, k8s_core_api, k8s_custom_obj_api
-
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+from config import CONFIG_CLASS
 
 
 def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> dict:
@@ -295,8 +293,10 @@ def _build_image(
         namespace="orchest",
         follow=True,
     ):
-        found_ending_flag = event.endswith(__DOCKERFILE_RESERVED_FLAG)
-        found_error_flag = event.endswith(__DOCKERFILE_RESERVED_ERROR_FLAG)
+        found_ending_flag = event.endswith(
+            CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+        )
+        found_error_flag = event.endswith(CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG)
         # Break here because kaniko is storing the image or the build
         # has failed.
         if found_ending_flag or found_error_flag:

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from typing import Optional
 
@@ -25,11 +24,6 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
             "templates": [
                 {
                     "name": "cache-image",
-                    "securityContext": {
-                        "runAsUser": 0,
-                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/warmer:latest",
@@ -99,11 +93,6 @@ def _get_image_build_workflow_manifest(
             "templates": [
                 {
                     "name": "build-env",
-                    "securityContext": {
-                        "runAsUser": 0,
-                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/executor:latest",

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -37,6 +37,8 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
                             },
                         ],
                     },
+                    # K8S_TODO: set to builder node once it exists.
+                    "nodeSelector": {"node-role.kubernetes.io/master": ""},
                     "resources": {
                         "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },
@@ -136,6 +138,8 @@ def _get_image_build_workflow_manifest(
                             },
                         ],
                     },
+                    # K8S_TODO: set to builder node once it exists.
+                    "nodeSelector": {"node-role.kubernetes.io/master": ""},
                     "resources": {
                         "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -104,7 +104,7 @@ def _get_image_build_workflow_manifest(
                             "--cache=true",
                             "--cache-dir=/cache",
                             "--use-new-run",
-                            "--verbosity=debug",
+                            "--verbosity=info",
                             "--snapshotMode=redo",
                             # From the docs: "This flag takes a single
                             # snapshot of the filesystem at the end of

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -266,6 +266,8 @@ def _cache_image(
         msg = "There was a problem pulling the base image."
         user_logs_file_object.write(msg)
         complete_logs_file_object.write(msg)
+        # User logs are not flushed for performance reasons, considering
+        # they are sent through socketio as well.
         complete_logs_file_object.flush()
         raise errors.ImageCachingFailedError()
 

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -39,6 +39,9 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
                             },
                         ],
                     },
+                    "resources": {
+                        "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
+                    },
                 },
             ],
             # The celery task actually takes care of deleting the
@@ -129,6 +132,9 @@ def _get_image_build_workflow_manifest(
                                 "readOnly": True,
                             },
                         ],
+                    },
+                    "resources": {
+                        "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },
                 },
             ],

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -120,7 +120,7 @@ def _get_image_build_workflow_manifest(
                             # the build, so only one layer will be
                             # appended to the base image."  We use this
                             # flag since we can't cache layers due to
-                            # now knoting how aggressive in caching we
+                            # now knowing how aggressive in caching we
                             # can be.
                             "--single-snapshot",
                         ],

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -58,8 +58,9 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     """
     statements = []
     statements.append("FROM orchest/jupyter-server:latest")
+    statements.append(f'WORKDIR {os.path.join("/", work_dir)}')
 
-    statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
+    statements.append("COPY . .")
 
     # Note: commands are concatenated with && because this way an
     # exit_code != 0 will bubble up and cause the docker build to fail,
@@ -68,8 +69,7 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
     error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
-        f'RUN cd "{os.path.join("/", work_dir)}" '
-        f"&& bash {bash_script} "
+        f"RUN bash {bash_script} "
         "&& build_path_ext=/jupyterlab-orchest-build/extensions "
         "&& userdir_path_ext=/usr/local/share/jupyter/lab/extensions "
         "&& if [ -d $userdir_path_ext ] && [ -d $build_path_ext ]; then "

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -19,8 +19,6 @@ from config import CONFIG_CLASS
 
 logger = get_logger()
 
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
 __JUPYTER_BUILD_FULL_LOGS_DIRECTORY = "/tmp/jupyter_builds_logs"
 
 
@@ -72,7 +70,8 @@ def write_jupyter_dockerfile(task_uuid, work_dir, bash_script, path):
     # exit_code != 0 will bubble up and cause the docker build to fail,
     # as it should. The bash script is removed so that the user won't
     # be able to see it after the build is done.
-    flag = __DOCKERFILE_RESERVED_FLAG
+    flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+    error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
         f"&& bash {bash_script} "
@@ -85,7 +84,7 @@ def write_jupyter_dockerfile(task_uuid, work_dir, bash_script, path):
         # The || <error flag> allows to avoid kaniko errors logs making
         # into it the user logs and tell us that there has been an
         # error.
-        f"|| (echo {__DOCKERFILE_RESERVED_ERROR_FLAG} && PRODUCE_AN_ERROR)"
+        f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
     statements.append("LABEL _orchest_jupyter_build_is_intermediate=0")
 

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -144,6 +144,7 @@ def prepare_build_context(task_uuid):
     return {
         "snapshot_path": snapshot_path,
         "snapshot_host_path": f"/var/lib/orchest{snapshot_path}",
+        "base_image": "orchest/jupyter-server:latest",
     }
 
 
@@ -212,7 +213,14 @@ def build_jupyter_task(task_uuid):
             raise e
         finally:
             # We get here either because the task was successful or was
-            # aborted, in any case, delete the workflow.
+            # aborted, in any case, delete the workflows.
+            k8s_custom_obj_api.delete_namespaced_custom_object(
+                "argoproj.io",
+                "v1alpha1",
+                "orchest",
+                "workflows",
+                f"image-cache-task-{task_uuid}",
+            )
             k8s_custom_obj_api.delete_namespaced_custom_object(
                 "argoproj.io",
                 "v1alpha1",

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -12,7 +12,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 from _orchest.internals import config as _config
 from _orchest.internals.utils import rmtree
 from app.connections import k8s_custom_obj_api
-from app.core.image_utils import build_docker_image, cleanup_docker_artifacts
+from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from app.utils import get_logger
 from config import CONFIG_CLASS
@@ -187,7 +187,7 @@ def build_jupyter_task(task_uuid):
 
             status = SioStreamedTask.run(
                 # What we are actually running/doing in this task,
-                task_lambda=lambda user_logs_fo: build_docker_image(
+                task_lambda=lambda user_logs_fo: build_image(
                     task_uuid,
                     docker_image_name,
                     build_context,

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -58,11 +58,6 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     """
     statements = []
     statements.append("FROM orchest/jupyter-server:latest")
-    # The task uuid is applied first so that if a build is aborted early
-    # any produced artifact will at least have this label and will thus
-    # "searchable" through this label, e.g for cleanups.
-    statements.append(f"LABEL _orchest_jupyter_build_task_uuid={task_uuid}")
-    statements.append("LABEL _orchest_jupyter_build_is_intermediate=1")
 
     statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
 
@@ -86,7 +81,6 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
         # error.
         f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
-    statements.append("LABEL _orchest_jupyter_build_is_intermediate=0")
 
     statements = "\n".join(statements)
 

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -10,7 +10,7 @@ from celery import Task
 from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 from celery.utils.log import get_task_logger
 
-from _orchest.internals.utils import copytree, get_k8s_namespace_name
+from _orchest.internals.utils import copytree, get_k8s_namespace_name, rmtree
 from app import create_app
 from app.celery_app import make_celery
 from app.connections import k8s_custom_obj_api
@@ -306,10 +306,7 @@ def delete_base_images_cache(self) -> str:
     try:
         with os.scandir(CONFIG_CLASS.BASE_IMAGES_CACHE) as entries:
             for entry in entries:
-                if entry.is_dir() and not entry.is_symlink():
-                    shutil.rmtree(entry.path)
-                else:
-                    os.remove(entry.path)
+                rmtree(entry)
     except FileNotFoundError:
         ...
     return "SUCCESS"

--- a/services/orchest-api/app/app/errors.py
+++ b/services/orchest-api/app/app/errors.py
@@ -24,3 +24,11 @@ class SessionCleanupFailedError(Exception):
 
 class PodNeverReachedExpectedStatusError(Exception):
     pass
+
+
+class ImageCachingFailedError(Exception):
+    pass
+
+
+class ImageBuildFailedError(Exception):
+    pass

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -30,6 +30,7 @@ class Config:
     # Image building.
     BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+    BASE_IMAGES_CACHE = "/tmp/kaniko/cache"
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.
@@ -65,6 +66,7 @@ class Config:
         "app.core.tasks.run_pipeline": {"queue": "celery"},
         "app.core.tasks.build_environment": {"queue": "builds"},
         "app.core.tasks.build_jupyter": {"queue": "builds"},
+        "app.core.tasks.delete_base_images_cache": {"queue": "builds"},
     }
 
 

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -30,7 +30,10 @@ class Config:
     # Image building.
     BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
-    BASE_IMAGES_CACHE = "/tmp/kaniko/cache"
+    # K8S_TODO this will likely need to be adjusted when it comes to
+    # integrating the distributed file system. This is the path where
+    # orchest currently resides in the node.
+    BASE_IMAGES_CACHE = "/var/lib/orchest/userdir/.orchest/base_images_cache"
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -27,6 +27,10 @@ class Config:
     # activity.
     CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=30)
 
+    # Image building.
+    BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
+    BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.
     # NOTE: Flask will not configure lowercase variables. Therefore the

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -64,7 +64,11 @@ class Config:
     # Content for `.orchest/.gitignore` in project dir.
     # `pipelines/*/logs/` excludes `logs/` directories that are two
     # levels below the `.pipelines/` directory.
-    GIT_IGNORE_PROJECT_HIDDEN_ORCHEST = ["pipelines/*/logs/", "pipelines/*/data/"]
+    GIT_IGNORE_PROJECT_HIDDEN_ORCHEST = [
+        "pipelines/*/logs/",
+        "pipelines/*/data/",
+        "plasma.sock",
+    ]
     # On project creation through Orchest, we want the patterns from the
     # `.orchest/.gitignore` to be present in the root-level `.gitignore`
     # so that when creating a new job the files are not copied to the

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -149,6 +149,20 @@ def register_orchest_api_views(app, db):
 
         return resp.content, resp.status_code, resp.headers.items()
 
+    @app.route(
+        "/catch/api-proxy/api/environment-images/base-images-cache",
+        methods=["DELETE"],
+    )
+    def catch_api_environment_images_delete_base_images_cache():
+
+        resp = requests.delete(
+            "http://"
+            + app.config["ORCHEST_API_ADDRESS"]
+            + "/api/environment-images/base-images-cache"
+        )
+
+        return resp.content, resp.status_code, resp.headers.items()
+
     @app.route("/catch/api-proxy/api/jupyter-builds", methods=["POST"])
     def catch_api_proxy_jupyter_builds_post():
         resp = requests.post(

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -6,6 +6,7 @@ import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/Routes";
 import StyledButtonOutlined from "@/styled-components/StyledButton";
+import DeleteIcon from "@mui/icons-material/Delete";
 import PeopleIcon from "@mui/icons-material/People";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import SaveIcon from "@mui/icons-material/Save";
@@ -42,6 +43,7 @@ const SettingsView: React.FC = () => {
   const [state, setState] = React.useState({
     status: "...",
     restarting: false,
+    deletingBaseImagesCache: false,
     // text representation of config object, filtered for certain keys
     config: undefined,
     // the full JSON config object
@@ -266,6 +268,55 @@ const SettingsView: React.FC = () => {
 
   const checkUpdate = useCheckUpdate();
 
+  const deleteBaseImagesCache = () => {
+    return setConfirm(
+      "Warning",
+      "Are you sure you want to clear the base images cache? This will abort all ongoing environment and jupyter builds.",
+      async (resolve) => {
+        setState((prevState) => ({
+          ...prevState,
+          deletingBaseImagesCache: true,
+        }));
+        resolve(true);
+        try {
+          let checkOrchestPromise = makeCancelable(
+            makeRequest(
+              "DELETE",
+              "/catch/api-proxy/api/environment-images/base-images-cache"
+            ),
+            promiseManager
+          );
+
+          checkOrchestPromise.promise
+            .then(() => {
+              setState((prevState) => ({
+                ...prevState,
+                deletingBaseImagesCache: false,
+              }));
+            })
+            .catch((error) => {
+              setState((prevState) => ({
+                ...prevState,
+                deletingBaseImagesCache: false,
+              }));
+              console.error(error);
+              resolve(false);
+              setAlert("Error", "Could not clear base images cache.");
+            });
+        } catch (error) {
+          setState((prevState) => ({
+            ...prevState,
+            deletingBaseImagesCache: false,
+          }));
+          console.error(error);
+          resolve(false);
+          setAlert("Error", "Could not clear base images cache.");
+          return false;
+        }
+      }
+    );
+  };
+
   React.useEffect(() => {
     checkOrchestStatus();
     getConfig();
@@ -481,6 +532,37 @@ const SettingsView: React.FC = () => {
             >
               Manage users
             </StyledButtonOutlined>
+          </div>
+          <div className="clear"></div>
+        </div>
+
+        <h3>Images Cache</h3>
+        <div className="columns">
+          <div className="column">
+            <p>Clear the base images cache to free up disk space.</p>
+          </div>
+          <div className="column">
+            {(() => {
+              if (!state.deletingBaseImagesCache) {
+                return (
+                  <StyledButtonOutlined
+                    variant="outlined"
+                    color="secondary"
+                    startIcon={<DeleteIcon />}
+                    onClick={deleteBaseImagesCache}
+                  >
+                    Delete Base images cache
+                  </StyledButtonOutlined>
+                );
+              } else {
+                return (
+                  <>
+                    <LinearProgress className="push-down" />
+                    <p>Deleting base images cache.</p>
+                  </>
+                );
+              }
+            })()}
           </div>
           <div className="clear"></div>
         </div>

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -269,6 +269,7 @@ const SettingsView: React.FC = () => {
   const checkUpdate = useCheckUpdate();
 
   const deleteBaseImagesCache = () => {
+    // K8S_TODO: decide if the wording "base images cache" is desirable.
     return setConfirm(
       "Warning",
       "Are you sure you want to clear the base images cache? This will abort all ongoing environment and jupyter builds.",

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -278,7 +278,6 @@ const SettingsView: React.FC = () => {
           ...prevState,
           deletingBaseImagesCache: true,
         }));
-        resolve(true);
         try {
           let checkOrchestPromise = makeCancelable(
             makeRequest(
@@ -294,6 +293,7 @@ const SettingsView: React.FC = () => {
                 ...prevState,
                 deletingBaseImagesCache: false,
               }));
+              resolve(true);
             })
             .catch((error) => {
               setState((prevState) => ({


### PR DESCRIPTION
## Description

This PR aims to reduce the build time of environment images. Three main issues so far:
- base image caching (solved by making use of kaniko warmer)
- layer caching and/or "kaniko unpacking rootfs as cmd copy requires it". Difficult since we don't know how aggressively we can cache.
- pushing to the registry is slow

Conclusions:
- pulling cached layers and uncompressing them takes a very long time
- pushing to the registry is still very slow and takes the lion share of the environment build time
- let's see if block storage helps in improving these pain points
- would be nice to be able to trim down our base images

Related kaniko issues:
- https://github.com/GoogleContainerTools/kaniko/issues/875
- https://github.com/GoogleContainerTools/kaniko/issues/1013
- https://github.com/GoogleContainerTools/kaniko/issues/1392
- https://github.com/GoogleContainerTools/kaniko/issues/970

## Remaining TODOs

- [x] make use of a labeled "builder" node?
- [x] endpoint & GUI settings button to clean up cached base images
- [x] try making the build completely reproducible (e.g. by removing references to the `task_uuid` in the setup script etc.) to see if it helps in avoiding a registry push if the image exists already and if the sha is the same
- [x] more fiddling around with kaniko `--flags` to improve performance