### PR TITLE
Allow cancel a job run in pipeline editor

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -1580,6 +1580,31 @@ const PipelineView: React.FC = () => {
   };
 
   const cancelRun = async () => {
+    if (isJobRun) {
+      setConfirm(
+        "Warning",
+        "Are you sure that you want to cancel this job run?",
+        async (resolve) => {
+          setIsCancellingRun(true);
+          try {
+            await fetcher(
+              `/catch/api-proxy/api/jobs/${jobUuidFromRoute}/${runUuid}`,
+              {
+                method: "DELETE",
+              }
+            );
+            resolve(true);
+          } catch (error) {
+            setAlert("Error", `Failed to cancel this job run.`);
+            resolve(false);
+          }
+          setIsCancellingRun(false);
+          return true;
+        }
+      );
+      return;
+    }
+
     if (!pipelineRunning) {
       setAlert("Error", "There is no pipeline running.");
       return;
@@ -1987,7 +2012,11 @@ const PipelineView: React.FC = () => {
         step={step}
         selected={selected}
         ref={state.refManager.nrefs[step.uuid]}
-        executionState={stepExecutionState[step.uuid] || { status: "IDLE" }}
+        executionState={
+          stepExecutionState
+            ? stepExecutionState[step.uuid] || { status: "IDLE" }
+            : { status: "IDLE" }
+        }
         onConnect={makeConnection}
         onClick={onClickStepHandler}
         onDoubleClick={onDoubleClickStepHandler}
@@ -2174,7 +2203,7 @@ const PipelineView: React.FC = () => {
                   )}
                 </div>
               )}
-            {!isReadOnly && pipelineRunning && (
+            {pipelineRunning && (
               <div className="selection-buttons">
                 <Button
                   variant="contained"

--- a/services/orchest-webserver/client/src/pipeline-view/useStepExecutionState.ts
+++ b/services/orchest-webserver/client/src/pipeline-view/useStepExecutionState.ts
@@ -4,7 +4,7 @@ import type { PipelineRun } from "@/types";
 import { serverTimeToDate } from "@/utils/webserver-utils";
 import { fetcher } from "@orchest/lib-utils";
 import React from "react";
-import useSWR, { MutatorCallback } from "swr";
+import useSWR, { MutatorCallback, useSWRConfig } from "swr";
 import { ExecutionState } from "./PipelineStep";
 
 const STATUS_POLL_FREQUENCY = 1000;
@@ -30,6 +30,7 @@ export const useStepExecutionState = (
   url: string | null,
   callback: (status: TStatus) => void
 ) => {
+  const { cache } = useSWRConfig();
   const { data = {}, error, mutate } = useSWR<StepExecutionStateObj>(
     url,
     (url) =>
@@ -60,7 +61,7 @@ export const useStepExecutionState = (
   );
 
   return {
-    stepExecutionState: data,
+    stepExecutionState: data || cache.get(url),
     setStepExecutionState,
   };
 };


### PR DESCRIPTION
## Description

Currently a job run can only be canceled in pipeline run table. 
This PR adds the cancel run button in pipeline view, same as the interactive run.
~Plus a minor improvement, pipeline view will stop polling job run status if pipeline is not running.~

Fixes: #701 

## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.
