### PR TITLE
Show Project Selector in deeper levels of the UI

### DIFF
--- a/services/base-images/runnable-shared/runner/requirements-dev.txt
+++ b/services/base-images/runnable-shared/runner/requirements-dev.txt
@@ -1,6 +1,6 @@
-nbformat
-nbconvert
-IPython
-ipykernel
+ipykernel==6.6.0
+ipython==7.31.1
+nbconvert==6.3.0
+nbformat==5.1.3
 pytest
 -e ../../../../lib/python/orchest-internals

--- a/services/orchest-webserver/client/src/components/HeaderBar.tsx
+++ b/services/orchest-webserver/client/src/components/HeaderBar.tsx
@@ -22,7 +22,7 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import { useLocation, useRouteMatch } from "react-router-dom";
 import { IconButton } from "./common/IconButton";
-import ProjectSelector from "./ProjectSelector";
+import { ProjectSelector } from "./ProjectSelector";
 import SessionToggleButton from "./SessionToggleButton";
 
 export const HeaderBar = ({

--- a/services/orchest-webserver/client/src/components/MainDrawer.tsx
+++ b/services/orchest-webserver/client/src/components/MainDrawer.tsx
@@ -140,14 +140,7 @@ export const AppDrawer: React.FC<{ isOpen?: boolean }> = ({ isOpen }) => {
 
   const isSelected = (path: string, exact = false) => {
     const route = routes.find((route) => route.path === pathname);
-
-    // this is a special case, we use "/pipeline" to present the pipeline of a job run
-    // this means that user is still viewing a job, so "/jobs" should be selected
-    const isJobRun = pathname === "/pipeline" && jobUuid && runUuid;
-
-    const pathToMatch = isJobRun
-      ? "/jobs"
-      : route?.root || route?.path || pathname;
+    const pathToMatch = route?.root || route?.path || pathname;
 
     return (
       matchPath(pathToMatch, {

--- a/services/orchest-webserver/client/src/hooks/useMatchProjectRoot.ts
+++ b/services/orchest-webserver/client/src/hooks/useMatchProjectRoot.ts
@@ -1,31 +1,26 @@
-import { siteMap } from "@/routingConfig";
+import { RouteData } from "@/routingConfig";
 import React from "react";
 import { matchPath } from "react-router-dom";
 import { useHistoryListener } from "./useCustomRoute";
 
-const projectRootPaths = [
-  siteMap.jobs.path,
-  siteMap.environments.path,
-  siteMap.pipelines.path,
-];
-
-const findRouteMatch = (paths: string[]) => {
-  for (const path of paths) {
+const findRouteMatch = (routes: Pick<RouteData, "path" | "root">[]) => {
+  for (const route of routes) {
     const match = matchPath(window.location.pathname, {
-      path,
+      path: route.path,
       exact: true,
     });
-    if (match) return match;
+    if (match) return route;
   }
   return null;
 };
 
-const useMatchProjectRoot = () => {
-  const [match, setMatch] = React.useState(findRouteMatch(projectRootPaths));
-  const findRootMatch = () => {
-    const found = findRouteMatch(projectRootPaths);
+const useMatchRoutePaths = (routes: Pick<RouteData, "path" | "root">[]) => {
+  const routesRef = React.useRef(routes);
+  const [match, setMatch] = React.useState(findRouteMatch(routesRef.current));
+  const findRootMatch = React.useCallback(() => {
+    const found = findRouteMatch(routesRef.current);
     setMatch(found);
-  };
+  }, [routesRef]);
   useHistoryListener({
     forward: findRootMatch,
     backward: findRootMatch,
@@ -34,4 +29,4 @@ const useMatchProjectRoot = () => {
   return match;
 };
 
-export { useMatchProjectRoot, projectRootPaths, findRouteMatch };
+export { useMatchRoutePaths };

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -44,7 +44,7 @@ type RouteName =
   | "help"
   | "notFound";
 
-type RouteData = {
+export type RouteData = {
   path: string;
   root?: string;
   component: React.FunctionComponent;
@@ -218,6 +218,34 @@ export const siteMap = getOrderedRoutes().reduce<Record<RouteName, RouteData>>(
   }),
   {} as Record<RouteName, RouteData>
 );
+
+export const projectRootPaths = [
+  siteMap.jobs.path,
+  siteMap.environments.path,
+  siteMap.pipelines.path,
+];
+
+export const withinProjectPaths = getOrderedRoutes().reduce<
+  Pick<RouteData, "path" | "root">[]
+>((all, curr) => {
+  // only include within-project paths
+  // i.e. if the context involves multiple projects, it should be excluded
+  if (
+    projectRootPaths.includes(curr.path) ||
+    projectRootPaths.includes(curr.root) ||
+    curr.path === "/project"
+    // projectsPaths.includes(curr.path)
+  ) {
+    return [
+      ...all,
+      {
+        path: curr.path,
+        root: curr.root,
+      },
+    ];
+  }
+  return all;
+}, [] as Pick<RouteData, "path" | "root">[]);
 
 const snakeCase = (str: string, divider = "_") =>
   str


### PR DESCRIPTION
## Description

Currently Project Selector only appears in `/pipelines`, `/environments`, and `/jobs`, but not in the views at a deeper level, such as `/job`. It's very confusing especially when user have jobs/pipelines with the same name across projects. 

To make it clearer which project user is working on, this PR make ProjectSelector visible as long as the current view is within one project.

Current UI logic: if user switches projects while viewing "Jobs", the view stays at Jobs, e.g. from Project A Jobs -> Project B Jobs. This PR follows the same rationale, see the following example:

Viewing a job in project A, switch to project B, viewing the jobs of project B.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
