### PR TITLE
Orchest-api rework cleanup as a command

### DIFF
--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -24,8 +24,10 @@ from app.apis.namespace_environment_builds import AbortEnvironmentBuild
 from app.apis.namespace_jobs import AbortJob
 from app.apis.namespace_jupyter_builds import AbortJupyterBuild, CreateJupyterBuild
 from app.apis.namespace_runs import AbortPipelineRun
+from app.apis.namespace_sessions import StopInteractiveSession
+from app.config import CONFIG_CLASS
 from app.connections import db
-from app.core import environments, image_utils
+from app.core import environments
 from app.core.scheduler import Scheduler
 from app.models import (
     EnvironmentBuild,
@@ -87,117 +89,6 @@ def create_app(config_class=None, use_db=True, be_scheduler=False, to_migrate_db
     if to_migrate_db:
         return app
 
-    if use_db and not _utils.is_running_from_reloader():
-        with app.app_context():
-            # In case of running multiple gunicorn workers, we need to
-            # ensure that cleanup is only run once. Therefore, we
-            # attempt to create a directory first (which is an atomic
-            # operation). The edge case of Flask development mode
-            # running multiple threads is handled above using the
-            # `is_running_from_reloader()` check.
-            try:
-                if app.config.get("TESTING", False):
-                    # Do nothing.
-                    # In case of tests we always want to run cleanup.
-                    # Because every test will get a clean app, the same
-                    # code should run for all tests.
-                    pass
-                else:
-                    app.logger.debug("Trying to create /tmp/cleanup_done")
-                    os.mkdir("/tmp/cleanup_done")
-                    app.logger.info("/tmp/cleanup_done successfully created.")
-            except FileExistsError:
-                app.logger.info(
-                    f"/tmp/cleanup_done exists. Skipping cleanup: {os.getpid()}."
-                )
-            else:
-                app.logger.debug("Starting app initialization cleanup.")
-
-                # NOTE: This cleanup code blocks the gunicorn worker
-                # from handling requests, because it is required for the
-                # app to be initialized. So make sure the cleanup is
-                # quick! (Especially when running only a single gunicorn
-                # worker as the entire orchest-api will become
-                # unresponsive.)
-                # In case of an ungraceful shutdown, these entities
-                # could be in an invalid state, so they are deleted,
-                # since for sure they are not running anymore.
-                try:
-                    InteractiveSession.query.delete()
-
-                    # Delete old JupyterBuilds on start to avoid
-                    # accumulation in the DB. Leave the latest such that
-                    # the user can see details about the last executed
-                    # build after restarting Orchest.
-                    jupyter_builds = (
-                        JupyterBuild.query.order_by(JupyterBuild.requested_time.desc())
-                        .offset(1)
-                        .all()
-                    )
-
-                    # Can't use offset and .delete in conjunction in
-                    # sqlalchemy unfortunately.
-                    for jupyer_build in jupyter_builds:
-                        db.session.delete(jupyer_build)
-
-                    db.session.commit()
-
-                    # Fix interactive runs.
-                    runs = InteractivePipelineRun.query.filter(
-                        InteractivePipelineRun.status.in_(["PENDING", "STARTED"])
-                    ).all()
-                    with TwoPhaseExecutor(db.session) as tpe:
-                        for run in runs:
-                            AbortPipelineRun(tpe).transaction(run.uuid)
-
-                    # Fix one off jobs (and their pipeline runs).
-                    jobs = Job.query.filter_by(schedule=None, status="STARTED").all()
-                    with TwoPhaseExecutor(db.session) as tpe:
-                        for job in jobs:
-                            AbortJob(tpe).transaction(job.uuid)
-
-                    # This is to fix the state of cron jobs pipeline
-                    # runs.
-                    runs = NonInteractivePipelineRun.query.filter(
-                        NonInteractivePipelineRun.status.in_(["STARTED"])
-                    ).all()
-                    with TwoPhaseExecutor(db.session) as tpe:
-                        for run in runs:
-                            AbortPipelineRun(tpe).transaction(run.uuid)
-
-                    # Fix env builds.
-                    builds = EnvironmentBuild.query.filter(
-                        EnvironmentBuild.status.in_(["PENDING", "STARTED"])
-                    ).all()
-                    with TwoPhaseExecutor(db.session) as tpe:
-                        for build in builds:
-                            AbortEnvironmentBuild(tpe).transaction(build.uuid)
-
-                    # Fix jupyter builds.
-                    builds = JupyterBuild.query.filter(
-                        JupyterBuild.status.in_(["PENDING", "STARTED"])
-                    ).all()
-                    with TwoPhaseExecutor(db.session) as tpe:
-                        for build in builds:
-                            AbortJupyterBuild(tpe).transaction(build.uuid)
-
-                    # Trigger a build of JupyterLab if no JupyterLab
-                    # image is found for this version and JupyterLab
-                    # setup_script is non-empty.
-                    trigger_conditional_jupyter_build(app)
-
-                    # Make environments unavailable to a user after an
-                    # update.
-                    image_utils.process_stale_environment_images()
-
-                    # Remove dangling Orchest images, mostly useful
-                    # after an update.
-                    image_utils.delete_dangling_orchest_images()
-
-                except Exception as e:
-                    app.logger.error("Cleanup failed")
-                    app.logger.error(e)
-
     # Create a background scheduler (in a daemon thread) for every
     # gunicorn worker. The individual schedulers do not cause duplicate
     # execution because all jobs of the all the schedulers read state
@@ -232,6 +123,9 @@ def create_app(config_class=None, use_db=True, be_scheduler=False, to_migrate_db
             seconds=app.config["SCHEDULER_INTERVAL"],
             args=[app],
         )
+
+        if _utils.is_running_from_reloader():
+            trigger_conditional_jupyter_build(app)
 
     # Register blueprints at the end to avoid issues when migrating the
     # DB. When registering a blueprint the DB schema is also registered
@@ -359,3 +253,75 @@ def register_teardown_request(app):
         return response
 
     return app
+
+
+def cleanup(app):
+    app = create_app(config_class=CONFIG_CLASS, use_db=True, be_scheduler=False)
+
+    with app.app_context():
+        app.logger.debug("Starting app cleanup.")
+
+        try:
+            # Fix interactive runs.
+            runs = InteractivePipelineRun.query.filter(
+                InteractivePipelineRun.status.in_(["PENDING", "STARTED"])
+            ).all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for run in runs:
+                    AbortPipelineRun(tpe).transaction(run.uuid)
+
+            int_sessions = InteractiveSession.query.all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for session in int_sessions:
+                    StopInteractiveSession(tpe).transaction(
+                        session.project_uuid, session.pipeline_uuid
+                    )
+
+            # Fix env builds.
+            builds = EnvironmentBuild.query.filter(
+                EnvironmentBuild.status.in_(["PENDING", "STARTED"])
+            ).all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for build in builds:
+                    AbortEnvironmentBuild(tpe).transaction(build.uuid)
+
+            # Fix jupyter builds.
+            builds = JupyterBuild.query.filter(
+                JupyterBuild.status.in_(["PENDING", "STARTED"])
+            ).all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for build in builds:
+                    AbortJupyterBuild(tpe).transaction(build.uuid)
+
+            # Fix one off jobs (and their pipeline runs).
+            jobs = Job.query.filter_by(schedule=None, status="STARTED").all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for job in jobs:
+                    AbortJob(tpe).transaction(job.uuid)
+
+            # This is to fix the state of cron jobs pipeline runs.
+            runs = NonInteractivePipelineRun.query.filter(
+                NonInteractivePipelineRun.status.in_(["STARTED"])
+            ).all()
+            with TwoPhaseExecutor(db.session) as tpe:
+                for run in runs:
+                    AbortPipelineRun(tpe).transaction(run.uuid)
+
+            # Delete old JupyterBuilds on to avoid accumulation in the
+            # DB. Leave the latest such that the user can see details
+            # about the last executed build after restarting Orchest.
+            jupyter_builds = (
+                JupyterBuild.query.order_by(JupyterBuild.requested_time.desc())
+                .offset(1)
+                .all()
+            )
+            # Can't use offset and .delete in conjunction in sqlalchemy
+            # unfortunately.
+            for jupyter_build in jupyter_builds:
+                db.session.delete(jupyter_build)
+
+            db.session.commit()
+
+        except Exception as e:
+            app.logger.error("Cleanup failed.")
+            app.logger.error(e)

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -274,7 +274,7 @@ def cleanup(app):
             with TwoPhaseExecutor(db.session) as tpe:
                 for session in int_sessions:
                     StopInteractiveSession(tpe).transaction(
-                        session.project_uuid, session.pipeline_uuid
+                        session.project_uuid, session.pipeline_uuid, async_mode=False
                     )
 
             # Fix env builds.

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -117,7 +117,7 @@ class DeleteImage(TwoPhaseFunction):
         )
         for sess in int_sess:
             StopInteractiveSession(self.tpe).transaction(
-                sess.project_uuid, sess.pipeline_uuid
+                sess.project_uuid, sess.pipeline_uuid, async_mode=True
             )
 
         # Stop all interactive runs making use of the env.

--- a/services/orchest-api/app/app/apis/namespace_pipelines.py
+++ b/services/orchest-api/app/app/apis/namespace_pipelines.py
@@ -147,7 +147,9 @@ class DeletePipeline(TwoPhaseFunction):
             db.session.delete(run)
 
         # Stop any interactive session related to the pipeline.
-        StopInteractiveSession(self.tpe).transaction(project_uuid, pipeline_uuid)
+        StopInteractiveSession(self.tpe).transaction(
+            project_uuid, pipeline_uuid, async_mode=True
+        )
 
         models.Pipeline.query.filter_by(
             project_uuid=project_uuid, uuid=pipeline_uuid

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -143,7 +143,7 @@ class DeleteProject(TwoPhaseFunction):
         for session in sessions:
             # Stop any interactive session related to the pipeline.
             StopInteractiveSession(self.tpe).transaction(
-                project_uuid, session.pipeline_uuid
+                project_uuid, session.pipeline_uuid, async_mode=True
             )
 
         # Any job related to the pipeline is stopped if necessary

--- a/services/orchest-api/app/cleanup.py
+++ b/services/orchest-api/app/cleanup.py
@@ -1,0 +1,10 @@
+"""Performs a cleanup of Orchest controlled resources.
+
+This is used to ensure that on Orchest start and stop the system
+remains in a consistent state and without dangling resources like pods
+or sessions.
+"""
+from app import cleanup
+
+if __name__ == "__main__":
+    cleanup()

--- a/services/session-sidecar/app/main.py
+++ b/services/session-sidecar/app/main.py
@@ -102,7 +102,7 @@ def follow_service_logs(service):
 
 
 if __name__ == "__main__":
-    signal.signal(signal.SIGTERM, lambda: sys.exit(0))
+    signal.signal(signal.SIGTERM, lambda *args, **kwargs: sys.exit(0))
     logging.getLogger().setLevel(logging.INFO)
 
     # Needs to be here since the logs directory does not exists for


### PR DESCRIPTION
## Description

~This PR makes it so that the `orchest-api` will perform the required cleanups on exit. This helps to maintain state consistent when it comes to shutting down, restarting or stopping Orchest.~

See https://github.com/orchest/orchest/pull/721#issuecomment-1053501770

