### PR TITLE
Orchest-ctl refactoring PR 2, `orchest version` 

### DIFF
--- a/deploy/orchest-ctl/pod.yml
+++ b/deploy/orchest-ctl/pod.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: orchest-ctl
     version: %VERSION%
-    command: %COMMAND%
+    command: ""
 spec:
   containers:
   - command:

--- a/orchest
+++ b/orchest
@@ -70,7 +70,7 @@ function on_exit {
 trap on_exit EXIT
 
 # Necessary because
-# https://github.com/kubernetes/kubernetes/issues/83242 Not: not
+# https://github.com/kubernetes/kubernetes/issues/83242 Note: not
 # sleeping here because not all sleep implementations support floating
 # point values, and sleeping for 1s introuces a bad delay UX wise. It
 # doesn't go through more than 1 iteration usually.

--- a/orchest
+++ b/orchest
@@ -55,9 +55,8 @@ image="orchest/orchest-ctl"
 
 set -e
 
-# TODO: passing an argument containing @ will break this.
 pod=$(sed -e "s@%IMAGE%@$image@g" -e "s@%VERSION%@$repo_version@g" \
--e "s@%COMMAND%@$@@g" "$DIR/deploy/orchest-ctl/pod.yml" | \
+"$DIR/deploy/orchest-ctl/pod.yml" | \
 minikube kubectl -- create -n orchest -o name -f -)
 
 # Make sure to cleanup the pod on exit.
@@ -76,6 +75,8 @@ trap on_exit EXIT
 # doesn't go through more than 1 iteration usually.
 for i in {1..100}; do minikube kubectl -- get -n orchest "${pod}" \
     > /dev/null 2>&1 && break; done
+
+minikube kubectl -- label -n orchest "${pod}" "command=$1" --overwrite > /dev/null 
 
 # Wait for 15mins because the image might need to be pulled. TODO:
 # alert the user if a pull happens, then wait.

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -92,11 +92,17 @@ def version(
         show_default=False,
         help="Get extensive version information.",
     ),
+    json: bool = typer.Option(
+        False,
+        "--json",
+        show_default=False,
+        help="Get output in json.",
+    ),
 ):
     """
     Get Orchest version.
     """
-    app.version(ext=ext)
+    orchest.version(ext=ext, output_json=json)
 
 
 @typer_app.command()

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -2,6 +2,16 @@ from typing import List, Set
 
 ORCHEST_NAMESPACE = "orchest"
 
+DEPLOYMENT_VERSION_SYNCED_WITH_CLUSTER_VERSION = set(
+    [
+        "celery-worker",
+        "docker-registry",
+        "file-manager",
+        "orchest-api",
+        "orchest-webserver",
+    ]
+)
+
 ORCHEST_DEPLOYMENTS = [
     "celery-worker",
     "docker-registry",

--- a/services/orchest-ctl/app/orchest/__init__.py
+++ b/services/orchest-ctl/app/orchest/__init__.py
@@ -1,1 +1,1 @@
-from app.orchest._core import install
+from app.orchest._core import install, version

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -152,7 +152,7 @@ def _echo_version(
         }
         if deployment_versions is not None:
             data["deployment_versions"] = deployment_versions
-        print(json.dumps(data, sort_keys=True, indent=2))
+        utils.echo(json.dumps(data, sort_keys=True, indent=2), wrap=False)
 
 
 def version(ext=False, output_json: bool = False) -> None:

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -15,6 +15,9 @@ from app.orchest import _k8s_wrapper as k8sw
 
 logger = logging.getLogger(__name__)
 
+
+# This is just another failsafe to make sure we don't leave dangling
+# pods around.
 signal.signal(signal.SIGTERM, lambda *args, **kwargs: k8sw.delete_orchest_ctl_pod())
 atexit.register(k8sw.delete_orchest_ctl_pod)
 

--- a/services/orchest-ctl/app/orchest/_k8s_wrapper.py
+++ b/services/orchest-ctl/app/orchest/_k8s_wrapper.py
@@ -17,6 +17,16 @@ from app.connections import k8s_apps_api, k8s_core_api
 def get_orchest_deployments(
     deployments: Optional[List[str]] = None,
 ) -> List[Optional[k8s_client.V1Deployment]]:
+    """Returns Deployment objects given their name.
+
+    Args:
+        deployments: Names of deployments to retrieve. If not passed or
+            None, config.ORCHEST_DEPLOYMENTS will be used.
+
+    Return:
+        List of Deployment objects, returned in the same order as the
+        given deployments argument.
+    """
     if deployments is None:
         deployments = config.ORCHEST_DEPLOYMENTS
     threads = []

--- a/services/orchest-ctl/app/orchest/_k8s_wrapper.py
+++ b/services/orchest-ctl/app/orchest/_k8s_wrapper.py
@@ -45,6 +45,10 @@ def set_orchest_cluster_version(version: str):
     )
 
 
