### PR TITLE
Fix opening files in JupyterLab that contain uppercase characters in their name

### DIFF
--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -239,7 +239,7 @@ export const toQueryString = <T extends string>(
           const [key, value] = entry;
           const encodedValue =
             value && value !== "null" && value !== "undefined" // we don't pass along null or undefined since it doesn't mean much to the receiver
-              ? encodeURIComponent(value.toString().toLowerCase())
+              ? encodeURIComponent(value.toString())
               : null;
           return encodedValue
             ? `${str}${snakeCase(key)}=${encodedValue}&`


### PR DESCRIPTION
## Description
Do not parse query string to lowercase

Parsing to lowercase would break opening files in JupyterLab through the
"EDIT IN JUPYTERLAB" button as it passes the filename as a query string.

Fuzzy filtering of the pipeline run table will not break as it itself
parses the given filter to lowercase (thanks @iannbing for mentioning
this case).

Fixes: #765 

## Checklist
- [X] The PR branch is set up to merge into `dev` instead of `master`.

