### PR TITLE
Fix services deletion

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -493,7 +493,7 @@ const PipelineSettingsView: React.FC = () => {
                 "Warning",
                 `Are you sure you want to delete the service: ${row.name}?`,
                 async (resolve) => {
-                  deleteService(row.name)
+                  deleteService(row.uuid)
                     .then(() => {
                       resolve(true);
                     })


### PR DESCRIPTION
## Description

It was not possible to delete a service. Now it is possible again.

**Todo**
~~- [ ] Add a Cypress test for service deletion. Currently we also just do `rm -rf` to remove state so we never tested for the behavior.~~ --> https://github.com/orchest/orchest/issues/719