+def get_orchest_cluster_version() -> str:
+    return k8s_core_api.read_namespace("orchest").metadata.labels.get("version")
+
+
 def delete_orchest_ctl_pod():
     """Deletes the pod in which this script is running
 

--- a/services/orchest-ctl/app/orchest_old.py
+++ b/services/orchest-ctl/app/orchest_old.py
@@ -381,61 +381,6 @@ class OrchestApp:
                 else:
                     raise typer.Exit(code=3)
 
-    def version(self, ext=False, verbose: bool = True):
-        """Returns the version of Orchest.
-
-        Args:
-            ext: If True return the extensive version of Orchest.
-                Meaning that the version of every pulled image is
-                checked.
-            verbose: Echo non-error related output to the user.
-
-        """
-        if not ext:
-            version = os.getenv("ORCHEST_VERSION")
-            verbose and utils.echo(f"Orchest version: {version}")
-            return
-
-        verbose and utils.echo("Getting versions of all containers...")
-
-        # Get container versions.
-        stdouts = self.resource_manager.containers_version()
-        stdout_values = set()
-        for img, stdout in stdouts.items():
-            stdout_values.add(stdout)
-            verbose and utils.echo(f"{img:<44}: {stdout}")
-
-        # Check whether all required images are present.
-        installation_req_images: Set[str] = set(
-            img
-            for img in config.ORCHEST_IMAGES["minimal"]
-            if img.startswith("orchest/")
-        )
-        missing_images = installation_req_images - set(stdouts.keys())
-
-        if missing_images:
-            logger.info("Missing images:\n" + "\n".join(missing_images))
-            utils.echo(
-                "Could not get version of all Orchest required images because some"
-                " are missing. Make sure Orchest is correctly installed:"
-            )
-            utils.echo("\torchest install")
-            raise typer.Exit(code=1)
-        elif len(stdout_values) > 1:
-            # If not all versions are the same.
-            utils.echo(
-                "Not all containers are running on the same version of Orchest, which"
-                " can lead to the application crashing. You can fix this by running:",
-            )
-            utils.echo("\torchest update")
-            utils.echo("This should get all containers on the same version again.")
-            raise typer.Exit(code=2)
-        else:
-            verbose and utils.echo(
-                "All containers are running on the same version"
-                " of Orchest. Happy coding!"
-            )
-
     def debug(self, ext: bool, compress: bool):
         debug_dump(ext, compress)
 


### PR DESCRIPTION
## Description

Ports `orchest version` to k8s, and introduces a `--json` flag, e.g. `orchest version --json --ext`:

```json
{
  "cluster_version": "v2022.02.8",
  "deployment_versions": {
    "argo-workflow-argo-workflows-server": "v3.2.6",
    "argo-workflow-argo-workflows-workflow-controller": "v3.2.6",
    "celery-worker": "latest",
    "docker-registry": "2.7.1",
    "file-manager": "latest",
    "orchest-api": "latest",
    "orchest-database": "13.1",
    "orchest-webserver": "latest",
    "rabbitmq-server": "3",
    "update-server": "latest"
  }
}
```
