### PR TITLE
Remove memory-server related docs

### DIFF
--- a/docs/source/fundamentals/configuration.rst
+++ b/docs/source/fundamentals/configuration.rst
@@ -68,40 +68,6 @@ Explanation of possible configuration settings:
        All telemetry is completely anonymized through your ``TELEMETRY_UUID``, and we do not store
        any IP information either on our servers.
 
-.. _pipeline settings:
-
-Pipeline settings
------------------
-There are also configuration options per pipeline that can be set through the UI by opening a
-pipeline and going to its *Settings* in the top right corner. This will add a JSON block
-to the corresponding pipeline definition, for example:
-
-.. code-block:: text
-
-   "settings": {
-     "auto_eviction": true,
-     "data_passing_memory_size": "1GB"
-   }
-
-``auto_eviction``
-    Possible values: ``true`` or ``false``.
-
-    When sending data between pipeline steps through memory all the data is by default kept in
-    memory, only overwriting an object if the same pipeline step passes data again. To free memory
-    you can either *Clear memory* through the pipeline settings or enable auto eviction. Auto
-    eviction will make sure objects are evicted once all depending steps have obtained the data.
-
-    .. note::
-       Auto eviction is always enabled for *jobs*.
-
-``data_passing_memory_size``
-    Values have to be strings formatted as floats with a unit of ``GB``, ``MB`` or ``KB``, e.g.
-    ``"5.4GB"``.
-
-    The size of the memory store for data passing. All objects that are passed between steps are by
-    default stored in memory (unless you explicitly use :meth:`orchest.transfer.output_to_disk`)
-    and thus it is recommended to choose an appropriate size for your pipeline.
-
 .. _configuration jupyterlab:
 
 Configuring JupyterLab

--- a/docs/source/fundamentals/data_passing.rst
+++ b/docs/source/fundamentals/data_passing.rst
@@ -87,10 +87,6 @@ The ``input_data`` in step-3 will be as follows:
 You can see both ``my_string`` and ``my_list``, the output data from steps 1 and 2 respectively, are
 in the received input data. But what is the ``unnamed``? We will answer this in the next section.
 
-.. tip::
-   👉 You can increase the size of the shared memory (to allow for larger data to be passed) in the
-   :ref:`pipeline settings <pipeline settings>`.
-
 Passing data without a name
 ---------------------------
 As you could see in the previous example, step-3 received input data with a special key called
@@ -173,14 +169,3 @@ the data in ``unnamed`` has changed!):
    }
 
 Top-to-bottom in the UI corresponds with left-to-right in ``unnamed``.
-
-Memory footprint
-----------------
-When passing data between steps, by default it is passed through memory and kept it memory for the
-lifetime of the :ref:`session <interactive session>`. This makes it easy to develop your pipeline
-without having to rerun it in its entirety again. The data is essentially cached in memory.
-
-If you are passing large amounts of data between steps, then you might have to increase the size of
-the cache. This can be done through the :ref:`pipeline settings <pipeline settings>`. Alternatively,
-you might want to enable ``auto-eviction`` so that cached data is removed once all receiving steps
-have obtained the passed data.

--- a/docs/source/fundamentals/glossary.rst
+++ b/docs/source/fundamentals/glossary.rst
@@ -44,7 +44,7 @@ Interactive session
     inside the pipeline editor, or in the list pipelines. A session is automatically started for you
     when opening up a pipeline.
 
-    * Automatically boots and manages: JupyterLab, jupyter-enterprise-gateway and ``memory-server``.
+    * Automatically boots and manages: JupyterLab and jupyter-enterprise-gateway.
     * Required in order to start an :ref:`interactive pipeline run <interactive pipeline run>`.
 
 .. _pipeline run:


### PR DESCRIPTION
## Description

Removes all memory-server related docs. The Kubernetes MVP won't have a memory-server and so we want to remove all user-facing content that mention it.

Related PR: #769 

## Checklist
- [X] The PR branch is set up to merge into `feat/k8s` instead of `master`.