### PR TITLE
Invoke scripts with the `sh` extension using `bash`

### DIFF
--- a/services/base-images/runnable-shared/runner/run.py
+++ b/services/base-images/runnable-shared/runner/run.py
@@ -63,9 +63,12 @@ def main():
         extension_script_mapping = {
             "py": f"{python_env}/bin/python",
             "r": "Rscript",
-            "sh": "sh",
+            # Invoke using bash as it is already present in the image
+            # and users are likely to use bash functionality instead of
+            # strict sh.
+            "sh": "bash",
             "jl": "julia",
-            "": "sh",
+            "": "bash",
         }
 
         pr = ProcessRunner(pipeline_uuid, step_uuid, working_dir)


### PR DESCRIPTION
## Description

This adds more functionality to the scripts, without breaking any of the functionality as `bash` is a superset of `sh`.

In case you are looking to test it out. The following does work (without any errors) with the given change, but did not work before:
```bash
function sayIt {
    echo "I AM SAYING IT"
}

sayIt
```

The `function` keyword is not recognized by `sh`, the `sh` equivalent would be:
```sh
sayIt() {
    echo "I AM SAYING IT"
}

sayIt
```

