### PR TITLE
daemonset pre pull images endpoints

### DIFF
--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -19,6 +19,7 @@ from sqlalchemy_utils import create_database, database_exists
 from _orchest.internals import config as _config
 from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor
+from app import utils
 from app.apis import blueprint as api
 from app.apis.namespace_environment_image_builds import AbortEnvironmentImageBuild
 from app.apis.namespace_jobs import AbortJob
@@ -29,7 +30,6 @@ from app.apis.namespace_jupyter_image_builds import (
 from app.apis.namespace_runs import AbortPipelineRun
 from app.apis.namespace_sessions import StopInteractiveSession
 from app.connections import db
-from app.core import environments
 from app.core.scheduler import Scheduler
 from app.models import (
     EnvironmentImageBuild,
@@ -227,8 +227,8 @@ def trigger_conditional_jupyter_image_build(app):
     else:
         return
 
-    user_jupyer_server_image = _config.JUPYTER_IMAGE_NAME
-    if environments.get_environment_image_id(user_jupyer_server_image) is not None:
+    # If the image has already been built no need to build again.
+    if utils.get_jupyter_server_image_to_use() != "orchest/jupyter-server:latest":
         return
 
     try:

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -6,8 +6,8 @@ import yaml
 from flask_restx import Namespace, Resource
 
 from _orchest.internals import config as _config
-from app import schema, utils
-from app.connections import k8s_core_api
+from app import models, schema, utils
+from app.connections import db, k8s_core_api
 
 api = Namespace("ctl", description="Orchest-api internal control.")
 api = utils.register_schema(api)
@@ -50,6 +50,39 @@ class Restart(Resource):
         )
 
         return {}, 201
+
+
+@api.route("/orchest-images-to-pre-pull")
+class OrchestImagesToPrePull(Resource):
+    @api.doc("orchest_images_to_pre_pull")
+    def get(self):
+        """Orchest images to pre pull on all nodes for a better UX."""
+        # K8S_TODO: remove latest once we have versioned images on
+        # dockerhub.
+        pre_pull_orchest_images = [
+            "orchest/jupyter-enterprise-gateway:latest",
+            "orchest/session-sidecar:latest",
+        ]
+        has_customized_jupyter = db.session.query(
+            db.session.query(models.JupyterImageBuild)
+            .filter_by(status="SUCCESS")
+            .exists()
+        ).scalar()
+        if has_customized_jupyter:
+            registry_ip = k8s_core_api.read_namespaced_service(
+                _config.REGISTRY, _config.ORCHEST_NAMESPACE
+            ).spec.cluster_ip
+            pre_pull_orchest_images.append(
+                f"{registry_ip}/orchest/{_config.JUPYTER_IMAGE_NAME}:latest"
+            )
+        else:
+            # K8S_TODO: remove latest once we have versioned images on
+            # dockerhub.
+            pre_pull_orchest_images.append("orchest/jupyter-server:latest")
+
+        pre_pull_orchest_images = {"pre_pull_orchest_images": pre_pull_orchest_images}
+
+        return pre_pull_orchest_images, 200
 
 
 def _get_update_sidecar_manifest(update_pod_name, token: str) -> dict:

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Tuple
 from _orchest.internals import config as _config
 from app import utils
 from app.connections import k8s_core_api
-from app.core import environments
 from app.types import SessionConfig, SessionType
 from config import CONFIG_CLASS
 
@@ -405,12 +404,6 @@ def _get_jupyter_server_deployment_service_manifest(
         },
     }
 
-    # Check if user tweaked JupyterLab image exists.
-    if environments.get_environment_image_id(_config.JUPYTER_IMAGE_NAME) is not None:
-        image = _config.JUPYTER_IMAGE_NAME
-    else:
-        image = "orchest/jupyter-server:latest"
-
     volumes_dict, volume_mounts_dict = _get_jupyter_volumes_and_volume_mounts(
         project_uuid, host_userdir, host_project_dir, project_relative_pipeline_path
     )
@@ -442,7 +435,7 @@ def _get_jupyter_server_deployment_service_manifest(
                     "containers": [
                         {
                             "name": metadata["name"],
-                            "image": image,
+                            "image": utils.get_jupyter_server_image_to_use(),
                             # K8S_TODO: fix me.
                             "imagePullPolicy": "IfNotPresent",
                             "volumeMounts": [
@@ -676,6 +669,7 @@ def _get_jupyter_enterprise_gateway_deployment_service_manifest(
     volumes_dict, volume_mounts_dict = _get_jupyter_volumes_and_volume_mounts(
         project_uuid, host_userdir, host_project_dir, project_relative_pipeline_path
     )
+
     deployment_manifest = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -668,6 +668,11 @@ environment_image = Model(
     },
 )
 
+environment_images = Model(
+    "EnvironmentImages",
+    {"environment_images": fields.List(fields.Nested(environment_image))},
+)
+
 
 jupyter_image_build = Model(
     "JupyterEnvironmentBuild",


### PR DESCRIPTION
## Description

Adds a couple of endpoints to provide to the `daemonset` in charge of pre pulling images what images should be pulled.
Endpoints:
- `/environment-images/latest` for a list of the latest environment images for every environment
- `ctl/orchest-images-to-pre-pull` for the list of orchest images to pre pull (i.e. session related)

Sessions will now make use of a customized jupyter-server image correctly.