### PR TITLE
Integrate a custom file-manager into the pipeline editor

### DIFF
--- a/services/orchest-webserver/app/app/core/filemanager.py
+++ b/services/orchest-webserver/app/app/core/filemanager.py
@@ -1,53 +1,44 @@
 import logging
 import os
 import re
-from os.path import expanduser
 
 from flask import jsonify
 
-logger = logging.getLogger("app")
+from _orchest.internals import config as _config
 
-PROJECT_DIR_PATH_STUB = "/project-dir"
-PROJECT_DIR_PATH = os.path.join(expanduser("~"), "Desktop")
+logger = logging.getLogger(__name__)
+
+PROJECT_DIR_PATH = _config.PROJECT_DIR
 ALLOWED_ROOTS = [PROJECT_DIR_PATH, "/data"]
 
 
 def allowed_file(filename):
-    """
-    Allow all files for now
+    """Answers: Is the given file allowed?
+
+    Note:
+        Allows all files for now.
+
     """
     return True
 
 
 def root_from_request(request):
-    root = None
-
-    if "root" in request.args:
-        root = resolve_root_dir(request.args["root"])
-    else:
-        root = resolve_root_dir(PROJECT_DIR_PATH_STUB)
+    root = request.args.get("root", PROJECT_DIR_PATH)
 
     if root in ALLOWED_ROOTS:
         return root
     else:
-        raise Exception("Received illegal root path.")
+        raise ValueError("Received illegal root path.")
 
 
 def old_new_roots_from_request(request):
-    old_root = resolve_root_dir(request.args["oldRoot"])
-    new_root = resolve_root_dir(request.args["newRoot"])
+    old_root = request.args["oldRoot"]
+    new_root = request.args["newRoot"]
 
     if old_root in ALLOWED_ROOTS and new_root in ALLOWED_ROOTS:
         return [old_root, new_root]
     else:
-        raise Exception("Received illegal root path.")
-
-
-def resolve_root_dir(path):
-    if path == PROJECT_DIR_PATH_STUB:
-        return PROJECT_DIR_PATH
-    else:
-        return path
+        raise ValueError("Received illegal root path.")
 
 
 def find_unique_duplicate_filepath(fp):

--- a/services/orchest-webserver/app/app/core/filemanager.py
+++ b/services/orchest-webserver/app/app/core/filemanager.py
@@ -1,0 +1,197 @@
+import logging
+import os
+import re
+from os.path import expanduser
+
+from flask import jsonify
+
+logger = logging.getLogger("app")
+
+PROJECT_DIR_PATH_STUB = "/project-dir"
+PROJECT_DIR_PATH = os.path.join(expanduser("~"), "Desktop")
+ALLOWED_ROOTS = [PROJECT_DIR_PATH, "/data"]
+
+
+def allowed_file(filename):
+    """
+    Allow all files for now
+    """
+    return True
+
+
+def root_from_request(request):
+    root = None
+
+    if "root" in request.args:
+        root = resolve_root_dir(request.args["root"])
+    else:
+        root = resolve_root_dir(PROJECT_DIR_PATH_STUB)
+
+    if root in ALLOWED_ROOTS:
+        return root
+    else:
+        raise Exception("Received illegal root path.")
+
+
+def old_new_roots_from_request(request):
+    old_root = resolve_root_dir(request.args["oldRoot"])
+    new_root = resolve_root_dir(request.args["newRoot"])
+
+    if old_root in ALLOWED_ROOTS and new_root in ALLOWED_ROOTS:
+        return [old_root, new_root]
+    else:
+        raise Exception("Received illegal root path.")
+
+
+def resolve_root_dir(path):
+    if path == PROJECT_DIR_PATH_STUB:
+        return PROJECT_DIR_PATH
+    else:
+        return path
+
+
+def find_unique_duplicate_filepath(fp):
+    counter = 1
+    new_path_fs = "{base} ({counter}){ext}"
+
+    if fp.endswith("/"):
+        basename = os.path.basename(fp[:-1])
+        ext = ""
+        base_no_ext = basename
+    else:
+        basename = os.path.basename(fp)
+        _, ext = os.path.splitext(fp)
+        if len(ext) > 0:
+            base_no_ext = basename[: -len(ext)]
+        else:
+            base_no_ext = basename
+
+    # Try to find existing counter ending
+    regex = r".*? \((\d+)\)$"
+    matches = re.finditer(regex, base_no_ext)
+
+    group_match = None
+    for _, match in enumerate(matches, start=1):
+        if len(match.group()) > 0:
+            group_match = match.group(1)
+
+    # Strip off the (<number>) match
+    if group_match is not None:
+        base_no_ext = base_no_ext[: -(len(group_match) + 3)]
+
+    while True:
+        new_path = os.path.join(
+            os.path.abspath(os.path.join(fp, os.pardir)),
+            new_path_fs.format(base=base_no_ext, counter=counter, ext=ext),
+        )
+
+        if os.path.isfile(new_path) or os.path.isdir(new_path):
+            counter += 1
+            continue
+        else:
+            return new_path
+
+
+def generate_abs_path(path, root, dir, is_dir=False):
+    """
+    This generates a new absolute path, relative from the `dir`
+    """
+    return (
+        "/" + os.path.relpath(os.path.join(root, path), dir) + ("/" if is_dir else "")
+    )
+
+
+def zipdir(path, ziph):
+    # ziph is zipfile handle
+    for root, _, files in os.walk(path):
+        for file in files:
+            ziph.write(
+                os.path.join(root, file),
+                os.path.relpath(os.path.join(root, file), os.path.join(path, "..")),
+            )
+
+
+def generate_tree(dir, path_filter="/", allowed_file_extensions=[], depth=3):
+
+    if not os.path.isdir(dir):
+        return jsonify({"message": "Dir %s not found." % dir}), 404
+
+    # Init structs
+    tree = {
+        "type": "directory",
+        "name": os.path.basename(path_filter[:-1]),
+        "path": path_filter,
+        "children": [],
+    }
+    if path_filter == "/":
+        tree["root"] = True
+    else:
+        tree["depth"] = path_filter.count(os.sep) - 1
+
+    dir_nodes = {}
+
+    if path_filter != "/":
+        filtered_path = os.path.join(dir, path_filter[1:-1])
+    else:
+        filtered_path = dir
+
+    dir_nodes[filtered_path] = tree
+
+    dir_depth = dir.count(os.sep)
+
+    logger.debug("Walking %s " % filtered_path)
+    for root, dirs, files in os.walk(filtered_path):
+
+        dir_delete_set = set()
+        for dirname in dirs:
+
+            dir_path = os.path.join(root, dirname)
+            dir_node = {
+                "type": "directory",
+                "name": dirname,
+                "children": [],
+                "depth": root.count(os.sep) - dir_depth + 1,
+                "path": generate_abs_path(dirname, root, dir, is_dir=True),
+            }
+
+            relative_depth = dir_node["depth"] - (path_filter.count(os.sep) - 2)
+            if relative_depth > depth:  # Account for filtered_path
+                dir_delete_set.add(dirname)
+
+            logger.debug(relative_depth)
+
+            dir_nodes[dir_path] = dir_node
+            dir_nodes[root]["children"].append(dir_node)
+
+        # Filter dirs in delete set
+        dirs[:] = [d for d in dirs if d not in dir_delete_set]
+
+        for filename in files:
+
+            if (
+                len(allowed_file_extensions) == 0
+                or filename.split(".")[-1] in allowed_file_extensions
+            ):
+                file_node = {
+                    "type": "file",
+                    "name": filename,
+                    "path": generate_abs_path(filename, root, dir),
+                }
+
+                # this key should always exist
+                try:
+                    dir_nodes[root]["children"].append(file_node)
+                except KeyError as e:
+                    logger.error(
+                        "Key %s does not exist in dir_nodes %s. Error: %s"
+                        % (root, dir_nodes, e)
+                    )
+                except Exception as e:
+                    logger.error("Error: %e" % e)
+
+        # Sort files & directories (directories always go before files)
+        if "children" in dir_nodes[root]:
+            dir_nodes[root]["children"].sort(
+                key=lambda e: {"directory": "a.", "file": "b."}[e["type"]] + e["name"]
+            )
+    return jsonify(tree)

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -498,7 +498,7 @@ def create_job_directory(job_uuid, pipeline_uuid, project_uuid):
 
 
 def rmtree(path, ignore_errors=False):
-    """A wrapped rm -rf.
+    """A wrapped `rm -rf -- {path}`.
 
     If eventlet is being used and it's either patching all modules or
     patching subprocess, this function is not going to block the thread.
@@ -507,7 +507,9 @@ def rmtree(path, ignore_errors=False):
         OSError if it failed to remove.
 
     """
