### PR TITLE
Feat/k8s orchest deployments probes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@ venv/
 .venvs/
 npm_modules/
 dist/
+deploy/
 pnpm-lock.yaml

--- a/deploy/helm/charts/auth-server/templates/deployment.yaml
+++ b/deploy/helm/charts/auth-server/templates/deployment.yaml
@@ -32,3 +32,21 @@ deployment
            mountPath: /userdir
          - name: config
            mountPath: /config
+        startupProbe:
+          httpGet:
+            path: /login/server-config
+            port: 80
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 20
+        livenessProbe:
+          httpGet:
+            path: /login/server-config
+            port: 80
+            scheme: HTTP
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 2

--- a/deploy/helm/charts/auth-server/templates/deployment.yaml
+++ b/deploy/helm/charts/auth-server/templates/deployment.yaml
@@ -33,10 +33,12 @@ deployment
          - name: config
            mountPath: /config
         startupProbe:
-          httpGet:
-            path: /login/server-config
-            port: 80
-            scheme: HTTP
+          exec:
+            command:
+              - sh
+              - -c
+              - "nc -zvw1 orchest-database 5432 &&
+                wget -T 1 -t 1 localhost/login/server-config --spider"
           periodSeconds: 1
           successThreshold: 1
           timeoutSeconds: 5

--- a/deploy/helm/charts/celery-worker/templates/deployment.yaml
+++ b/deploy/helm/charts/celery-worker/templates/deployment.yaml
@@ -44,7 +44,7 @@ deployment
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 5
-          failureThreshold: 10
+          failureThreshold: 40
         livenessProbe:
           exec:
             command:

--- a/deploy/helm/charts/celery-worker/templates/deployment.yaml
+++ b/deploy/helm/charts/celery-worker/templates/deployment.yaml
@@ -33,3 +33,27 @@ deployment
            mountPath: /var/run
          - name: userdir
            mountPath: /userdir
+        startupProbe:
+          exec:
+            command:
+              - celery
+              - -A
+              - app.core.tasks
+              - inspect
+              - ping
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 10
+        livenessProbe:
+          exec:
+            command:
+              - celery
+              - -A
+              - app.core.tasks
+              - inspect
+              - ping
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 10

--- a/deploy/helm/charts/celery-worker/templates/deployment.yaml
+++ b/deploy/helm/charts/celery-worker/templates/deployment.yaml
@@ -36,23 +36,26 @@ deployment
         startupProbe:
           exec:
             command:
-              - celery
-              - -A
-              - app.core.tasks
-              - inspect
-              - ping
+              - sh
+              - -c
+              - "nc -zvw1 rabbitmq-server 5672 &&
+                nc -zvw1 orchest-database 5432 &&
+                [ -f worker-builds.pid ] &&
+                [ -f worker-interactive.pid ] &&
+                [ -f worker-jobs.pid ]"
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 5
           failureThreshold: 40
         livenessProbe:
           exec:
+          # A pid file gets deleted if the worker dies.
             command:
-              - celery
-              - -A
-              - app.core.tasks
-              - inspect
-              - ping
+              - sh
+              - -c
+              - "[ -f worker-builds.pid ] &&
+                [ -f worker-interactive.pid ] &&
+                [ -f worker-jobs.pid ]"
           periodSeconds: 5
           timeoutSeconds: 5
           successThreshold: 1

--- a/deploy/helm/charts/file-manager/templates/deployment.yaml
+++ b/deploy/helm/charts/file-manager/templates/deployment.yaml
@@ -19,3 +19,13 @@ deployment
         volumeMounts:
          - name: userdir
            mountPath: /userdir
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 4
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 5

--- a/deploy/helm/charts/orchest-api/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-api/templates/deployment.yaml
@@ -32,12 +32,13 @@ deployment
          - name: userdir
            mountPath: /userdir
         startupProbe:
-          httpGet:
-            path: /api
-            port: 80
-            scheme: HTTP
-          periodSeconds: 5
-          successThreshold: 1
+          exec:
+            command:
+              - sh
+              - -c
+              - "nc -zvw1 rabbitmq-server 5672 &&
+                nc -zvw1 orchest-database 5432 &&
+                wget -T 1 -t 1 localhost/api --spider"
           # Be generous with time because the container could be doing a
           # cleanup and not be able to respond.
           timeoutSeconds: 5

--- a/deploy/helm/charts/orchest-api/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-api/templates/deployment.yaml
@@ -43,7 +43,7 @@ deployment
           # cleanup and not be able to respond.
           timeoutSeconds: 5
           periodSeconds: 5
