### PR TITLE
Fix page loading when visiting file preview, pipeline settings, logs with an interactive run

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineDetails.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineDetails.tsx
@@ -42,9 +42,9 @@ const PipelineDetailsContainer = styled("div")(({ theme }) => ({
   flexDirection: "column",
 }));
 
-const PipelineDetails: React.FC<{
+export const PipelineDetails: React.FC<{
   onOpenNotebook: (e: React.MouseEvent) => void;
-  onOpenFilePreviewView?: (e: React.MouseEvent, uuid: string) => void;
+  onOpenFilePreviewView: (e: React.MouseEvent, uuid: string) => void;
   onChangeView: (index: number) => void;
   onClose: () => void;
   onDelete: () => void;
@@ -78,9 +78,6 @@ const PipelineDetails: React.FC<{
   const [panelWidth, setPanelWidth] = React.useState(storedPanelWidth);
 
   const [subViewIndex, setSubViewIndex] = React.useState(defaultViewIndex);
-
-  const openFilePreviewView = (e: React.MouseEvent, step_uuid: string) =>
-    onOpenFilePreviewView && onOpenFilePreviewView(e, step_uuid);
 
   const onStartDragging = React.useCallback((e: React.MouseEvent) => {
     eventVars.current.prevClientX = e.clientX;
@@ -204,8 +201,8 @@ const PipelineDetails: React.FC<{
             startIcon={<VisibilityIcon />}
             variant="contained"
             color="secondary"
-            onClick={(e) => openFilePreviewView(e, step.uuid)}
-            onAuxClick={(e) => openFilePreviewView(e, step.uuid)}
+            onClick={(e) => onOpenFilePreviewView(e, step.uuid)}
+            onAuxClick={(e) => onOpenFilePreviewView(e, step.uuid)}
             data-test-id="step-view-file"
           >
             View file
@@ -239,5 +236,3 @@ const PipelineDetails: React.FC<{
     </PipelineDetailsContainer>
   );
 };
-
-export default PipelineDetails;

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -46,7 +46,7 @@ import io from "socket.io-client";
 import { siteMap } from "../Routes";
 import { extractStepsFromPipelineJson, updatePipelineJson } from "./common";
 import PipelineConnection from "./PipelineConnection";
-import PipelineDetails from "./PipelineDetails";
+import { PipelineDetails } from "./PipelineDetails";
 import PipelineStep, { STEP_HEIGHT, STEP_WIDTH } from "./PipelineStep";
 import { getStepSelectorRectangle, Rectangle } from "./Rectangle";
 import { ServicesMenu } from "./ServicesMenu";
@@ -1390,6 +1390,11 @@ const PipelineView: React.FC = () => {
   };
 
   const onOpenFilePreviewView = (e: React.MouseEvent, stepUuid: string) => {
+    const isJobRun = jobUuidFromRoute && runUuid;
+    const jobRunQueryArgs = {
+      jobUuid: jobUuidFromRoute,
+      runUuid,
+    };
     navigateTo(
       siteMap.filePreview.path,
       {
@@ -1397,8 +1402,7 @@ const PipelineView: React.FC = () => {
           projectUuid,
           pipelineUuid,
           stepUuid,
-          jobUuid: jobUuidFromRoute,
-          runUuid,
+          ...(isJobRun ? jobRunQueryArgs : undefined),
         },
         state: { isReadOnly },
       },

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -391,6 +391,12 @@ const PipelineView: React.FC = () => {
     setState({ eventVars: state.eventVars });
   };
 
+  const isJobRun = jobUuidFromRoute && runUuid;
+  const jobRunQueryArgs = {
+    jobUuid: jobUuidFromRoute,
+    runUuid,
+  };
+
   const openSettings = (e: React.MouseEvent) => {
     navigateTo(
       siteMap.pipelineSettings.path,
@@ -398,8 +404,7 @@ const PipelineView: React.FC = () => {
         query: {
           projectUuid,
           pipelineUuid,
-          jobUuid: jobUuidFromRoute,
-          runUuid,
+          ...(isJobRun ? jobRunQueryArgs : undefined),
         },
         state: { isReadOnly },
       },
@@ -414,13 +419,62 @@ const PipelineView: React.FC = () => {
         query: {
           projectUuid,
           pipelineUuid,
-          jobUuid: jobUuidFromRoute,
-          runUuid,
+          ...(isJobRun ? jobRunQueryArgs : undefined),
         },
         state: { isReadOnly },
       },
       e
     );
+  };
+
+  const onOpenFilePreviewView = (e: React.MouseEvent, stepUuid: string) => {
+    navigateTo(
+      siteMap.filePreview.path,
+      {
+        query: {
+          projectUuid,
+          pipelineUuid,
+          stepUuid,
+          ...(isJobRun ? jobRunQueryArgs : undefined),
+        },
+        state: { isReadOnly },
+      },
+      e
+    );
+  };
+
+  const openNotebook = (e: React.MouseEvent, stepUUID: string) => {
+    if (session === undefined) {
+      setAlert(
+        "Error",
+        "Please start the session before opening the Notebook in Jupyter."
+      );
+    } else if (session.status === "RUNNING") {
+      const filePath = collapseDoubleDots(
+        pipelineCwd + state.eventVars.steps[stepUUID].file_path
+      ).slice(1);
+      navigateTo(
+        siteMap.jupyterLab.path,
+        {
+          query: {
+            projectUuid,
+            pipelineUuid,
+            filePath,
+          },
+        },
+        e
+      );
+    } else if (session.status === "LAUNCHING") {
+      setAlert(
+        "Error",
+        "Please wait for the session to start before opening the Notebook in Jupyter."
+      );
+    } else {
+      setAlert(
+        "Error",
+        "Please start the session before opening the Notebook in Jupyter."
+      );
+    }
   };
 
   const [isShowingServices, setIsShowingServices] = React.useState(false);
@@ -1353,61 +1407,6 @@ const PipelineView: React.FC = () => {
     setState((state) => {
       return { eventVars: state.eventVars };
     });
-  };
-
-  const openNotebook = (e: React.MouseEvent, stepUUID: string) => {
-    if (session === undefined) {
-      setAlert(
-        "Error",
-        "Please start the session before opening the Notebook in Jupyter."
-      );
-    } else if (session.status === "RUNNING") {
-      const filePath = collapseDoubleDots(
-        pipelineCwd + state.eventVars.steps[stepUUID].file_path
-      ).slice(1);
-      navigateTo(
-        siteMap.jupyterLab.path,
-        {
-          query: {
-            projectUuid,
-            pipelineUuid,
-            filePath,
-          },
-        },
-        e
-      );
-    } else if (session.status === "LAUNCHING") {
-      setAlert(
-        "Error",
-        "Please wait for the session to start before opening the Notebook in Jupyter."
-      );
-    } else {
-      setAlert(
-        "Error",
-        "Please start the session before opening the Notebook in Jupyter."
-      );
-    }
-  };
-
-  const onOpenFilePreviewView = (e: React.MouseEvent, stepUuid: string) => {
-    const isJobRun = jobUuidFromRoute && runUuid;
-    const jobRunQueryArgs = {
-      jobUuid: jobUuidFromRoute,
-      runUuid,
-    };
-    navigateTo(
-      siteMap.filePreview.path,
-      {
-        query: {
-          projectUuid,
-          pipelineUuid,
-          stepUuid,
-          ...(isJobRun ? jobRunQueryArgs : undefined),
-        },
-        state: { isReadOnly },
-      },
-      e
-    );
   };
 
   const onOpenNotebook = (e: React.MouseEvent) => {

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -48,6 +48,8 @@ const FilePreviewView: React.FC = () => {
     runUuid,
   } = useCustomRoute();
 
+  const isJobRun = jobUuid && runUuid;
+
   // local states
   const [state, setState] = React.useState({
     notebookHtml: undefined,
@@ -87,7 +89,7 @@ const FilePreviewView: React.FC = () => {
         loadingFile: true,
       }));
 
-      let pipelineURL = jobUuid
+      let pipelineURL = isJobRun
         ? getPipelineJSONEndpoint(pipelineUuid, projectUuid, jobUuid, runUuid)
         : getPipelineJSONEndpoint(pipelineUuid, projectUuid);
 
@@ -146,7 +148,7 @@ const FilePreviewView: React.FC = () => {
   const fetchFile = () =>
     new Promise((resolve, reject) => {
       let fileURL = `/async/file-viewer/${projectUuid}/${pipelineUuid}/${stepUuid}`;
-      if (runUuid) {
+      if (isJobRun) {
         fileURL += "?pipeline_run_uuid=" + runUuid;
         fileURL += "&job_uuid=" + jobUuid;
       }


### PR DESCRIPTION
## Description

When trying to navigate to subsequent views of pipeline editor (i.e. pipeline settings, logs, file preview), the view would break because run uuid was passed along (thus it was considered as a job run, instead of an interactive run).

## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.