### PR TITLE
Do not run fix userdir permissions after restarting with `--cloud`

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -254,7 +254,7 @@ def restart(
 
     dev = dev or (mode == "dev")
     container_config = get_container_config(port, cloud=cloud, dev=dev)
-    app.restart(container_config)
+    app.restart(container_config, cloud=cloud)
 
 
 @typer_app.command(hidden=True)

--- a/services/orchest-ctl/app/orchest.py
+++ b/services/orchest-ctl/app/orchest.py
@@ -358,7 +358,7 @@ class OrchestApp:
 
         utils.echo("Shutdown successful.")
 
-    def restart(self, container_config: dict):
+    def restart(self, container_config: dict, cloud: bool = False):
         """Starts Orchest.
 
         Raises:
@@ -368,7 +368,7 @@ class OrchestApp:
 
         """
         self.stop()
-        self.start(container_config)
+        self.start(container_config, cloud=cloud)
 
     def _updateserver(self, port: int = 8000, cloud: bool = False, dev: bool = False):
         """Starts the update-server service."""


### PR DESCRIPTION
## Description

In the edge case where Orchest is updated or restarted directly, the flag to skip the `find` command to fix userdir permissions was not passed. Now it is.

This resulted in the `find` command still running in certain cases, making the restart of Orchest (possibly) very slow.

Should've been caught in #669.
