### PR TITLE
Orchest-ctl refactoring PR 3, `orchest status`

### DIFF
--- a/deploy/orchest-ctl/pod.yml
+++ b/deploy/orchest-ctl/pod.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: orchest-ctl
     version: %VERSION%
-    command: ""
+    command: %COMMAND%
 spec:
   containers:
   - command:

--- a/deploy/orchest-ctl/pod.yml
+++ b/deploy/orchest-ctl/pod.yml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: orchest-ctl
     version: %VERSION%
+    # Refer to config.STATUS_CHANGING_OPERATIONS if you plan changes to
+    # this label.
     command: %COMMAND%
 spec:
   containers:

--- a/orchest
+++ b/orchest
@@ -55,9 +55,13 @@ image="orchest/orchest-ctl"
 
 set -e
 
-# TODO: passing an argument containing @ will break this.
+# It's important that the "command" label is set right at creation time,
+# which allows to detect conflicting concurrent commands without race
+# conditions. Refer to config.STATUS_CHANGING_OPERATIONS if you plan
+# changes to this label. TODO: passing an argument containing @ will
+# break this.
 pod=$(sed -e "s@%IMAGE%@$image@g" -e "s@%VERSION%@$repo_version@g" \
--e "s@%COMMAND%@$@@g" "$DIR/deploy/orchest-ctl/pod.yml" | \
+-e "s@%COMMAND%@$1@g" "$DIR/deploy/orchest-ctl/pod.yml" | \
 minikube kubectl -- create -n orchest -o name -f -)
 
 # Make sure to cleanup the pod on exit.

--- a/orchest
+++ b/orchest
@@ -55,8 +55,9 @@ image="orchest/orchest-ctl"
 
 set -e
 
+# TODO: passing an argument containing @ will break this.
 pod=$(sed -e "s@%IMAGE%@$image@g" -e "s@%VERSION%@$repo_version@g" \
-"$DIR/deploy/orchest-ctl/pod.yml" | \
+-e "s@%COMMAND%@$@@g" "$DIR/deploy/orchest-ctl/pod.yml" | \
 minikube kubectl -- create -n orchest -o name -f -)
 
 # Make sure to cleanup the pod on exit.
@@ -75,8 +76,6 @@ trap on_exit EXIT
 # doesn't go through more than 1 iteration usually.
 for i in {1..100}; do minikube kubectl -- get -n orchest "${pod}" \
     > /dev/null 2>&1 && break; done
-
-minikube kubectl -- label -n orchest "${pod}" "command=$1" --overwrite > /dev/null 
 
 # Wait for 15mins because the image might need to be pulled. TODO:
 # alert the user if a pull happens, then wait.

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -115,32 +115,20 @@ def stop():
 
 @typer_app.command()
 def status(
-    ext: bool = typer.Option(
+    json: bool = typer.Option(
         False,
-        "--ext",
+        "--json",
         show_default=False,
-        help="Get extensive status information.",
+        help="Get output in json.",
     ),
 ):
     """
-    Get status of Orchest.
+    Get status of Orchest, one of: "installing", "restarting",
+    "running", "starting", "stopped", "stopping", "unhealthy",
+    "updating".
 
-    Exit codes:
-
-    - 0: Orchest is running and services are ready.
-
-    - 1: Orchest is not running.
-
-    - 2: Orchest is running, but some required service has shut down.
-
-    - 3: Orchest is running, but some required service is not passing a
-    health check.
-
-    - 4: Orchest is restarting.
-
-    - 5: Orchest is updating.
     """
-    app.status(ext=ext)
+    orchest.status(output_json=json)
 
 
 @typer_app.command()

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -87,6 +87,8 @@ ORCHEST_IMAGES = {
 }
 
 WRAP_LINES = 72
+# Used to avoid outputting anything that isn't the desired json.
+JSON_MODE = False
 
 ORCHEST_WEBSERVER_ADDRESS = "http://orchest-webserver:80"
 

--- a/services/orchest-ctl/app/config.py
+++ b/services/orchest-ctl/app/config.py
@@ -1,6 +1,30 @@
+from enum import Enum
 from typing import List, Set
 
 ORCHEST_NAMESPACE = "orchest"
+
+STATUS_CHANGING_OPERATIONS = ["install", "start", "stop", "restart", "update"]
+
+
+class OrchestStatus(str, Enum):
+    INSTALLING = "installing"
+    RESTARTING = "restarting"
+    RUNNING = "running"
+    STARTING = "starting"
+    STOPPED = "stopped"
+    STOPPING = "stopping"
+    UNHEALTHY = "unhealthy"
+    UPDATING = "updating"
+
+
+ORCHEST_STATUS_CHANGING_OPERATION_TO_STATUS = {
+    "install": OrchestStatus.INSTALLING,
+    "start": OrchestStatus.STARTING,
+    "stop": OrchestStatus.STOPPING,
+    "restart": OrchestStatus.RESTARTING,
+    "update": OrchestStatus.UPDATING,
+}
+
 
 DEPLOYMENT_VERSION_SYNCED_WITH_CLUSTER_VERSION = set(
     [

--- a/services/orchest-ctl/app/orchest/__init__.py
+++ b/services/orchest-ctl/app/orchest/__init__.py
@@ -1,1 +1,6 @@
+"""Core functionality of orchest-ctl.
+
+Refer to config.STATUS_CHANGING_OPERATIONS if you introduce new status
+changing operations or if you change the name of existing ones.
+"""
 from app.orchest._core import install, status, version

--- a/services/orchest-ctl/app/orchest/__init__.py
+++ b/services/orchest-ctl/app/orchest/__init__.py
@@ -1,1 +1,1 @@
-from app.orchest._core import install, version
+from app.orchest._core import install, status, version

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -1,4 +1,3 @@
-"""Core functionality of orchest-ctl."""
 import atexit
 import json
 import logging

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -163,6 +163,7 @@ def version(ext=False, output_json: bool = False):
         including deployment versions.
         output_json: If true echo json instead of text.
     """
+    config.JSON_MODE = output_json
     cluster_version = k8sw.get_orchest_cluster_version()
     if not ext:
         _echo_version(cluster_version, None, output_json)

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -10,13 +10,15 @@ from urllib import request
 
 import typer
 
-from app import error
+from app import config, error
 from app.config import WRAP_LINES
 
 logger = logging.getLogger(__name__)
 
 
 def echo(*args, wrap=WRAP_LINES, **kwargs):
+    if config.JSON_MODE:
+        return
     """Wraps typer.echo to natively support line wrapping."""
     if wrap:
         message = kwargs.get("message")


### PR DESCRIPTION
## Description

Ports `orchest status` to k8s, and introduces a `--json` flag, e.g. `orchest status --json`:

```json
{"status": "unhealthy", "reason": ["orchest-api"]}
```
