### PR TITLE
Fix hanging data table when a delete dialog is cancelled

### DIFF
--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -245,8 +245,14 @@ type CancelHandler = (
   resolve: (value: boolean | PromiseLike<boolean>) => void
 ) => Promise<boolean | void> | void | boolean;
 
-const defaultOnConfirm: ConfirmHandler = () => true;
-const defaultOnCancel: CancelHandler = () => false;
+const defaultOnConfirm: ConfirmHandler = (resolve) => {
+  resolve(true);
+  return true;
+};
+const defaultOnCancel: CancelHandler = (resolve) => {
+  resolve(false);
+  return false;
+};
 
 const withPromptMessageDispatcher = function <T extends PromptMessage>(
   dispatch: (value: AppContextAction) => void,

--- a/services/orchest-webserver/client/src/hooks/useSendAnalyticEvent.ts
+++ b/services/orchest-webserver/client/src/hooks/useSendAnalyticEvent.ts
@@ -20,24 +20,30 @@ type StringifyReactElement =
       React.ReactNode | React.ReactElement | string | number | boolean
     >;
 
-const stringifyReactElement = (target: StringifyReactElement) => {
+const stringifyReactElement = (
+  target: StringifyReactElement | StringifyReactElement[]
+) => {
+  if (!target) return "";
+  if (Array.isArray(target)) {
+    return target.reduce(
+      (all, item) => `${all}${stringifyReactElement(item)}`,
+      ""
+    );
+  }
   if (typeof target === "string") return target;
   if (typeof target === "number" || typeof target === "boolean")
     return JSON.stringify(target);
   // Object literal
   if (
     typeof target === "object" &&
+    !Array.isArray(target) &&
     target !== null &&
     !hasValue(target.props?.children)
   ) {
-    return Object.entries(target).reduce((all, [key, value]) => {
-      const child = !value.props?.children
-        ? value
-        : stringifyReactElement(value);
-      console.log(child);
-      return `${all}, ${JSON.stringify({
-        [key]: stringifyReactElement(child),
-      })}`;
+    return Object.values(target).reduce((all, value) => {
+      if (!value || value === "br") return all;
+      const child = stringifyReactElement(value.props?.children || value);
+      return child ? `${all}${child}` : all;
     }, "");
   }
   // ReactElement[]
@@ -45,20 +51,25 @@ const stringifyReactElement = (target: StringifyReactElement) => {
     if (typeof target.props.children === "string") return target.props.children;
     return target.props.children.reduce(
       (all: string, current: React.ReactElement) => {
-        return `${all} ${stringifyReactElement(current)}`;
+        return `${all}${stringifyReactElement(current)}`;
       },
       ""
     );
   }
-  // ReactElement
-  return stringifyReactElement(target);
+
+  // Symbol(react.element)
+  return "";
 };
 
 const stringifyObjectWithReactElements = (
-  obj: StringifyReactElement | Record<string, StringifyReactElement>
+  obj:
+    | StringifyReactElement
+    | StringifyReactElement[]
+    | Record<string, StringifyReactElement>
 ) =>
   JSON.stringify(obj, (key, value) => {
     if (React.isValidElement(value)) return stringifyReactElement(value);
+    if (Array.isArray(value)) return stringifyReactElement(value);
     return value;
   });
 


### PR DESCRIPTION
## Description

This PR fixes the bug: DataTable is hanging if a delete dialog is cancelled. The default onConfirm and onCancel should call the resolve function in the args.

This PR also cleans up the analytics message. Currently the content includes irrelevant data such as props.


## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
