### PR TITLE
Add 100 rows per page option to DataTable

### DIFF
--- a/services/orchest-webserver/client/src/components/DataTable.tsx
+++ b/services/orchest-webserver/client/src/components/DataTable.tsx
@@ -425,7 +425,10 @@ function generateLoadingRows<T>(
   rowCount: number,
   columns: DataTableColumn<T>[]
 ) {
-  return [...Array(rowCount).keys()].map((key) => {
+  // rendering large amount of table rows with skeleton is causing performance issue
+  // We limit it to 25, which should suffice for most users' viewport.
+  const renderedRowCount = Math.min(25, rowCount);
+  return [...Array(renderedRowCount).keys()].map((key) => {
     return columns.reduce((all, col) => {
       // add isLoading: true signifies this row is a loading row (i.e. will be filled by Skeleton).
       // thus, the data ([col.id]) doesn't matter, we just fill an empty string.
@@ -863,7 +866,7 @@ export const DataTable = <T extends Record<string, any>>({
           </Stack>
           <TablePagination
             sx={{ flex: 1 }}
-            rowsPerPageOptions={[5, 10, 25]}
+            rowsPerPageOptions={[5, 10, 25, 100]}
             component="div"
             count={totalCount}
             rowsPerPage={rowsPerPage}

--- a/services/orchest-webserver/client/src/edit-job-view/EditJobView.tsx
+++ b/services/orchest-webserver/client/src/edit-job-view/EditJobView.tsx
@@ -562,6 +562,7 @@ const EditJobView: React.FC = () => {
               >
                 <TextField
                   required
+                  autoFocus
                   label="Job name"
                   value={job.name}
                   sx={{ width: "50%" }}

--- a/services/orchest-webserver/client/src/jobs-view/CreateJobDialog.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/CreateJobDialog.tsx
@@ -119,7 +119,7 @@ export const CreateJobDialog = ({
           )}
         </DialogContent>
         <DialogActions>
-          <Button color="secondary" onClick={closeDialog}>
+          <Button color="secondary" tabIndex={-1} onClick={closeDialog}>
             Cancel
           </Button>
           <Button


### PR DESCRIPTION
## Description

Currently DataTable provides 5, 10, and 25 rows per page. This PR adds an extra option 100.

Fixes: #700 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
