### PR TITLE
Fix command palette broken when entities with same name

### DIFF
--- a/services/orchest-webserver/client/src/components/CommandPalette.tsx
+++ b/services/orchest-webserver/client/src/components/CommandPalette.tsx
@@ -374,7 +374,7 @@ const CommandPalette: React.FC = () => {
     [selectedCommandIndex, filteredCommands]
   );
 
-  const selectCommand = (index) => {
+  const selectCommand = (index: number) => {
     if (filteredCommands[index]) {
       handleCommand(filteredCommands[index]);
     }
@@ -432,8 +432,8 @@ const CommandPalette: React.FC = () => {
               return (
                 <ListItem
                   selected={selectedCommandIndex === i}
-                  key={command.title}
-                  onClick={selectCommand}
+                  key={i} // command.title is not unique if there are jobs with same name
+                  onClick={() => selectCommand(i)}
                 >
                   {command.title}
                 </ListItem>


### PR DESCRIPTION
## Description

This PR fixes the following bugs in Command Palette:
- broken if there are entities with same name in the same project
- unable to click to execute command

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