-          failureThreshold: 20
+          failureThreshold: 40
           successThreshold: 1
         livenessProbe:
           httpGet:

--- a/deploy/helm/charts/orchest-api/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-api/templates/deployment.yaml
@@ -31,3 +31,25 @@ deployment
            mountPath: /var/run
          - name: userdir
            mountPath: /userdir
+        startupProbe:
+          httpGet:
+            path: /api
+            port: 80
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          # Be generous with time because the container could be doing a
+          # cleanup and not be able to respond.
+          timeoutSeconds: 5
+          periodSeconds: 5
+          failureThreshold: 20
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /api
+            port: 80
+            scheme: HTTP
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 5

--- a/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
@@ -53,3 +53,21 @@ deployment
            mountPath: /config
          - name: repo
            mountPath: /orchest-host
+        startupProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 20
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+          failureThreshold: 2

--- a/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
@@ -54,14 +54,15 @@ deployment
          - name: repo
            mountPath: /orchest-host
         startupProbe:
-          httpGet:
-            path: /
-            port: 80
-            scheme: HTTP
-          periodSeconds: 1
-          successThreshold: 1
-          timeoutSeconds: 5
-          failureThreshold: 20
+          exec:
+        # K8S_TODO: enable auth check once the auth-server is enabled.
+        # wget auth-server/login/server-config -T 2 -t 1 --spider &&
+            command:
+              - sh
+              - -c
+              - "wget orchest-api/api -T 2 -t 1 --spider &&
+                wget file-manager -T 2 -t 1 &&
+                wget -T 1 -t 1 localhost --spider"
         livenessProbe:
           httpGet:
             path: /

--- a/deploy/helm/charts/postgres/templates/deployment.yaml
+++ b/deploy/helm/charts/postgres/templates/deployment.yaml
@@ -24,3 +24,14 @@ deployment
         volumeMounts:
          - name: pgdata
            mountPath: /userdir/.orchest/database/data           
+        readinessProbe:
+          exec:
+            command:
+              - pg_isready
+              - --username
+              - postgres
+          initialDelaySeconds: 1
+          periodSeconds: 4
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 20

--- a/deploy/helm/charts/rabbitmq/templates/deployment.yaml
+++ b/deploy/helm/charts/rabbitmq/templates/deployment.yaml
@@ -19,14 +19,15 @@ deployment
         volumeMounts:
          - name: mnesia
            mountPath: /var/lib/rabbitmq/mnesia
-        livenessProbe:
+        readinessProbe:
           exec:
             command:
-              - /opt/rabbitmq/sbin/rabbitmq-diagnostics
-              - -q
-              - check_port_connectivity
-          initialDelaySeconds: 1
+              - su
+              - rabbitmq
+              - -c
+              - "/opt/rabbitmq/sbin/rabbitmq-diagnostics ping"
+          initialDelaySeconds: 5
           periodSeconds: 5
-          successThreshold: 1
           timeoutSeconds: 5
-          failureThreshold: 10
+          successThreshold: 1
+          failureThreshold: 40

--- a/deploy/helm/charts/rabbitmq/templates/deployment.yaml
+++ b/deploy/helm/charts/rabbitmq/templates/deployment.yaml
@@ -19,3 +19,14 @@ deployment
         volumeMounts:
          - name: mnesia
            mountPath: /var/lib/rabbitmq/mnesia
+        livenessProbe:
+          exec:
+            command:
+              - /opt/rabbitmq/sbin/rabbitmq-diagnostics
+              - -q
+              - check_port_connectivity
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 10

--- a/services/auth-server/Dockerfile
+++ b/services/auth-server/Dockerfile
@@ -2,7 +2,10 @@ FROM tiangolo/meinheld-gunicorn-flask:python3.8
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Refresh SSL certificates
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates --fresh
+RUN apt-get update \
+  && apt-get install -y ca-certificates netcat \
+  && update-ca-certificates --fresh
+
 
 # Install nodejs for frontend client build
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs

--- a/services/orchest-api/Dockerfile
+++ b/services/orchest-api/Dockerfile
@@ -1,6 +1,9 @@
 FROM tiangolo/meinheld-gunicorn-flask:python3.8
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
+RUN apt-get update \
+    && apt-get install -y netcat
+
 # Get all requirements in place.
 COPY ./requirements.txt /orchest/services/orchest-api/
 COPY ./lib /orchest/lib

