### PR TITLE
Make `/jobs` `DELETE` endpoints resolve quicker

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -940,8 +940,9 @@ class AbortJob(TwoPhaseFunction):
             res.abort()
 
         if project_uuid is not None:
-            process_stale_environment_images(
-                project_uuid, only_marked_for_removal=False
+            current_app.config["SCHEDULER"].add_job(
+                process_stale_environment_images,
+                args=[project_uuid, False],
             )
 
 
@@ -1231,8 +1232,9 @@ class DeleteJob(TwoPhaseFunction):
 
     def _collateral(self, project_uuid: str):
         if project_uuid is not None:
-            process_stale_environment_images(
-                project_uuid, only_marked_for_removal=False
+            current_app.config["SCHEDULER"].add_job(
+                process_stale_environment_images,
+                args=[project_uuid, False],
             )
 
 
@@ -1378,8 +1380,9 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
 
     def _collateral(self, project_uuid: str, completed: bool):
         if completed and project_uuid is not None:
-            process_stale_environment_images(
-                project_uuid, only_marked_for_removal=False
+            current_app.config["SCHEDULER"].add_job(
+                process_stale_environment_images,
+                args=[project_uuid, False],
             )
 
 


### PR DESCRIPTION
## Description

Moves `process_stale_environment_images` to the background scheduler.

`process_stale_environment_images` could potentially hang whilst waiting
for the Docker Engine (talking about I/O here) and by running it on the
background scheduler the request should return almost instantly instead
of potentially hang.

This fix was talked about in #693.