### PR TITLE
Orchest-ctl refactoring PR 5, `orchest adduser`

### DIFF
--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -316,7 +316,7 @@ def adduser(
         echo("Token cannot be empty.", err=True)
         raise typer.Exit(code=1)
 
-    app.add_user(username, password, token, is_admin)
+    orchest.add_user(username, password, token, is_admin)
 
 
 @typer_app.command()

--- a/services/orchest-ctl/app/orchest/__init__.py
+++ b/services/orchest-ctl/app/orchest/__init__.py
@@ -4,4 +4,4 @@ Refer to config.STATUS_CHANGING_OPERATIONS and
 _k8s_wrapper.get_ongoing_status_change if you introduce new status
 changing operations or if you change the name of existing ones.
 """
-from app.orchest._core import install, restart, start, status, stop, version
+from app.orchest._core import add_user, install, restart, start, status, stop, version

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import typer
 from kubernetes import client as k8s_client
+from kubernetes.stream import stream
 
 from app import config, utils
 from app.connections import k8s_core_api
@@ -407,3 +408,57 @@ def start():
 def restart():
     stop()
     start()
+
+
+def add_user(username: str, password: str, token: str, is_admin: str) -> None:
+    """Adds a new user to Orchest.
+
+    Args:
+        username:
+        password:
+        token:
+        is_admin:
+    """
+
+    db_depl, auth_server_depl = k8sw.get_orchest_deployments(
+        ["orchest-database", "auth-server"]
+    )
+
+    if db_depl is None or db_depl.status.ready_replicas != db_depl.spec.replicas:
+        utils.echo("The orchest-database service needs to be running.", err=True)
+        raise typer.Exit(code=1)
+
+    if (
+        auth_server_depl is None
+        or auth_server_depl.status.ready_replicas != auth_server_depl.spec.replicas
+    ):
+        utils.echo("The auth-server service needs to be running.", err=True)
+        raise typer.Exit(code=1)
+
+    pods = k8s_core_api.list_namespaced_pod(
+        config.ORCHEST_NAMESPACE, label_selector="app=auth-server"
+    )
+    if not pods:
+        utils.echo("Could not find auth-server pod.")
+        raise typer.Exit(code=1)
+    pod = pods[0]
+
+    cmd = f"python add_user.py {username} {password}"
+    if token:
+        cmd += f" --token {token}"
+    if is_admin:
+        cmd += " --is_admin"
+    cmd = cmd.split()
+
+    resp = stream(
+        k8s_core_api.connect_get_namespaced_pod_exec,
+        pod.metadata.name,
+        config.ORCHEST_NAMESPACE,
+        command=cmd[:1],
+        args=cmd[1:],
+        stderr=True,
+        stdin=False,
+        stdout=True,
+        tty=False,
+    )
+    utils.echo(str(resp))

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -443,19 +443,19 @@ def add_user(username: str, password: str, token: str, is_admin: str) -> None:
         raise typer.Exit(code=1)
     pod = pods[0]
 
-    cmd = f"python add_user.py {username} {password}"
+    args = ["add_user.py", username, password]
     if token:
-        cmd += f" --token {token}"
+        args.append("--token")
+        args.append(token)
     if is_admin:
-        cmd += " --is_admin"
-    cmd = cmd.split()
+        args.append("--admin")
 
     resp = stream(
         k8s_core_api.connect_get_namespaced_pod_exec,
         pod.metadata.name,
         config.ORCHEST_NAMESPACE,
-        command=cmd[:1],
-        args=cmd[1:],
+        command=["python"],
+        args=args,
         stderr=True,
         stdin=False,
         stdout=True,

--- a/services/orchest-ctl/app/orchest_old.py
+++ b/services/orchest-ctl/app/orchest_old.py
@@ -169,52 +169,6 @@ class OrchestApp:
     def debug(self, ext: bool, compress: bool):
         debug_dump(ext, compress)
 
-    def add_user(self, username, password, token, is_admin):
-        """Adds a new user to Orchest.
-
-        Args:
-            username:
-            password:
-            token:
-            is_admin:
-        """
-
-        ids, running_containers = self.resource_manager.get_containers(state="running")
-        auth_server_id = None
-        database_running = False
-        for id, container in zip(ids, running_containers):
-            if "postgres" in container:
-                database_running = True
-            if "auth-server" in container:
-                auth_server_id = id
-
-        if not database_running:
-            utils.echo("The orchest-database service needs to be running.", err=True)
-            raise typer.Exit(code=1)
-
-        if auth_server_id is None:
-            utils.echo("The auth-server service needs to be running.", err=True)
-            raise typer.Exit(code=1)
-
-        cmd = f"python add_user.py {username} {password}"
-        if token:
-            cmd += f" --token {token}"
-        if is_admin:
-            cmd += " --is_admin"
-
-        exit_code = self.docker_client.exec_runs([(auth_server_id, cmd)])[0]
-
-        if exit_code != 0:
-            utils.echo(
-                (
-                    "Non zero exit code whilst trying to add a user to "
-                    f"the auth-server: {exit_code}."
-                ),
-                err=True,
-            )
-
-        raise typer.Exit(code=exit_code)
-
     def run(self, job_name, project_name, pipeline_name, wait=False, rm=False):
         """Queues the pipeline as a one-time job."""
         # Orchest has to be running for this command to work, since we


### PR DESCRIPTION
## Description

Ports `orchest adduser` to k8s. The command is not completely tested given that it requires the `auth-server` to be running, which is currently not included in our deployment.
