### PR TITLE
Improve error handling for deleting selected rows

### DIFF
--- a/services/orchest-webserver/client/src/components/EnvironmentList.tsx
+++ b/services/orchest-webserver/client/src/components/EnvironmentList.tsx
@@ -245,23 +245,25 @@ const EnvironmentList: React.FC<IEnvironmentListProps> = ({ projectUuid }) => {
         const environmentsDict = fetchedEnvironments.reduce((all, curr) => {
           return { ...all, [curr.uuid]: curr };
         }, {});
-
-        Promise.all(
-          environmentUuids.map((environmentUuid) => {
-            const { project_uuid, uuid, name } = environmentsDict[
-              environmentUuid
-            ] as Environment;
-            return removeEnvironment(project_uuid, uuid, name);
-          })
-        )
-          .then(() => {
-            resolve(true);
-          })
-          .catch(() => {
-            resolve(false); // no need to setAlert here, will be handled by removeEnvironment
-          });
-
-        return true;
+        try {
+          Promise.all(
+            environmentUuids.map((environmentUuid) => {
+              const { project_uuid, uuid, name } = environmentsDict[
+                environmentUuid
+              ] as Environment;
+              return removeEnvironment(project_uuid, uuid, name);
+            })
+          )
+            .then(() => {
+              resolve(true);
+            })
+            .catch(() => {
+              resolve(false); // no need to setAlert here, will be handled by removeEnvironment
+            });
+          return true;
+        } catch (error) {
+          return false;
+        }
       }
     );
   };

--- a/services/orchest-webserver/client/src/jobs-view/JobList.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/JobList.tsx
@@ -172,15 +172,17 @@ const JobList: React.FC<{ projectUuid: string }> = ({ projectUuid }) => {
             })
           )
             .then(() => {
-              fetchJobs();
               resolve(true);
             })
             .catch((e) => {
               setAlert("Error", `Failed to delete selected jobs: ${e}`);
               resolve(false);
+            })
+            .finally(() => {
+              fetchJobs();
             });
           return true;
-        } catch (e) {
+        } catch (error) {
           return false;
         }
       }

--- a/services/orchest-webserver/client/src/pipelines-view/PipelineList.tsx
+++ b/services/orchest-webserver/client/src/pipelines-view/PipelineList.tsx
@@ -394,19 +394,14 @@ export const PipelineList: React.FC<{ projectUuid: string }> = ({
           )
         )
           .then(() => {
-            setPipelines((current) =>
-              current.filter(
-                (currentPipeline) =>
-                  !pipelineUuids.includes(currentPipeline.uuid)
-              )
-            );
-
             resolve(true);
           })
           .catch((e) => {
             setAlert("Error", `Failed to delete pipeline: ${e}`);
-            fetchPipelines();
             resolve(false);
+          })
+          .finally(() => {
+            fetchPipelines();
           });
 
         return true;

--- a/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
@@ -209,11 +209,13 @@ const ProjectsView: React.FC = () => {
           projectUuids.map((projectUuid) => deleteProjectRequest(projectUuid))
         )
           .then(() => {
-            fetchProjects();
             resolve(true); // 2. this is resolved later, and this resolves the Promise returned by setConfirm, and thereafter resolved in DataTable
           })
           .catch(() => {
             resolve(false);
+          })
+          .finally(() => {
+            fetchProjects();
           });
         return true; // 1. this is resolved first, thus, the dialog will be gone once user click CONFIRM
       }


### PR DESCRIPTION
## Description

Currently DataTable doesn't handle errors internally when deleting selected rows. This might cause "frozen" state if failed to delete selected rows within DataTable.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
