### PR TITLE
Add route /job-run

### DIFF
--- a/services/orchest-webserver/client/src/job-view/PipelineRunTable.tsx
+++ b/services/orchest-webserver/client/src/job-view/PipelineRunTable.tsx
@@ -160,7 +160,7 @@ export const PipelineRunTable: React.FC<{
     }
 
     navigateTo(
-      siteMap.pipeline.path,
+      siteMap.jobRun.path,
       {
         query: {
           projectUuid: pipelineRun.project_uuid,

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -15,6 +15,7 @@ import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
+import { useIsReadOnly } from "@/pipeline-view/hooks/useIsReadOnly";
 import { siteMap } from "@/Routes";
 import type {
   PipelineJson,
@@ -136,8 +137,13 @@ const PipelineSettingsView: React.FC = () => {
 
   const { getSession } = useSessionsContext();
 
-  const isReadOnly =
-    (hasValue(runUuid) && hasValue(jobUuid)) || isReadOnlyFromQueryString;
+  const isJobRun = hasValue(jobUuid && runUuid);
+  const isReadOnly = useIsReadOnly(
+    projectUuid,
+    jobUuid,
+    runUuid,
+    isJobRun || isReadOnlyFromQueryString
+  );
 
   // Fetching data
   const {
@@ -226,7 +232,7 @@ const PipelineSettingsView: React.FC = () => {
   };
 
   const closeSettings = () => {
-    navigateTo(siteMap.pipeline.path, {
+    navigateTo(isJobRun ? siteMap.jobRun.path : siteMap.pipeline.path, {
       query: {
         projectUuid,
         pipelineUuid,

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -15,7 +15,6 @@ import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useIsReadOnly } from "@/pipeline-view/hooks/useIsReadOnly";
 import { siteMap } from "@/Routes";
 import type {
   PipelineJson,
@@ -138,12 +137,7 @@ const PipelineSettingsView: React.FC = () => {
   const { getSession } = useSessionsContext();
 
   const isJobRun = hasValue(jobUuid && runUuid);
-  const isReadOnly = useIsReadOnly(
-    projectUuid,
-    jobUuid,
-    runUuid,
-    isJobRun || isReadOnlyFromQueryString
-  );
+  const isReadOnly = isJobRun || isReadOnlyFromQueryString;
 
   // Fetching data
   const {

--- a/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
@@ -31,12 +31,14 @@ import ListSubheader from "@mui/material/ListSubheader";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import {
+  hasValue,
   makeCancelable,
   makeRequest,
   PromiseManager,
 } from "@orchest/lib-utils";
 import React from "react";
 import io from "socket.io-client";
+import { useIsReadOnly } from "./hooks/useIsReadOnly";
 
 export type ILogsViewProps = TViewPropsWithRequiredQueryArgs<
   "pipeline_uuid" | "project_uuid"
@@ -54,11 +56,19 @@ const LogsView: React.FC = () => {
     pipelineUuid,
     jobUuid,
     runUuid,
-    isReadOnly,
+    isReadOnly: isReadOnlyFromQueryString,
     navigateTo,
   } = useCustomRoute();
 
   const { getSession } = useSessionsContext();
+
+  const isJobRun = hasValue(jobUuid && runUuid);
+  useIsReadOnly(
+    projectUuid,
+    jobUuid,
+    runUuid,
+    isJobRun || isReadOnlyFromQueryString
+  );
 
   const [promiseManager] = React.useState(new PromiseManager());
 
@@ -214,14 +224,13 @@ const LogsView: React.FC = () => {
   };
 
   const close = () => {
-    navigateTo(siteMap.pipeline.path, {
+    navigateTo(isJobRun ? siteMap.jobRun.path : siteMap.pipeline.path, {
       query: {
         projectUuid,
         pipelineUuid,
         jobUuid,
         runUuid,
       },
-      state: { isReadOnly },
     });
   };
 

--- a/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
@@ -38,7 +38,6 @@ import {
 } from "@orchest/lib-utils";
 import React from "react";
 import io from "socket.io-client";
-import { useIsReadOnly } from "./hooks/useIsReadOnly";
 
 export type ILogsViewProps = TViewPropsWithRequiredQueryArgs<
   "pipeline_uuid" | "project_uuid"
@@ -56,19 +55,12 @@ const LogsView: React.FC = () => {
     pipelineUuid,
     jobUuid,
     runUuid,
-    isReadOnly: isReadOnlyFromQueryString,
     navigateTo,
   } = useCustomRoute();
 
   const { getSession } = useSessionsContext();
 
   const isJobRun = hasValue(jobUuid && runUuid);
-  useIsReadOnly(
-    projectUuid,
-    jobUuid,
-    runUuid,
-    isJobRun || isReadOnlyFromQueryString
-  );
 
   const [promiseManager] = React.useState(new PromiseManager());
 

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -239,7 +239,9 @@ export const PipelineEditor: React.FC = () => {
 
   const openSettings = (e: React.MouseEvent) => {
     navigateTo(
-      siteMap.pipelineSettings.path,
+      isJobRun
+        ? siteMap.jobRunPipelineSettings.path
+        : siteMap.pipelineSettings.path,
       {
         query: {
           projectUuid,
@@ -254,7 +256,7 @@ export const PipelineEditor: React.FC = () => {
 
   const openLogs = (e: React.MouseEvent) => {
     navigateTo(
-      siteMap.logs.path,
+      isJobRun ? siteMap.jobRunLogs.path : siteMap.logs.path,
       {
         query: {
           projectUuid,

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -272,7 +272,7 @@ export const PipelineEditor: React.FC = () => {
   const onOpenFilePreviewView = React.useCallback(
     (e: React.MouseEvent, stepUuid: string) => {
       navigateTo(
-        siteMap.filePreview.path,
+        isJobRun ? siteMap.jobRunFilePreview.path : siteMap.filePreview.path,
         {
           query: {
             projectUuid,

--- a/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
@@ -13,6 +13,7 @@ import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import Menu from "@mui/material/Menu";
 import Typography from "@mui/material/Typography";
+import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 
 const formatUrl = (url: string) => {
@@ -42,9 +43,13 @@ export const ServicesMenu = ({
     navigateTo,
   } = useCustomRoute();
 
+  const isJobRun = hasValue(jobUuid && runUuid);
+
   const openSettings = (e: React.MouseEvent) => {
     navigateTo(
-      siteMap.pipelineSettings.path,
+      isJobRun
+        ? siteMap.jobRunPipelineSettings.path
+        : siteMap.pipelineSettings.path,
       {
         query: {
           projectUuid,

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -7,6 +7,7 @@ import {
   PipelineJson,
   StepsDict,
 } from "@/types";
+import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 import { MutatorCallback } from "swr";
 import { useAutoStartSession } from "../hooks/useAutoStartSession";
@@ -127,11 +128,12 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     runUuidFromRoute
   );
 
+  const isJobRun = hasValue(jobUuid && runUuidFromRoute);
   const isReadOnly = useIsReadOnly(
     projectUuid,
     jobUuid,
     runUuid,
-    isReadOnlyFromQueryString
+    isJobRun || isReadOnlyFromQueryString
   );
 
   const {

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -1,4 +1,5 @@
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { useForceUpdate } from "@/hooks/useForceUpdate";
 import {
   Environment,
   IOrchestSession,
@@ -166,6 +167,19 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     document.body.addEventListener("mousemove", startTracking);
     return () => document.body.removeEventListener("mousemove", startTracking);
   }, [trackMouseMovement]);
+
+  // in read-only mode, PipelineEditor doesn't re-render after stepDomRefs collects all DOM elements of the steps
+  // we need to force re-render one more time to show the connection lines
+  const shouldForceRerender =
+    isReadOnly &&
+    eventVars.connections.length > 0 &&
+    Object.keys(stepDomRefs.current).length === 0;
+
+  const [, forceUpdate] = useForceUpdate();
+
+  React.useLayoutEffect(() => {
+    if (shouldForceRerender) forceUpdate();
+  }, [shouldForceRerender, forceUpdate]);
 
   return (
     <PipelineEditorContext.Provider

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
@@ -12,18 +12,14 @@ export const useIsReadOnly = (
   const { dispatch } = useProjectsContext();
   const { requestBuild } = useAppContext();
 
-  const [isReadOnly, _setIsReadOnly] = React.useState(initialValue);
+  const [isReadOnly, setIsReadOnly] = React.useState(initialValue);
 
-  const setIsReadOnly = React.useCallback(
-    (readOnly: boolean) => {
-      dispatch({
-        type: "SET_PIPELINE_IS_READONLY",
-        payload: readOnly,
-      });
-      _setIsReadOnly(readOnly);
-    },
-    [dispatch]
-  );
+  React.useEffect(() => {
+    dispatch({
+      type: "SET_PIPELINE_IS_READONLY",
+      payload: isReadOnly,
+    });
+  }, [dispatch, isReadOnly]);
 
   const hasActiveRun = runUuid && jobUuid;
   const isNonPipelineRun = !hasActiveRun && isReadOnly;

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
@@ -224,7 +224,7 @@ const StepDetailsComponent: React.FC<{
             onClick={(e) => onOpenFilePreviewView(e, step.uuid)}
             onAuxClick={(e) => onOpenFilePreviewView(e, step.uuid)}
             data-test-id="step-view-file"
-            disabled={!fileExists}
+            disabled={!isReadOnly && !fileExists} // file exists endpoint doesn't consider job runs
           >
             View file
           </Button>

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -37,6 +37,7 @@ type RouteName =
   | "jobRun"
   | "jobRunPipelineSettings"
   | "jobRunLogs"
+  | "jobRunFilePreview"
   | "pipelineReadonly"
   | "editJob"
   | "fileManager"
@@ -172,6 +173,13 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
       root: "/jobs",
       title: getTitle("Job Run Logs"),
       component: LogsView,
+    },
+    {
+      name: "jobRunFilePreview",
+      path: "/job-run/file-preview",
+      root: "/jobs",
+      title: getTitle("Job Run Step File Preview"),
+      component: FilePreviewView,
     },
     {
       name: "editJob",

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -35,6 +35,8 @@ type RouteName =
   | "jobs"
   | "job"
   | "jobRun"
+  | "jobRunPipelineSettings"
+  | "jobRunLogs"
   | "pipelineReadonly"
   | "editJob"
   | "fileManager"
@@ -156,6 +158,20 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
       root: "/jobs",
       title: getTitle("Job Run"),
       component: PipelineView,
+    },
+    {
+      name: "jobRunPipelineSettings",
+      path: "/job-run/pipeline-settings",
+      root: "/jobs",
+      title: getTitle("Job Run Pipeline Settings"),
+      component: PipelineSettingsView,
+    },
+    {
+      name: "jobRunLogs",
+      path: "/job-run/logs",
+      root: "/jobs",
+      title: getTitle("Job Run Logs"),
+      component: LogsView,
     },
     {
       name: "editJob",

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -34,6 +34,7 @@ type RouteName =
   | "environment"
   | "jobs"
   | "job"
+  | "jobRun"
   | "pipelineReadonly"
   | "editJob"
   | "fileManager"
@@ -148,6 +149,13 @@ export const getOrderedRoutes = (getTitle?: (props: unknown) => string) => {
       root: "/jobs",
       title: getTitle("Job"),
       component: JobView,
+    },
+    {
+      name: "jobRun",
+      path: "/job-run",
+      root: "/jobs",
+      title: getTitle("Job Run"),
+      component: PipelineView,
     },
     {
       name: "editJob",

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -4,7 +4,6 @@ import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
-import { useIsReadOnly } from "@/pipeline-view/hooks/useIsReadOnly";
 import { siteMap } from "@/Routes";
 import {
   getPipelineJSONEndpoint,
@@ -49,10 +48,11 @@ const FilePreviewView: React.FC = () => {
     stepUuid,
     jobUuid,
     runUuid,
+    isReadOnly: isReadOnlyFromQueryString,
   } = useCustomRoute();
 
   const isJobRun = hasValue(jobUuid && runUuid);
-  const isReadOnly = useIsReadOnly(projectUuid, jobUuid, runUuid, isJobRun);
+  const isReadOnly = isJobRun || isReadOnlyFromQueryString;
 
   // local states
   const [state, setState] = React.useState({

--- a/services/orchest-webserver/client/src/views/JobRunView.tsx
+++ b/services/orchest-webserver/client/src/views/JobRunView.tsx
@@ -1,0 +1,23 @@
+import { Layout } from "@/components/Layout";
+import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
+import React from "react";
+import { PipelineCanvasContextProvider } from "../pipeline-view/contexts/PipelineCanvasContext";
+import { PipelineEditorContextProvider } from "../pipeline-view/contexts/PipelineEditorContext";
+import { PipelineEditor } from "../pipeline-view/PipelineEditor";
+import { siteMap } from "../Routes";
+
+const PipelineView: React.FC = () => {
+  useSendAnalyticEvent("view load", { name: siteMap.jobRun.path });
+
+  return (
+    <Layout disablePadding>
+      <PipelineEditorContextProvider>
+        <PipelineCanvasContextProvider>
+          <PipelineEditor />
+        </PipelineCanvasContextProvider>
+      </PipelineEditorContextProvider>
+    </Layout>
+  );
+};
+
+export default PipelineView;


### PR DESCRIPTION
## Description

Currently `/pipeline` is used both for editing a pipeline and viewing a read-only pipeline of a job run. This causes quite a few bugs. For example, the root view while viewing a job run becomes `/pipelines`, where it should have been `/jobs`. And read-only state might be reset when user refreshes the page.

This PR creates a new route: `/job-run` and re-use the same component PipelineEditor. `/job-run` shows the pipeline always in the read-only mode, and its root view is `/jobs`. 

Edit: because this PR remove the unnecessary re-rendering. PipelineEditor in read-only mode has missing connection lines until first session polling response. Thus, this PR also fixes this issue.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
