### PR TITLE
Fix not redirecting to Pipeline List after importing if the import URL contains trailing slash

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
@@ -52,8 +52,8 @@ export const CreateNextStepButton = ({
           incoming_connections: [],
           file_path: "",
           kernel: {
-            name: environment?.language,
-            display_name: environment?.name,
+            name: environment?.language || "python",
+            display_name: environment?.name || "Python",
           },
           environment: environment?.uuid,
           parameters: {},

--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -50,7 +50,7 @@ const ImportStatusNotification = ({ data }: { data?: BackgroundTask }) => {
 };
 
 const getProjectNameFromUrl = (importUrl: string) => {
-  const matchGithubRepoName = importUrl.match(/\/([^\/]+)$/);
+  const matchGithubRepoName = importUrl.match(/\/([^\/]+)\/?$/);
   return matchGithubRepoName ? matchGithubRepoName[1] : "";
 };
 


### PR DESCRIPTION
## Description

The regular expression for the import_url should take into account the trailing slash.

Fixes: #743
