### PR TITLE
Fix highlighting navigation item "Jobs" when viewing the pipeline of a job run

### DIFF
--- a/services/orchest-webserver/client/src/components/MainDrawer.tsx
+++ b/services/orchest-webserver/client/src/components/MainDrawer.tsx
@@ -125,7 +125,7 @@ export const AppDrawer: React.FC<{ isOpen?: boolean }> = ({ isOpen }) => {
   const location = useLocation();
   const pathname = location.pathname;
 
-  const { navigateTo } = useCustomRoute();
+  const { navigateTo, jobUuid, runUuid } = useCustomRoute();
 
   const projectMenuItems = getProjectMenuItems(projectUuid);
 
@@ -140,8 +140,17 @@ export const AppDrawer: React.FC<{ isOpen?: boolean }> = ({ isOpen }) => {
 
   const isSelected = (path: string, exact = false) => {
     const route = routes.find((route) => route.path === pathname);
+
+    // this is a special case, we use "/pipeline" to present the pipeline of a job run
+    // this means that user is still viewing a job, so "/jobs" should be selected
+    const isJobRun = pathname === "/pipeline" && jobUuid && runUuid;
+
+    const pathToMatch = isJobRun
+      ? "/jobs"
+      : route?.root || route?.path || pathname;
+
     return (
-      matchPath(route?.root || route?.path || pathname, {
+      matchPath(pathToMatch, {
         path: path.split("?")[0],
         exact,
       }) !== null

--- a/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
@@ -52,8 +52,8 @@ export const CreateNextStepButton = ({
           incoming_connections: [],
           file_path: "",
           kernel: {
-            name: environment?.language,
-            display_name: environment?.name,
+            name: environment?.language || "python",
+            display_name: environment?.name || "Python",
           },
           environment: environment?.uuid,
           parameters: {},


### PR DESCRIPTION
## Description

Currently if user is viewing the pipeline of a job run, the navigation item "Jobs", instead of "Pipelines", shouldn't be highlighted. 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
