### PR TITLE
Fix failing end-to-end tests for Orchest update checks

### DIFF
--- a/cypress/cypress/integration/auth.spec.ts
+++ b/cypress/cypress/integration/auth.spec.ts
@@ -2,9 +2,9 @@ import { reset, TEST_ID } from "../support/common";
 
 describe("auth system", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
   });
 
   it("can create and delete a user", () => {

--- a/cypress/cypress/integration/environments.spec.ts
+++ b/cypress/cypress/integration/environments.spec.ts
@@ -7,9 +7,9 @@ import {
 
 describe("environments", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
     cy.createProject(SAMPLE_PROJECT_NAMES.P1);
     // Delete the environment that has been created with the project.
     cy.deleteAllEnvironments();

--- a/cypress/cypress/integration/file-system-interactions.spec.ts
+++ b/cypress/cypress/integration/file-system-interactions.spec.ts
@@ -9,9 +9,9 @@ import {
 
 describe("file system interactions", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
   });
 
   it("creates a project through the FS", () => {

--- a/cypress/cypress/integration/interactive-runs.spec.ts
+++ b/cypress/cypress/integration/interactive-runs.spec.ts
@@ -15,9 +15,9 @@ import {
 
 describe("interactive runs", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
     cy.createProject(SAMPLE_PROJECT_NAMES.P1);
     assertEnvIsBuilt();
     cy.goToMenu("pipelines");

--- a/cypress/cypress/integration/jobs.spec.ts
+++ b/cypress/cypress/integration/jobs.spec.ts
@@ -102,9 +102,9 @@ const loadProject = () => {
 
 describe("jobs", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
   });
 
   context("requires the dump-env-params pipeline ", () => {

--- a/cypress/cypress/integration/onboarding.spec.ts
+++ b/cypress/cypress/integration/onboarding.spec.ts
@@ -6,11 +6,13 @@ const QUICKSTART_PROJECT_UUID = projectsWithQuickstart.find(
 ).uuid;
 
 describe("onboarding", () => {
+  beforeEach(() => {
+    cy.disableCheckUpdate();
+  });
   context("should be visible", () => {
     beforeEach(() => {
       reset();
       cy.clearLocalStorageSnapshot();
-      cy.disableCheckUpdate();
     });
 
     afterEach(() => {

--- a/cypress/cypress/integration/pipelines.spec.ts
+++ b/cypress/cypress/integration/pipelines.spec.ts
@@ -25,9 +25,9 @@ let pathTestCases = [
 
 describe("pipelines", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
     cy.createProject(SAMPLE_PROJECT_NAMES.P1);
     cy.goToMenu("pipelines");
   });

--- a/cypress/cypress/integration/projects.spec.ts
+++ b/cypress/cypress/integration/projects.spec.ts
@@ -7,9 +7,9 @@ import {
 
 describe("projects", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
     cy.goToMenu("projects");
   });
 

--- a/cypress/cypress/integration/services.spec.ts
+++ b/cypress/cypress/integration/services.spec.ts
@@ -26,9 +26,9 @@ function verifyExternalConnectivity(externalConnData: { string: [string] }) {
 
 describe("services", () => {
   beforeEach(() => {
+    cy.disableCheckUpdate();
     reset();
     cy.setOnboardingCompleted("true");
-    cy.disableCheckUpdate();
   });
 
   context("requires the services-connectivity project ", () => {

--- a/cypress/cypress/support/commands.ts
+++ b/cypress/cypress/support/commands.ts
@@ -13,6 +13,7 @@ import {
 type TBooleanString = "true" | "false";
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
     interface Chainable {
       addPipelineEnvVars(
@@ -33,7 +34,7 @@ declare global {
         waitBuild?: boolean
       ): Chainable<undefined>;
       createPipeline(name: string, path?: string): Chainable<undefined>;
-      createProject(name: string): Chainable<undefined>;
+      createProject(name: string): Chainable<AUTWindow>;
       createStep(
         title: string,
         createNewFile?: boolean,
@@ -64,6 +65,7 @@ declare global {
         project?: string,
         environment?: string
       ): Chainable<number>;
+      getLocalStorage(key: string): void;
     }
   }
 }
@@ -78,7 +80,11 @@ Cypress.Commands.add("disableCheckUpdate", () => {
   // If the latest version can't be fetched, then we will never
   // prompt asking users to update.
   cy.intercept("GET", "/async/orchest-update-info", {
-    latest_version: null,
+    latest_version: "v2022.01.1",
+  });
+
+  cy.intercept("GET", "/async/version", {
+    version: "v2022.01.1",
   });
 });
 
@@ -417,8 +423,9 @@ Cypress.Commands.add("getProjectUUID", (project: string) => {
   return cy
     .request("async/projects")
     .its("body")
-    .then((body: Array<any>) =>
-      cy.wrap(body.filter((obj) => obj.path == project)[0].uuid)
+    .then(
+      (body: Array<{ uuid: string; path: string }>) =>
+        body.filter((obj) => obj.path == project)[0].uuid
     );
 });
 
@@ -454,8 +461,9 @@ Cypress.Commands.add(
     return cy
       .request(`store/environments/${projectUUID}`)
       .its("body")
-      .then((body: Array<any>) =>
-        cy.wrap(body.filter((obj) => obj.name == environment)[0].uuid)
+      .then(
+        (body: Array<{ name: string; uuid: string }>) =>
+          body.filter((obj) => obj.name == environment)[0].uuid
       );
   }
 );

--- a/services/orchest-webserver/client/src/components/CommandPalette.tsx
+++ b/services/orchest-webserver/client/src/components/CommandPalette.tsx
@@ -185,7 +185,7 @@ const CommandPalette: React.FC = () => {
     );
   }, [commands, query]);
 
-  const fetcher = fetcherCreator();
+  const localFetcher = fetcherCreator();
 
   const showCommandPalette = () => {
     dispatch({
@@ -247,15 +247,15 @@ const CommandPalette: React.FC = () => {
   };
 
   const fetchPipelines = () => {
-    return fetcher<Pipeline>("/async/pipelines", "result");
+    return localFetcher<Pipeline>("/async/pipelines", "result");
   };
 
   const fetchProjects = () => {
-    return fetcher<Project>("/async/projects");
+    return localFetcher<Project>("/async/projects");
   };
 
   const fetchJobs = () => {
-    return fetcher<Job>("/catch/api-proxy/api/jobs/", "jobs");
+    return localFetcher<Job>("/catch/api-proxy/api/jobs/", "jobs");
   };
 
   const onQueryChange = (

--- a/services/orchest-webserver/client/src/hooks/useLocalStorage.ts
+++ b/services/orchest-webserver/client/src/hooks/useLocalStorage.ts
@@ -26,17 +26,20 @@ export const useLocalStorage = <T>(key: string, defaultValue: T) => {
     }
   });
 
-  const setValue = (value: T | ((value: T) => T)) => {
-    try {
-      const valueToStore =
-        value instanceof Function ? value(storedValue) : value;
-      setStoredValue(valueToStore);
-      cachedItemString.current = JSON.stringify(valueToStore);
-      window.localStorage.setItem(privateKey, cachedItemString.current);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const setValue = React.useCallback(
+    (value: T | ((value: T) => T)) => {
+      try {
+        const valueToStore =
+          value instanceof Function ? value(storedValue) : value;
+        setStoredValue(valueToStore);
+        cachedItemString.current = JSON.stringify(valueToStore);
+        window.localStorage.setItem(privateKey, cachedItemString.current);
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [privateKey, storedValue]
+  );
 
   // stay sync when the value is updated by other tabs
   React.useEffect(() => {


### PR DESCRIPTION
## Description

Cypress tests were failing because cy.intercept was not functioning.

## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.