--- a/services/orchest-api/Dockerfile_celery
+++ b/services/orchest-api/Dockerfile_celery
@@ -2,7 +2,9 @@ FROM python:3.8-slim
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Needed to daemonize celery workers.
-RUN apt-get update && apt-get install -y supervisor rsync && mkdir -p /var/log/supervisor
+RUN apt-get update \
+     && apt-get install -y supervisor rsync netcat \
+     && mkdir -p /var/log/supervisor
 
 # Get all requirements in place.
 COPY ./requirements.txt /orchest/services/orchest-api/

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -199,7 +199,7 @@ class DeleteBaseImagesCache(TwoPhaseFunction):
             models.JupyterBuild.status.in_(["PENDING", "STARTED"])
         )
         for jb in jupyter_builds:
-            AbortJupyterBuild(self.tpe)._transaction(jb.uuid)
+            AbortJupyterBuild(self.tpe).transaction(jb.uuid)
 
     def _collateral(self):
         image_utils.delete_base_images_cache()

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -13,7 +13,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 from _orchest.internals import config as _config
 from _orchest.internals.utils import copytree, rmtree
 from app.connections import k8s_custom_obj_api
-from app.core.image_utils import build_docker_image, cleanup_docker_artifacts
+from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from config import CONFIG_CLASS
 
