### PR TITLE
Fix losing progress on Pipeline Settings when browser tab regaining focus

### DIFF
--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -7,7 +7,6 @@ export const ProjectsContext = React.createContext<IProjectsContext>(null);
 export const useProjectsContext = () => React.useContext(ProjectsContext);
 
 type Action =
-  | { type: "pipelineClear" }
   | {
       type: "pipelineSet";
       payload: Partial<
@@ -60,12 +59,6 @@ const reducer = (
   const action = _action instanceof Function ? _action(state) : _action;
 
   switch (action.type) {
-    case "pipelineClear":
-      return {
-        ...state,
-        pipeline_uuid: undefined,
-        pipelineName: undefined,
-      };
     case "pipelineSet":
       return { ...state, pipelineFetchHash: uuidv4(), ...action.payload };
     case "pipelineSetSaveStatus":

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -475,6 +475,16 @@ const PipelineSettingsView: React.FC = () => {
     pipelineJson?.settings?.data_passing_memory_size || ""
   );
 
+  const prettifyInputParameters = () => {
+    setInputParameters((current) => {
+      try {
+        return JSON.stringify(JSON.parse(current));
+      } catch (error) {
+        return current;
+      }
+    });
+  };
+
   return (
     <Layout>
       <div className="view-page pipeline-settings-view">
@@ -578,6 +588,7 @@ const PipelineSettingsView: React.FC = () => {
                             lineNumbers: true,
                             readOnly: isReadOnly,
                           }}
+                          onBlur={() => prettifyInputParameters()}
                           onBeforeChange={onChangePipelineParameters}
                         />
                         {(() => {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -472,7 +472,7 @@ const PipelineSettingsView: React.FC = () => {
     });
 
   const isMemorySizeValid = isValidMemorySize(
-    pipelineJson?.settings?.data_passing_memory_size || ""
+    settings?.data_passing_memory_size || ""
   );
 
   const prettifyInputParameters = () => {
@@ -540,7 +540,6 @@ const PipelineSettingsView: React.FC = () => {
                         <TextField
                           value={pipelineName}
                           margin="normal"
-                          multiline
                           onChange={(e) => setPipelineName(e.target.value)}
                           label="Pipeline name"
                           disabled={isReadOnly}
@@ -559,7 +558,6 @@ const PipelineSettingsView: React.FC = () => {
                         <TextField
                           value={pipelinePath}
                           margin="normal"
-                          multiline
                           onChange={(e) => setPipelinePath(e.target.value)}
                           label="Pipeline path"
                           disabled={isReadOnly || hasValue(session)}
@@ -649,7 +647,7 @@ const PipelineSettingsView: React.FC = () => {
                             disabled={isReadOnly}
                             control={
                               <Checkbox
-                                checked={pipelineJson?.settings?.auto_eviction}
+                                checked={settings?.auto_eviction}
                                 onChange={(e) => {
                                   onChangeEviction(e.target.checked);
                                 }}
@@ -669,20 +667,19 @@ const PipelineSettingsView: React.FC = () => {
                         )}
 
                         <TextField
-                          value={pipelineJson.settings.data_passing_memory_size}
+                          value={settings.data_passing_memory_size}
                           onChange={(e) =>
                             onChangeDataPassingMemorySize(e.target.value)
                           }
                           margin="normal"
                           label="Data passing memory size"
+                          error={!isMemorySizeValid}
+                          helperText={
+                            !isMemorySizeValid ? "Not a valid memory size." : ""
+                          }
                           disabled={isReadOnly}
                           data-test-id="pipeline-settings-configuration-memory-size"
                         />
-                        {!isMemorySizeValid && (
-                          <Alert severity="warning">
-                            Not a valid memory size.
-                          </Alert>
-                        )}
                       </Stack>
                       <div className="clear"></div>
                     </div>

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -10,7 +10,6 @@ import EnvVarList from "@/components/EnvVarList";
 import { Layout } from "@/components/Layout";
 import ServiceForm from "@/components/ServiceForm";
 import { ServiceTemplatesDialog } from "@/components/ServiceTemplatesDialog";
-import { ServiceTemplate } from "@/components/ServiceTemplatesDialog/content";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
@@ -37,7 +36,6 @@ import MiscellaneousServicesIcon from "@mui/icons-material/MiscellaneousServices
 import SaveIcon from "@mui/icons-material/Save";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
 import Alert from "@mui/material/Alert";
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
@@ -64,10 +62,13 @@ import {
   uuidv4,
 } from "@orchest/lib-utils";
 import "codemirror/mode/javascript/javascript";
-import cloneDeep from "lodash.clonedeep";
 import React from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
-import { getOrderValue } from "./common";
+import {
+  generatePipelineJsonForSaving,
+  getOrderValue,
+  instantiateNewService,
+} from "./common";
 import { useFetchPipelineMetadata } from "./useFetchPipelineMetadata";
 
 const CustomTabPanel = styled(TabPanel)(({ theme }) => ({
@@ -144,41 +145,23 @@ const PipelineSettingsView: React.FC = () => {
     envVariables,
     setEnvVariables,
     pipelinePath,
+    setPipelinePath,
+    services,
+    setServices,
+    settings,
+    setSettings,
     pipelineJson,
-    setPipelineJson,
+    pipelineName,
+    setPipelineName,
+    inputParameters,
+    setInputParameters,
   } = useFetchPipelineMetadata({ projectUuid, pipelineUuid, jobUuid, runUuid });
 
-  React.useEffect(() => {
-    if (pipelineJson) {
-      dispatch({
-        type: "pipelineSet",
-        payload: {
-          pipelineUuid,
-          projectUuid,
-          pipelineName: pipelineJson.name,
-        },
-      });
-    }
-  }, [pipelineJson, pipelineUuid, projectUuid, dispatch]);
-
   // local states
-  const [inputParameters, setInputParameters] = React.useState<string>(
-    JSON.stringify({}, null, 2)
-  );
 
-  React.useEffect(() => {
-    if (pipelineJson) {
-      setInputParameters(JSON.stringify(pipelineJson.parameters));
-      dispatch({
-        type: "pipelineSet",
-        payload: {
-          pipelineUuid,
-          projectUuid,
-          pipelineName: pipelineJson.name,
-        },
-      });
-    }
-  }, [pipelineJson, pipelineUuid, projectUuid, dispatch]);
+  const allServiceNames = React.useMemo(() => {
+    return new Set(Object.values(services || {}).map((s) => s.name));
+  }, [services]);
 
   const [tabIndex, setTabIndex] = React.useState<number>(
     tabMapping[initialTab] || 0 // note that initialTab can be 'null' since it's a querystring
@@ -199,45 +182,24 @@ const PipelineSettingsView: React.FC = () => {
     setEnvVarsChanged(false);
   }
 
-  const promiseManagerRef = React.useRef(new PromiseManager());
+  const promiseManager = React.useMemo(() => new PromiseManager(), []);
 
   const hasLoaded =
     pipelineJson && envVariables && (isReadOnly || projectEnvVariables);
 
   // If the component has loaded, attach the resize listener
-  const overflowListener = React.useRef(new OverflowListener());
+  const overflowListener = React.useMemo(() => new OverflowListener(), []);
   React.useEffect(() => {
     if (hasLoaded) {
-      overflowListener.current.attach();
+      overflowListener.attach();
     }
-  }, [hasLoaded]);
-
-  const addServiceFromTemplate = (service: ServiceTemplate["config"]) => {
-    let clonedService = cloneDeep(service);
-
-    const services = pipelineJson?.services || {};
-
-    const allNames = new Set(Object.values(services).map((s) => s.name));
-
-    let count = 0;
-    // assuming that user won't have more than 100 instances of the same service
-    while (count < 100) {
-      const newName = `${clonedService.name}${count === 0 ? "" : count}`;
-      if (!allNames.has(newName)) {
-        clonedService.name = newName;
-        break;
-      }
-      count += 1;
-    }
-
-    onChangeService(uuidv4(), clonedService);
-  };
+  }, [hasLoaded, overflowListener]);
 
   const onChangeService = (uuid: string, service: Service) => {
-    setPipelineJson((current) => {
+    setServices((current) => {
       // Maintain client side order key
       if (service.order === undefined) service.order = getOrderValue();
-      current.services[uuid] = service;
+      current[uuid] = service;
       return current;
     });
 
@@ -245,10 +207,10 @@ const PipelineSettingsView: React.FC = () => {
     setAsSaved(false);
   };
 
-  const deleteService = async (serviceName: string) => {
-    setPipelineJson((current) => {
-      delete current.services[serviceName];
-      return current;
+  const deleteService = async (serviceUuid: string) => {
+    setServices((current) => {
+      const { [serviceUuid]: serviceToRemove, ...remainder } = current; // eslint-disable-line @typescript-eslint/no-unused-vars
+      return remainder;
     });
 
     setServicesChanged(true);
@@ -275,62 +237,23 @@ const PipelineSettingsView: React.FC = () => {
     });
   };
 
-  const onChangeName = (value: string) => {
-    setPipelineJson((current) => ({ ...current, name: value }));
-    setAsSaved(false);
-  };
-
-  const onChangePipelineParameters = (editor, data, value) => {
+  const onChangePipelineParameters = (editor, data, value: string) => {
     setInputParameters(value);
-
-    try {
-      const parametersJSON = JSON.parse(value);
-      setPipelineJson((current) => ({
-        ...current,
-        parameters: parametersJSON,
-      }));
-
-      setAsSaved(false);
-    } catch (err) {}
   };
 
   const onChangeDataPassingMemorySize = (value: string) => {
-    setPipelineJson((current) => {
-      return {
-        ...current,
-        settings: { ...current.settings, data_passing_memory_size: value },
-      };
+    setSettings((current) => {
+      return { ...current, data_passing_memory_size: value };
     });
-    setAsSaved(false);
   };
 
   const onChangeEviction = (value: boolean) => {
-    setPipelineJson((current) => {
-      return {
-        ...current,
-        settings: { ...current.settings, auto_eviction: value },
-      };
+    setSettings((current) => {
+      return { ...current, auto_eviction: value };
     });
-
-    setAsSaved(false);
   };
 
-  const cleanPipelineJson = (
-    pipelineJson: PipelineJson
-  ): Omit<PipelineJson, "order"> => {
-    let pipelineCopy = cloneDeep(pipelineJson);
-    for (let uuid in pipelineCopy.services) {
-      const serviceName = pipelineCopy.services[uuid].name;
-      delete pipelineCopy.services[uuid].order;
-      pipelineCopy.services[serviceName] = {
-        ...pipelineCopy.services[uuid],
-      };
-      delete pipelineCopy.services[uuid];
-    }
-    return pipelineCopy;
-  };
-
-  const validateServiceEnvironmentVariables = (pipeline: any) => {
+  const validateServiceEnvironmentVariables = (pipeline: PipelineJson) => {
     for (let serviceName in pipeline.services) {
       let service = pipeline.services[serviceName];
 
@@ -351,20 +274,25 @@ const PipelineSettingsView: React.FC = () => {
     return true;
   };
 
-  const saveGeneralForm = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  const saveGeneralForm = async () => {
+    // do not mutate the original pipelineJson
+    // put all mutations together for saving
+    const updatedPipelineJson = generatePipelineJsonForSaving({
+      pipelineJson,
+      inputParameters,
+      pipelineName,
+      services,
+      settings,
+    });
 
-    // Remove order property from services
-    let cleanedPipelineJson = cleanPipelineJson(pipelineJson);
-
-    let validationResult = validatePipeline(cleanedPipelineJson);
+    let validationResult = validatePipeline(updatedPipelineJson);
     if (!validationResult.valid) {
       setAlert("Error", validationResult.errors[0]);
       return;
     }
 
     // Validate environment variables of services
-    if (!validateServiceEnvironmentVariables(cleanedPipelineJson)) {
+    if (!validateServiceEnvironmentVariables(updatedPipelineJson)) {
       return;
     }
 
@@ -389,7 +317,7 @@ const PipelineSettingsView: React.FC = () => {
     }
 
     let formData = new FormData();
-    formData.append("pipeline_json", JSON.stringify(cleanedPipelineJson));
+    formData.append("pipeline_json", JSON.stringify(updatedPipelineJson));
 
     Promise.allSettled([
       makeRequest(
@@ -403,7 +331,7 @@ const PipelineSettingsView: React.FC = () => {
             // Sync name changes with the global context
             dispatch({
               type: "pipelineSet",
-              payload: { pipelineName: pipelineJson?.name },
+              payload: { pipelineName },
             });
           }
         })
@@ -418,7 +346,10 @@ const PipelineSettingsView: React.FC = () => {
         }),
       makeRequest("PUT", `/async/pipelines/${projectUuid}/${pipelineUuid}`, {
         type: "json",
-        content: { env_variables: envVariablesObj.value },
+        content: {
+          env_variables: envVariablesObj.value,
+          path: !session ? pipelinePath : undefined, // path cannot be changed when there is an active session
+        },
       }).catch((response) => {
         setAlert("Error", "Could not save: environment variables");
         console.error(response);
@@ -440,7 +371,7 @@ const PipelineSettingsView: React.FC = () => {
           "PUT",
           `/catch/api-proxy/api/sessions/${projectUuid}/${pipelineUuid}`
         ),
-        promiseManagerRef.current
+        promiseManager
       );
 
       restartPromise.promise
@@ -514,9 +445,7 @@ const PipelineSettingsView: React.FC = () => {
     },
   ];
 
-  const serviceRows: DataTableRow<ServiceRow>[] = Object.entries(
-    pipelineJson?.services || {}
-  )
+  const serviceRows: DataTableRow<ServiceRow>[] = Object.entries(services)
     .sort((a, b) => a[1].order - b[1].order)
     .map(([key, service]) => {
       return {
@@ -531,7 +460,7 @@ const PipelineSettingsView: React.FC = () => {
             key={key}
             serviceUuid={key}
             service={service}
-            services={pipelineJson.services}
+            services={services}
             disabled={isReadOnly}
             updateService={(updated) => onChangeService(key, updated)}
             pipeline_uuid={pipelineUuid}
@@ -599,10 +528,10 @@ const PipelineSettingsView: React.FC = () => {
                       </div>
                       <div className="column">
                         <TextField
-                          value={pipelineJson?.name}
+                          value={pipelineName}
                           margin="normal"
                           multiline
-                          onChange={(e) => onChangeName(e.target.value)}
+                          onChange={(e) => setPipelineName(e.target.value)}
                           label="Pipeline name"
                           disabled={isReadOnly}
                           fullWidth
@@ -617,11 +546,21 @@ const PipelineSettingsView: React.FC = () => {
                         <h3>Path</h3>
                       </div>
                       <div className="column">
-                        <Box sx={{ width: "100%" }}>
-                          <Code sx={{ wordBreak: "break-word" }}>
-                            {pipelinePath}
-                          </Code>
-                        </Box>
+                        <TextField
+                          value={pipelinePath}
+                          margin="normal"
+                          multiline
+                          onChange={(e) => setPipelinePath(e.target.value)}
+                          label="Pipeline path"
+                          disabled={isReadOnly || hasValue(session)}
+                          helperText={
+                            session
+                              ? "You need to stop session before changing pipeline path"
+                              : ""
+                          }
+                          fullWidth
+                          data-test-id="pipeline-settings-configuration-pipeline-path"
+                        />
                       </div>
                       <div className="clear"></div>
                     </div>
@@ -860,9 +799,13 @@ const PipelineSettingsView: React.FC = () => {
                   </CustomAlert>
                   {!isReadOnly && (
                     <ServiceTemplatesDialog
-                      onSelection={(template) =>
-                        addServiceFromTemplate(template)
-                      }
+                      onSelection={(template) => {
+                        const newService = instantiateNewService(
+                          allServiceNames,
+                          template
+                        );
+                        onChangeService(uuidv4(), newService);
+                      }}
                     />
                   )}
                 </Stack>

--- a/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
@@ -1,3 +1,8 @@
+import { ServiceTemplate } from "@/components/ServiceTemplatesDialog/content";
+import type { PipelineJson, PipelineSettings, Service } from "@/types";
+import "codemirror/mode/javascript/javascript";
+import cloneDeep from "lodash.clonedeep";
+
 export const getOrderValue = () => {
   const lsKey = "_monotonic_getOrderValue";
   // returns monotinically increasing digit
@@ -7,4 +12,73 @@ export const getOrderValue = () => {
   let value = parseInt(window.localStorage.getItem(lsKey)) + 1;
   window.localStorage.setItem(lsKey, value + "");
   return value;
+};
+
+export const instantiateNewService = (
+  allNames: Set<string>,
+  service: ServiceTemplate["config"]
+) => {
+  let clonedService = cloneDeep(service);
+
+  let count = 0;
+  // assuming that user won't have more than 100 instances of the same service
+  while (count < 100) {
+    const newName = `${clonedService.name}${count === 0 ? "" : count}`;
+    if (!allNames.has(newName)) {
+      clonedService.name = newName;
+      break;
+    }
+    count += 1;
+  }
+  return clonedService;
+};
+
+export const parseJsonString = (str: string) => {
+  try {
+    const json = JSON.parse(str);
+    return json;
+  } catch (err) {
+    return null;
+  }
+};
+
+export const cleanPipelineJson = (
+  pipelineJson: PipelineJson
+): Omit<PipelineJson, "order"> => {
+  let pipelineCopy = cloneDeep(pipelineJson);
+  for (let uuid in pipelineCopy.services) {
+    const serviceName = pipelineCopy.services[uuid].name;
+    delete pipelineCopy.services[uuid].order;
+    pipelineCopy.services[serviceName] = {
+      ...pipelineCopy.services[uuid],
+    };
+    delete pipelineCopy.services[uuid];
+  }
+  return pipelineCopy;
+};
+
+export const generatePipelineJsonForSaving = ({
+  pipelineJson,
+  inputParameters,
+  pipelineName,
+  services,
+  settings,
+}: {
+  pipelineJson: PipelineJson;
+  inputParameters: string;
+  pipelineName: string;
+  services: Record<string, Service>;
+  settings: PipelineSettings;
+}): PipelineJson => {
+  if (!pipelineJson) return null;
+  const parameters = parseJsonString(inputParameters);
+
+  // Remove order property from services
+  return cleanPipelineJson({
+    ...pipelineJson,
+    name: pipelineName,
+    parameters: parameters || pipelineJson.parameters,
+    services,
+    settings,
+  });
 };

--- a/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineMetadata.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineMetadata.ts
@@ -42,11 +42,13 @@ export const useFetchPipelineMetadata = ({
     runUuid,
   });
 
+  /**
+   * Update ProjectsContext
+   */
   const initialized = React.useRef(false);
   React.useEffect(() => {
     if (!initialized.current && pipelineJson) {
       initialized.current = true;
-      // initialize all local states
       dispatch({
         type: "pipelineSet",
         payload: {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineEnvVariables.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineEnvVariables.tsx
@@ -1,0 +1,43 @@
+import { EnvVarPair } from "@/components/EnvVarList";
+import { useAppContext } from "@/contexts/AppContext";
+import { Pipeline, PipelineRun } from "@/types";
+import { envVariablesDictToArray } from "@/utils/webserver-utils";
+import React from "react";
+
+export const usePipelineEnvVariables = (
+  pipeline: Pipeline | undefined,
+  pipelineRun: PipelineRun | undefined
+) => {
+  const { setAsSaved } = useAppContext();
+
+  // Environment variables are fetched either from 1) pipeline 2) pipeline run
+  const [envVariables, _setEnvVariables] = React.useState<EnvVarPair[]>([]);
+
+  const fetchedEnvVariables = React.useMemo(() => {
+    if (pipeline || pipelineRun) {
+      return pipeline
+        ? pipeline.env_variables
+        : pipelineRun
+        ? pipelineRun.env_variables
+        : {};
+    }
+    return null;
+  }, [pipeline, pipelineRun]);
+
+  React.useEffect(() => {
+    if (fetchedEnvVariables) {
+      const envVarArray = envVariablesDictToArray(fetchedEnvVariables);
+      _setEnvVariables(envVarArray);
+    }
+  }, [fetchedEnvVariables]);
+
+  const setEnvVariables = React.useCallback(
+    (data: React.SetStateAction<EnvVarPair[]>) => {
+      _setEnvVariables(data);
+      setAsSaved(false);
+    },
+    [_setEnvVariables, setAsSaved]
+  );
+
+  return { envVariables, setEnvVariables };
+};

--- a/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineProperty.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineProperty.tsx
@@ -1,0 +1,29 @@
+import { useAppContext } from "@/contexts/AppContext";
+import React from "react";
+
+/**
+ * a generic hook that is used to persist mutations of properties of PipelineJson
+ */
+export function usePipelineProperty<T>(initialValue: T, fallbackValue?: T) {
+  const { setAsSaved } = useAppContext();
+
+  const [pipelineProperty, _setPipelineProperty] = React.useState<T>(undefined);
+  const isNameInitialized = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!isNameInitialized.current && initialValue) {
+      isNameInitialized.current = true;
+      _setPipelineProperty(initialValue);
+    }
+  }, [initialValue, _setPipelineProperty]);
+
+  const setPipelineProperty = React.useCallback(
+    (value: React.SetStateAction<T>) => {
+      _setPipelineProperty(value);
+      setAsSaved(false);
+    },
+    [_setPipelineProperty, setAsSaved]
+  );
+
+  return [pipelineProperty || fallbackValue, setPipelineProperty] as const;
+}

--- a/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
@@ -52,8 +52,8 @@ export const CreateNextStepButton = ({
           incoming_connections: [],
           file_path: "",
           kernel: {
-            name: environment?.language,
-            display_name: environment?.name,
+            name: environment?.language || "python",
+            display_name: environment?.name || "Python",
           },
           environment: environment?.uuid,
           parameters: {},

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineActionButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineActionButton.tsx
@@ -1,10 +1,15 @@
 import Button, { ButtonProps } from "@mui/material/Button";
 import React from "react";
 
-export const PipelineActionButton = ({ children, ...props }: ButtonProps) => {
-  return (
-    <Button variant="contained" color="secondary" {...props}>
-      {children}
-    </Button>
-  );
-};
+export const PipelineActionButton = React.forwardRef(
+  function PipelineActionButtonComponent(
+    { children, ...props }: ButtonProps,
+    ref: React.MutableRefObject<HTMLButtonElement>
+  ) {
+    return (
+      <Button ref={ref} variant="contained" color="secondary" {...props}>
+        {children}
+      </Button>
+    );
+  }
+);

--- a/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
@@ -1,5 +1,6 @@
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { siteMap } from "@/Routes";
+import { Service } from "@/types";
 import { getServiceURLs } from "@/utils/webserver-utils";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import TuneIcon from "@mui/icons-material/Tune";
@@ -29,11 +30,7 @@ export const ServicesMenu = ({
   anchor: React.MutableRefObject<Element>;
   services: Record<
     string,
-    {
-      ports: number[];
-      preserve_base_path: string;
-      name: string;
-    }
+    Pick<Service, "ports" | "preserve_base_path" | "name">
   > | null;
 }) => {
   const {

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -340,13 +340,15 @@ export type PipelineMetaData = {
   name: string;
 };
 
+export type PipelineSettings = {
+  auto_eviction?: boolean;
+  data_passing_memory_size?: string;
+};
+
 export type PipelineJson = {
   name: string;
   parameters: Record<string, Json>;
-  settings: {
-    auto_eviction?: boolean;
-    data_passing_memory_size?: string;
-  };
+  settings: PipelineSettings;
   steps: Record<string, Step>;
   uuid: string;
   version: string;


### PR DESCRIPTION
## Description

When editing Pipeline Settings, user loses their changes if they switch to other browser tabs and come back. This PR persists the changes as subsets of the whole Pipeline settings object. This PR also makes it possible to edit Pipeline Path in Pipeline Settings view. 

Fixes: #729, #770 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
