### PR TITLE
K8S move orchest directories to internal config

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -2,6 +2,15 @@ import os
 
 # TODO: add notice that some of these values have effect on the sdk!.
 
+# Orchest directories that need to exist in the userdir.
+USERDIR_DATA = "/userdir/data"
+USERDIR_JOBS = "/userdir/jobs"
+USERDIR_PROJECTS = "/userdir/projects"
+USERDIR_ENV_IMG_BUILDS = "/userdir/.orchest/env-img-builds"
+USERDIR_JUPYTER_IMG_BUILDS = "/userdir/.orchest/jupyter-img-builds"
+USERDIR_JUPYTERLAB = "/userdir/.orchest/user-configurations/jupyterlab"
+USERDIR_BASE_IMAGES_CACHE = "/userdir/.orchest/base-images-cache"
+
 DATA_DIR = "/data"
 PROJECT_DIR = "/project-dir"
 PIPELINE_FILE = "/pipeline.json"

--- a/services/orchest-api/app/app/core/environment_image_builds.py
+++ b/services/orchest-api/app/app/core/environment_image_builds.py
@@ -199,12 +199,12 @@ def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_pat
         See the check_environment_correctness_function
     """
     # the project path we receive is relative to the projects directory
-    userdir_project_path = os.path.join("/userdir/projects", project_path)
+    userdir_project_path = os.path.join(_config.USERDIR_PROJECTS, project_path)
 
     # sanity checks, if not respected exception will be raised
     check_environment_correctness(project_uuid, environment_uuid, userdir_project_path)
 
-    env_builds_dir = "/userdir/.orchest/env-builds"
+    env_builds_dir = _config.USERDIR_ENV_IMG_BUILDS
     # Make a snapshot of the project state, used for the context.
     snapshot_path = f"{env_builds_dir}/{task_uuid}"
     if os.path.isdir(snapshot_path):

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -55,7 +55,7 @@ def _get_base_image_cache_workflow_manifest(workflow_name, base_image: str) -> d
                 {
                     "name": "kaniko-cache",
                     "hostPath": {
-                        "path": CONFIG_CLASS.BASE_IMAGES_CACHE,
+                        "path": CONFIG_CLASS.HOST_BASE_IMAGES_CACHE,
                         "type": "DirectoryOrCreate",
                     },
                 },
@@ -176,7 +176,7 @@ def _get_image_build_workflow_manifest(
                 {
                     "name": "kaniko-cache",
                     "hostPath": {
-                        "path": CONFIG_CLASS.BASE_IMAGES_CACHE,
+                        "path": CONFIG_CLASS.HOST_BASE_IMAGES_CACHE,
                         "type": "DirectoryOrCreate",
                     },
                 },

--- a/services/orchest-api/app/app/core/jupyter_image_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_image_builds.py
@@ -102,8 +102,7 @@ def prepare_build_context(task_uuid):
     """
     # the project path we receive is relative to the projects directory
     jupyterlab_setup_script = os.path.join("/userdir", _config.JUPYTER_SETUP_SCRIPT)
-
-    jupyter_image_builds_dir = "/userdir/.orchest/jupyter-builds-dir"
+    jupyter_image_builds_dir = _config.USERDIR_JUPYTER_IMG_BUILDS
     snapshot_path = f"{jupyter_image_builds_dir}/{task_uuid}"
 
     if os.path.isdir(snapshot_path):

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -301,7 +301,7 @@ def delete_base_images_cache(self) -> str:
     operation and it avoids 1 layer of indirection.
     """
     try:
-        with os.scandir(CONFIG_CLASS.BASE_IMAGES_CACHE) as entries:
+        with os.scandir(_config.USERDIR_BASE_IMAGES_CACHE) as entries:
             for entry in entries:
                 rmtree(entry)
     except FileNotFoundError:

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -30,10 +30,7 @@ class Config:
     # Image building.
     BUILD_IMAGE_LOG_TERMINATION_FLAG = "_ORCHEST_RESERVED_LOG_TERMINATION_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
-    # K8S_TODO this will likely need to be adjusted when it comes to
-    # integrating the distributed file system. This is the path where
-    # orchest currently resides in the node.
-    BASE_IMAGES_CACHE = "/var/lib/orchest/userdir/.orchest/base-images-cache"
+    HOST_BASE_IMAGES_CACHE = f"/var/lib/orchest{_config.USERDIR_BASE_IMAGES_CACHE}"
 
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-ctl/app/utils.py
+++ b/services/orchest-ctl/app/utils.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from _orchest.internals import config as _config
 from app import config
 from app.config import WRAP_LINES
 
@@ -68,12 +69,12 @@ def fix_userdir_permissions() -> None:
 
 def create_required_directories() -> None:
     for path in [
-        "/userdir/data",
-        "/userdir/jobs",
-        "/userdir/projects",
-        "/userdir/.orchest/env-builds",
-        "/userdir/.orchest/jupyter-builds-dir",
-        "/userdir/.orchest/user-configurations/jupyterlab",
-        "/userdir/.orchest/base-images-cache",
+        _config.USERDIR_DATA,
+        _config.USERDIR_JOBS,
+        _config.USERDIR_PROJECTS,
+        _config.USERDIR_ENV_IMG_BUILDS,
+        _config.USERDIR_JUPYTER_IMG_BUILDS,
+        _config.USERDIR_JUPYTERLAB,
+        _config.USERDIR_BASE_IMAGES_CACHE,
     ]:
         Path(path).mkdir(parents=True, exist_ok=True)

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 import uuid
-from pathlib import Path
 
 import requests
 import sqlalchemy
@@ -310,11 +309,6 @@ def register_views(app, db):
 
         setup_script_path = os.path.join(
             app.config["USER_DIR"], _config.JUPYTER_SETUP_SCRIPT
-        )
-
-        # K8S_TODO: remove this?
-        Path("/userdir/.orchest/user-configurations/jupyterlab").mkdir(
-            parents=True, exist_ok=True
         )
 
         if request.method == "POST":


### PR DESCRIPTION
This PR contains some breaking changes, either reinstall through `orchest-ctl` or create the following directories: `/userdir/.orchest/env-img-builds`, `/userdir/.orchest/jupyter-img-builds`.