@@ -311,7 +311,7 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
 
             status = SioStreamedTask.run(
                 # What we are actually running/doing in this task,
-                task_lambda=lambda user_logs_fo: build_docker_image(
+                task_lambda=lambda user_logs_fo: build_image(
                     task_uuid,
                     docker_image_name,
                     build_context,

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -112,7 +112,6 @@ def write_environment_dockerfile(
     flag = __DOCKERFILE_RESERVED_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
-        f'&& echo "{flag}" '
         # The ! in front of echo is there so that the script will fail
         # since the statements in the "if" have failed, the echo is a
         # way of injecting the help message.

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -65,13 +65,14 @@ def write_environment_dockerfile(
     statements.append(f"FROM {base_image}")
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
+    statements.append(f'WORKDIR {os.path.join("/", work_dir)}')
 
     # Copy the entire context, that is, given the current use case, that
     # we are copying the project directory (from the snapshot) into the
     # docker image that is to be built, this allows the user defined
     # script defined through orchest to make use of files that are part
     # of its project, e.g. a requirements.txt or other scripts.
-    statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
+    statements.append("COPY . .")
 
     # Permission statements.
     ps = [
@@ -101,11 +102,10 @@ def write_environment_dockerfile(
     flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
     error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
-        f'RUN cd "{os.path.join("/", work_dir)}" '
         # The ! in front of echo is there so that the script will fail
         # since the statements in the "if" have failed, the echo is a
         # way of injecting the help message.
-        f'&& ((if [ $(id -u) = 0 ]; then {ps}; else {sps}; fi) || ! echo "{msg}") '
+        f'RUN ((if [ $(id -u) = 0 ]; then {ps}; else {sps}; fi) || ! echo "{msg}") '
         f"&& bash {bash_script} "
         # Needed to inject the rm statement this way, black was
         # introducing an error.

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -17,8 +17,6 @@ from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from config import CONFIG_CLASS
 
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
 __ENV_BUILD_FULL_LOGS_DIRECTORY = "/tmp/environment_builds_logs"
 
 
@@ -109,7 +107,8 @@ def write_environment_dockerfile(
         f"sudo rm {bash_script}; fi)"
     )
 
-    flag = __DOCKERFILE_RESERVED_FLAG
+    flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+    error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
         # The ! in front of echo is there so that the script will fail
@@ -123,7 +122,7 @@ def write_environment_dockerfile(
         # The || <error flag> allows to avoid kaniko errors logs making
         # into it the user logs and tell us that there has been an
         # error.
-        f"|| (echo {__DOCKERFILE_RESERVED_ERROR_FLAG} && PRODUCE_AN_ERROR)"
+        f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
     statements.append("LABEL _orchest_env_build_is_intermediate=0")
 

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -340,7 +340,14 @@ def build_environment_task(task_uuid, project_uuid, environment_uuid, project_pa
             raise e
         finally:
             # We get here either because the task was successful or was
-            # aborted, in any case, delete the workflow.
+            # aborted, in any case, delete the workflows.
+            k8s_custom_obj_api.delete_namespaced_custom_object(
+                "argoproj.io",
+                "v1alpha1",
+                "orchest",
+                "workflows",
+                f"image-cache-task-{task_uuid}",
+            )
             k8s_custom_obj_api.delete_namespaced_custom_object(
                 "argoproj.io",
                 "v1alpha1",

--- a/services/orchest-api/app/app/core/environment_builds.py
+++ b/services/orchest-api/app/app/core/environment_builds.py
@@ -63,14 +63,6 @@ def write_environment_dockerfile(
     """
     statements = []
     statements.append(f"FROM {base_image}")
-    # These labels are coupled with the logic that marks environment
-    # images for removal on update and the deletion of said stale
-    # images.
-    # The task uuid is applied first so that if a build is aborted early
-    # any produced artifact will at least have this label and will thus
-    # "searchable" through this label, e.g for cleanups.
-    statements.append(f"LABEL _orchest_env_build_task_uuid={task_uuid}")
-    statements.append("LABEL _orchest_env_build_is_intermediate=1")
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
 
@@ -123,7 +115,6 @@ def write_environment_dockerfile(
         # error.
         f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
-    statements.append("LABEL _orchest_env_build_is_intermediate=0")
 
     statements = "\n".join(statements)
 

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -113,6 +113,12 @@ def _get_image_build_workflow_manifest(
                             "--cache=true",
                             "--cache-dir=/cache",
                             "--use-new-run",
+                            # Note: make sure this runs at least with
+                            # kaniko 1.7, see
+                            # https://github.com/GoogleContainerTools/kaniko/pull/1735.
+                            # Essentially pre 1.7 there are some false
+                            # positive cache hits.
+                            "--cache-copy-layers",
                             # This allows us to simplify the logging
                             # logic by knowing that kaniko will not
                             # produce logs. If you need to restore the

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -263,14 +263,16 @@ def _build_image(
     task_uuid,
     image_name,
     build_context,
-    dockerfile_path,
     user_logs_file_object,
     complete_logs_file_object,
 ):
     """Triggers an argo workflow to build an image and follows it."""
     pod_name = f"image-build-task-{task_uuid}"
     manifest = _get_image_build_workflow_manifest(
-        pod_name, image_name, build_context["snapshot_host_path"], dockerfile_path
+        pod_name,
+        image_name,
+        build_context["snapshot_host_path"],
+        build_context["dockerfile_path"],
     )
 
     msg = "Building image...\n"
@@ -351,7 +353,6 @@ def build_image(
     task_uuid,
     image_name,
     build_context,
-    dockerfile_path,
     user_logs_file_object,
     complete_logs_path,
 ):
@@ -365,7 +366,6 @@ def build_image(
         task_uuid:
         image_name:
         build_context:
-        dockerfile_path:
         user_logs_file_object: file object to which logs from the user
             script are written.
         complete_logs_path: path to where to store the full logs are
@@ -387,7 +387,6 @@ def build_image(
                 task_uuid,
                 image_name,
                 build_context,
-                dockerfile_path,
                 user_logs_file_object,
                 complete_logs_file_object,
             )

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -106,6 +106,14 @@ def _get_image_build_workflow_manifest(
                             "--use-new-run",
                             "--verbosity=debug",
                             "--snapshotMode=redo",
+                            # From the docs: "This flag takes a single
+                            # snapshot of the filesystem at the end of
+                            # the build, so only one layer will be
+                            # appended to the base image."  We use this
+                            # flag since we can't cache layers due to
+                            # now knoting how aggressive in caching we
+                            # can be.
+                            "--single-snapshot",
                         ],
                         "volumeMounts": [
                             {"name": "build-context", "mountPath": "/build-context"},

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -342,7 +342,7 @@ def _build_image(
         raise errors.ImageBuildFailedError()
 
 
-def build_docker_image(
+def build_image(
     task_uuid,
     image_name,
     build_context,
@@ -350,8 +350,11 @@ def build_docker_image(
     user_logs_file_object,
     complete_logs_path,
 ):
-    """Build a docker image with the given tag, context_path and docker
-        file.
+    """Builds an image with the given tag, context_path and docker file.
+
+    The image build is done through the creation of k8s argo workflows,
+    which needs to be deleted by the caller, the workflows are named as
+    "image-cache-task-{task_uuid}" and "image-build-task-{task_uuid}".
 
     Args:
         task_uuid:

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from typing import Optional
 
@@ -24,6 +25,11 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
             "templates": [
                 {
                     "name": "cache-image",
+                    "securityContext": {
+                        "runAsUser": 0,
+                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/warmer:latest",
@@ -93,6 +99,11 @@ def _get_image_build_workflow_manifest(
             "templates": [
                 {
                     "name": "build-env",
+                    "securityContext": {
+                        "runAsUser": 0,
+                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/executor:latest",

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -9,9 +9,7 @@ from _orchest.internals import config as _config
 from _orchest.internals.utils import docker_images_list_safe, docker_images_rm_safe
 from app import errors, models, utils
 from app.connections import docker_client, k8s_core_api, k8s_custom_obj_api
-
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+from config import CONFIG_CLASS
 
 
 def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> dict:
@@ -295,8 +293,10 @@ def _build_image(
         namespace="orchest",
         follow=True,
     ):
-        found_ending_flag = event.endswith(__DOCKERFILE_RESERVED_FLAG)
-        found_error_flag = event.endswith(__DOCKERFILE_RESERVED_ERROR_FLAG)
+        found_ending_flag = event.endswith(
+            CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+        )
+        found_error_flag = event.endswith(CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG)
         # Break here because kaniko is storing the image or the build
         # has failed.
         if found_ending_flag or found_error_flag:

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from typing import Optional
 
@@ -25,11 +24,6 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
             "templates": [
                 {
                     "name": "cache-image",
-                    "securityContext": {
-                        "runAsUser": 0,
-                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/warmer:latest",
@@ -99,11 +93,6 @@ def _get_image_build_workflow_manifest(
             "templates": [
                 {
                     "name": "build-env",
-                    "securityContext": {
-                        "runAsUser": 0,
-                        "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                        "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                    },
                     "container": {
                         "name": "kaniko",
                         "image": "gcr.io/kaniko-project/executor:latest",

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -37,6 +37,8 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
                             },
                         ],
                     },
+                    # K8S_TODO: set to builder node once it exists.
+                    "nodeSelector": {"node-role.kubernetes.io/master": ""},
                     "resources": {
                         "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },
@@ -136,6 +138,8 @@ def _get_image_build_workflow_manifest(
                             },
                         ],
                     },
+                    # K8S_TODO: set to builder node once it exists.
+                    "nodeSelector": {"node-role.kubernetes.io/master": ""},
                     "resources": {
                         "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -104,7 +104,7 @@ def _get_image_build_workflow_manifest(
                             "--cache=true",
                             "--cache-dir=/cache",
                             "--use-new-run",
-                            "--verbosity=debug",
+                            "--verbosity=info",
                             "--snapshotMode=redo",
                             # From the docs: "This flag takes a single
                             # snapshot of the filesystem at the end of

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -266,6 +266,8 @@ def _cache_image(
         msg = "There was a problem pulling the base image."
         user_logs_file_object.write(msg)
         complete_logs_file_object.write(msg)
+        # User logs are not flushed for performance reasons, considering
+        # they are sent through socketio as well.
         complete_logs_file_object.flush()
         raise errors.ImageCachingFailedError()
 

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -39,6 +39,9 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
                             },
                         ],
                     },
+                    "resources": {
+                        "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
+                    },
                 },
             ],
             # The celery task actually takes care of deleting the
@@ -129,6 +132,9 @@ def _get_image_build_workflow_manifest(
                                 "readOnly": True,
                             },
                         ],
+                    },
+                    "resources": {
+                        "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },
                 },
             ],

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -120,7 +120,7 @@ def _get_image_build_workflow_manifest(
                             # the build, so only one layer will be
                             # appended to the base image."  We use this
                             # flag since we can't cache layers due to
-                            # now knoting how aggressive in caching we
+                            # now knowing how aggressive in caching we
                             # can be.
                             "--single-snapshot",
                         ],

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -58,8 +58,9 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     """
     statements = []
     statements.append("FROM orchest/jupyter-server:latest")
+    statements.append(f'WORKDIR {os.path.join("/", work_dir)}')
 
-    statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
+    statements.append("COPY . .")
 
     # Note: commands are concatenated with && because this way an
     # exit_code != 0 will bubble up and cause the docker build to fail,
@@ -68,8 +69,7 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
     error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
-        f'RUN cd "{os.path.join("/", work_dir)}" '
-        f"&& bash {bash_script} "
+        f"RUN bash {bash_script} "
         "&& build_path_ext=/jupyterlab-orchest-build/extensions "
         "&& userdir_path_ext=/usr/local/share/jupyter/lab/extensions "
         "&& if [ -d $userdir_path_ext ] && [ -d $build_path_ext ]; then "

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -19,8 +19,6 @@ from config import CONFIG_CLASS
 
 logger = get_logger()
 
-__DOCKERFILE_RESERVED_FLAG = "_ORCHEST_RESERVED_FLAG_"
-__DOCKERFILE_RESERVED_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
 __JUPYTER_BUILD_FULL_LOGS_DIRECTORY = "/tmp/jupyter_builds_logs"
 
 
@@ -72,7 +70,8 @@ def write_jupyter_dockerfile(task_uuid, work_dir, bash_script, path):
     # exit_code != 0 will bubble up and cause the docker build to fail,
     # as it should. The bash script is removed so that the user won't
     # be able to see it after the build is done.
-    flag = __DOCKERFILE_RESERVED_FLAG
+    flag = CONFIG_CLASS.BUILD_IMAGE_LOG_TERMINATION_FLAG
+    error_flag = CONFIG_CLASS.BUILD_IMAGE_ERROR_FLAG
     statements.append(
         f'RUN cd "{os.path.join("/", work_dir)}" '
         f"&& bash {bash_script} "
@@ -85,7 +84,7 @@ def write_jupyter_dockerfile(task_uuid, work_dir, bash_script, path):
         # The || <error flag> allows to avoid kaniko errors logs making
         # into it the user logs and tell us that there has been an
         # error.
-        f"|| (echo {__DOCKERFILE_RESERVED_ERROR_FLAG} && PRODUCE_AN_ERROR)"
+        f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
     statements.append("LABEL _orchest_jupyter_build_is_intermediate=0")
 

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -144,6 +144,7 @@ def prepare_build_context(task_uuid):
     return {
         "snapshot_path": snapshot_path,
         "snapshot_host_path": f"/var/lib/orchest{snapshot_path}",
+        "base_image": "orchest/jupyter-server:latest",
     }
 
 
@@ -212,7 +213,14 @@ def build_jupyter_task(task_uuid):
             raise e
         finally:
             # We get here either because the task was successful or was
-            # aborted, in any case, delete the workflow.
+            # aborted, in any case, delete the workflows.
+            k8s_custom_obj_api.delete_namespaced_custom_object(
+                "argoproj.io",
+                "v1alpha1",
+                "orchest",
+                "workflows",
+                f"image-cache-task-{task_uuid}",
+            )
             k8s_custom_obj_api.delete_namespaced_custom_object(
                 "argoproj.io",
                 "v1alpha1",

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -12,7 +12,7 @@ from celery.contrib.abortable import AbortableAsyncResult
 from _orchest.internals import config as _config
 from _orchest.internals.utils import rmtree
 from app.connections import k8s_custom_obj_api
-from app.core.image_utils import build_docker_image, cleanup_docker_artifacts
+from app.core.image_utils import build_image, cleanup_docker_artifacts
 from app.core.sio_streamed_task import SioStreamedTask
 from app.utils import get_logger
 from config import CONFIG_CLASS
@@ -187,7 +187,7 @@ def build_jupyter_task(task_uuid):
 
             status = SioStreamedTask.run(
                 # What we are actually running/doing in this task,
-                task_lambda=lambda user_logs_fo: build_docker_image(
+                task_lambda=lambda user_logs_fo: build_image(
                     task_uuid,
                     docker_image_name,
                     build_context,

--- a/services/orchest-api/app/app/core/jupyter_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_builds.py
@@ -58,11 +58,6 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
     """
     statements = []
     statements.append("FROM orchest/jupyter-server:latest")
-    # The task uuid is applied first so that if a build is aborted early
-    # any produced artifact will at least have this label and will thus
-    # "searchable" through this label, e.g for cleanups.
-    statements.append(f"LABEL _orchest_jupyter_build_task_uuid={task_uuid}")
-    statements.append("LABEL _orchest_jupyter_build_is_intermediate=1")
 
     statements.append(f"COPY . \"{os.path.join('/', work_dir)}\"")
 
@@ -86,7 +81,6 @@ def write_jupyter_dockerfile(work_dir, bash_script, path):
         # error.
         f"|| (echo {error_flag} && PRODUCE_AN_ERROR)"
     )
-    statements.append("LABEL _orchest_jupyter_build_is_intermediate=0")
 
     statements = "\n".join(statements)
 

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -10,7 +10,7 @@ from celery import Task
 from celery.contrib.abortable import AbortableAsyncResult, AbortableTask
 from celery.utils.log import get_task_logger
 
-from _orchest.internals.utils import copytree, get_k8s_namespace_name
+from _orchest.internals.utils import copytree, get_k8s_namespace_name, rmtree
 from app import create_app
 from app.celery_app import make_celery
 from app.connections import k8s_custom_obj_api
@@ -306,10 +306,7 @@ def delete_base_images_cache(self) -> str:
     try:
         with os.scandir(CONFIG_CLASS.BASE_IMAGES_CACHE) as entries:
             for entry in entries:
-                if entry.is_dir() and not entry.is_symlink():
-                    shutil.rmtree(entry.path)
-                else:
-                    os.remove(entry.path)
+                rmtree(entry)
     except FileNotFoundError:
         ...
     return "SUCCESS"

--- a/services/orchest-api/app/app/errors.py
+++ b/services/orchest-api/app/app/errors.py
@@ -24,3 +24,11 @@ class SessionCleanupFailedError(Exception):
 
 class PodNeverReachedExpectedStatusError(Exception):
     pass
+
+
+class ImageCachingFailedError(Exception):
+    pass
+
+
+class ImageBuildFailedError(Exception):
+    pass

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -30,6 +30,7 @@ class Config:
     # Image building.
     BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+    BASE_IMAGES_CACHE = "/tmp/kaniko/cache"
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.
@@ -65,6 +66,7 @@ class Config:
         "app.core.tasks.run_pipeline": {"queue": "celery"},
         "app.core.tasks.build_environment": {"queue": "builds"},
         "app.core.tasks.build_jupyter": {"queue": "builds"},
+        "app.core.tasks.delete_base_images_cache": {"queue": "builds"},
     }
 
 

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -30,7 +30,10 @@ class Config:
     # Image building.
     BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
-    BASE_IMAGES_CACHE = "/tmp/kaniko/cache"
+    # K8S_TODO this will likely need to be adjusted when it comes to
+    # integrating the distributed file system. This is the path where
+    # orchest currently resides in the node.
+    BASE_IMAGES_CACHE = "/var/lib/orchest/userdir/.orchest/base_images_cache"
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -27,6 +27,10 @@ class Config:
     # activity.
     CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=30)
 
+    # Image building.
+    BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
+    BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
+
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.
     # NOTE: Flask will not configure lowercase variables. Therefore the

--- a/services/orchest-webserver/Dockerfile
+++ b/services/orchest-webserver/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Install required system packages and refresh certs
 RUN apt-get update \
-    && apt-get install -y ca-certificates git rsync \
+    && apt-get install -y ca-certificates git rsync netcat \
     && update-ca-certificates --fresh
 
 # Install nodejs

--- a/services/orchest-webserver/app/app/config.py
+++ b/services/orchest-webserver/app/app/config.py
@@ -64,7 +64,11 @@ class Config:
     # Content for `.orchest/.gitignore` in project dir.
     # `pipelines/*/logs/` excludes `logs/` directories that are two
     # levels below the `.pipelines/` directory.
-    GIT_IGNORE_PROJECT_HIDDEN_ORCHEST = ["pipelines/*/logs/", "pipelines/*/data/"]
+    GIT_IGNORE_PROJECT_HIDDEN_ORCHEST = [
+        "pipelines/*/logs/",
+        "pipelines/*/data/",
+        "plasma.sock",
+    ]
     # On project creation through Orchest, we want the patterns from the
     # `.orchest/.gitignore` to be present in the root-level `.gitignore`
     # so that when creating a new job the files are not copied to the

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -149,6 +149,20 @@ def register_orchest_api_views(app, db):
 
         return resp.content, resp.status_code, resp.headers.items()
 
+    @app.route(
+        "/catch/api-proxy/api/environment-images/base-images-cache",
+        methods=["DELETE"],
+    )
+    def catch_api_environment_images_delete_base_images_cache():
+
+        resp = requests.delete(
+            "http://"
+            + app.config["ORCHEST_API_ADDRESS"]
+            + "/api/environment-images/base-images-cache"
+        )
+
+        return resp.content, resp.status_code, resp.headers.items()
+
     @app.route("/catch/api-proxy/api/jupyter-builds", methods=["POST"])
     def catch_api_proxy_jupyter_builds_post():
         resp = requests.post(

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -6,6 +6,7 @@ import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/Routes";
 import StyledButtonOutlined from "@/styled-components/StyledButton";
+import DeleteIcon from "@mui/icons-material/Delete";
 import PeopleIcon from "@mui/icons-material/People";
 import PowerSettingsNewIcon from "@mui/icons-material/PowerSettingsNew";
 import SaveIcon from "@mui/icons-material/Save";
@@ -42,6 +43,7 @@ const SettingsView: React.FC = () => {
   const [state, setState] = React.useState({
     status: "...",
     restarting: false,
+    deletingBaseImagesCache: false,
     // text representation of config object, filtered for certain keys
     config: undefined,
     // the full JSON config object
@@ -266,6 +268,55 @@ const SettingsView: React.FC = () => {
 
   const checkUpdate = useCheckUpdate();
 
+  const deleteBaseImagesCache = () => {
+    return setConfirm(
+      "Warning",
+      "Are you sure you want to clear the base images cache? This will abort all ongoing environment and jupyter builds.",
+      async (resolve) => {
+        setState((prevState) => ({
+          ...prevState,
+          deletingBaseImagesCache: true,
+        }));
+        resolve(true);
+        try {
+          let checkOrchestPromise = makeCancelable(
+            makeRequest(
+              "DELETE",
+              "/catch/api-proxy/api/environment-images/base-images-cache"
+            ),
+            promiseManager
+          );
+
+          checkOrchestPromise.promise
+            .then(() => {
+              setState((prevState) => ({
+                ...prevState,
+                deletingBaseImagesCache: false,
+              }));
+            })
+            .catch((error) => {
+              setState((prevState) => ({
+                ...prevState,
+                deletingBaseImagesCache: false,
+              }));
+              console.error(error);
+              resolve(false);
+              setAlert("Error", "Could not clear base images cache.");
+            });
+        } catch (error) {
+          setState((prevState) => ({
+            ...prevState,
+            deletingBaseImagesCache: false,
+          }));
+          console.error(error);
+          resolve(false);
+          setAlert("Error", "Could not clear base images cache.");
+          return false;
+        }
+      }
+    );
+  };
+
   React.useEffect(() => {
     checkOrchestStatus();
     getConfig();
@@ -481,6 +532,37 @@ const SettingsView: React.FC = () => {
             >
               Manage users
             </StyledButtonOutlined>
+          </div>
+          <div className="clear"></div>
+        </div>
+
+        <h3>Images Cache</h3>
+        <div className="columns">
+          <div className="column">
+            <p>Clear the base images cache to free up disk space.</p>
+          </div>
+          <div className="column">
+            {(() => {
+              if (!state.deletingBaseImagesCache) {
+                return (
+                  <StyledButtonOutlined
+                    variant="outlined"
+                    color="secondary"
+                    startIcon={<DeleteIcon />}
+                    onClick={deleteBaseImagesCache}
+                  >
+                    Delete Base images cache
+                  </StyledButtonOutlined>
+                );
+              } else {
+                return (
+                  <>
+                    <LinearProgress className="push-down" />
+                    <p>Deleting base images cache.</p>
+                  </>
+                );
+              }
+            })()}
           </div>
           <div className="clear"></div>
         </div>

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -269,6 +269,7 @@ const SettingsView: React.FC = () => {
   const checkUpdate = useCheckUpdate();
 
   const deleteBaseImagesCache = () => {
+    // K8S_TODO: decide if the wording "base images cache" is desirable.
     return setConfirm(
       "Warning",
       "Are you sure you want to clear the base images cache? This will abort all ongoing environment and jupyter builds.",

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -278,7 +278,6 @@ const SettingsView: React.FC = () => {
           ...prevState,
           deletingBaseImagesCache: true,
         }));
-        resolve(true);
         try {
           let checkOrchestPromise = makeCancelable(
             makeRequest(
@@ -294,6 +293,7 @@ const SettingsView: React.FC = () => {
                 ...prevState,
                 deletingBaseImagesCache: false,
               }));
+              resolve(true);
             })
             .catch((error) => {
               setState((prevState) => ({


### PR DESCRIPTION
## Description

This PR adds startupProbes, `livenessProbes` and `readinessProbes` to orchest deployments. When no `startupProbe` is necessary, a `readinessProbe` is used both as a health check and a readiness check. `StartupProbes` are used to formalize dependencies among deployments, this is, generally speaking, not strictly necessary but, in the case of the `orchest-webserver`, it provides a better UX given that it won't be ready until the `orchest-api` is ready, which data it depends upon to have a functioning client.

Note: timings, failure thresholds etc. are quite arbitrary, generally speaking I have tried to avoid false positives.

Related dos:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/