### PR TITLE
Fix service name collision or breakage

### DIFF
--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
@@ -1,7 +1,7 @@
 import { getOrderValue } from "@/pipeline-settings-view/common";
 import { PipelineJson } from "@/types";
 import { getPipelineJSONEndpoint } from "@/utils/webserver-utils";
-import { fetcher } from "@orchest/lib-utils";
+import { fetcher, uuidv4 } from "@orchest/lib-utils";
 import React from "react";
 import useSWR from "swr";
 import { MutatorCallback } from "swr/dist/types";
@@ -45,6 +45,14 @@ export const useFetchPipelineJson = (props: FetchPipelineJsonProps | null) => {
         if (pipelineObj.services === undefined) {
           pipelineObj.services = {};
         }
+
+        // use temporary uuid for easier FE manipulation, will be cleaned up when saving
+        pipelineObj.services = Object.values(pipelineObj.services).reduce(
+          (all, curr) => {
+            return { ...all, [uuidv4()]: curr };
+          },
+          {}
+        );
 
         // Augment services with order key
         for (let service in pipelineObj.services) {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -215,17 +215,20 @@ const PipelineSettingsView: React.FC = () => {
   const addServiceFromTemplate = (service: ServiceTemplate["config"]) => {
     let clonedService = cloneDeep(service);
 
-    const newCount = Object.values(pipelineJson?.services || {}).reduce(
-      (count, service) => {
-        const newName = `${clonedService.name}${count === 0 ? "" : count}`;
-        return service.name === newName ? count + 1 : count;
-      },
-      0
-    );
+    const services = pipelineJson?.services || {};
 
-    clonedService.name = `${clonedService.name}${
-      newCount === 0 ? "" : newCount
-    }`;
+    const allNames = new Set(Object.values(services).map((s) => s.name));
+
+    let count = 0;
+    // assuming that user won't have more than 100 instances of the same service
+    while (count < 100) {
+      const newName = `${clonedService.name}${count === 0 ? "" : count}`;
+      if (!allNames.has(newName)) {
+        clonedService.name = newName;
+        break;
+      }
+      count += 1;
+    }
 
     onChangeService(uuidv4(), clonedService);
   };

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -242,7 +242,8 @@ const PipelineSettingsView: React.FC = () => {
 
   const nameChangeService = (oldName: string, newName: string) => {
     setPipelineJson((current) => {
-      current[newName] = current[oldName];
+      current.services[newName] = { ...current.services[oldName] };
+      current.services[newName].name = newName;
       delete current.services[oldName];
       return current;
     });
@@ -513,6 +514,8 @@ const PipelineSettingsView: React.FC = () => {
       },
     },
   ];
+
+  console.log("HM", pipelineJson?.services);
 
   const serviceRows: DataTableRow<ServiceRow>[] = !pipelineJson
     ? []

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -1,5 +1,5 @@
 import { EnvVarPair } from "@/components/EnvVarList";
-import { PipelineJson } from "@/types";
+import { PipelineJson, Service } from "@/types";
 import { pipelineSchema } from "@/utils/pipeline-schema";
 import { extensionFromFilename, makeRequest } from "@orchest/lib-utils";
 import Ajv from "ajv";
@@ -140,11 +140,7 @@ export function clearOutgoingConnections(steps: {
 }
 
 export function getServiceURLs(
-  service: {
-    ports: number[];
-    preserve_base_path: string;
-    name: string;
-  },
+  service: Pick<Service, "ports" | "preserve_base_path" | "name">,
   projectUuid: string,
   pipelineUuid: string,
   runUuid: string


### PR DESCRIPTION
## Description

This PR fix the issue for service name collision and breakage.
If user attempts to rename a service with an existing name, the form will show a proper error message and disable all other fields until user gives a unique name.

Fixes: #375 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