-    exit_code = subprocess.call(f"rm -rf {path}", stderr=subprocess.STDOUT, shell=True)
+    exit_code = subprocess.call(
+        f"rm -rf -- {path}", stderr=subprocess.STDOUT, shell=True
+    )
     if exit_code != 0 and not ignore_errors:
         raise OSError(f"Failed to rm {path}: {exit_code}.")
 

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -1051,16 +1051,11 @@ def register_views(app, db):
         # Make absolute path relative
         fp = os.path.join(root_dir_path, path[1:])
 
-        if os.path.isfile(fp):
-            try:
-                os.remove(fp)
-            except Exception:
-                return jsonify({"message": "Deletion of file failed"}), 500
-        elif os.path.isdir(fp):
+        if os.path.exists(fp):
             try:
                 rmtree(fp)
             except Exception:
-                return jsonify({"message": "Deletion of folder failed"}), 500
+                return jsonify({"message": "Deletion failed."}), 500
         else:
             return jsonify({"message": "No file or directory at path %s" % path}), 500
 


### PR DESCRIPTION
## Description

Integrates a custom file-manager into the pipeline editor (initial implementation by @ricklamers in a separate repo). 

Fixes: #612 

## Checklist
- [X] The PR branch is set up to merge into `dev` instead of `master`.

## Notes
@ricklamers Probably a good idea if you take a quick look whether this integration is in-line with your ideas.
@iannbing Some notes for you when working on the frontend.

All routes are now prefixed by `/async/file-manager`, e.g. `/async/file-manager/create-dir`. You can find all routes in the `views.py` of the `orchest-webserver`.

Notes:
- I changed all calls to `shutil` to our patched version from the `utils.py`. I don't expect any issues from this, but good to check the behavior of copy and removal commands.
- Removed `resolve_root_dir` as I think it was used to test locally without having it integrated in Orchest.

