### PR TITLE
Fix read-only bugs in Pipeline Editor

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -408,11 +408,6 @@ export const PipelineEditor: React.FC = () => {
     [eventVars.openedStep, notebookFilePath, openNotebook, pipelineCwd]
   );
 
-  // const centerView = React.useCallback(() => {
-  //   resetPipelineCanvas();
-  //   dispatch({ type: "SET_SCALE_FACTOR", payload: DEFAULT_SCALE_FACTOR });
-  // }, [dispatch, resetPipelineCanvas]);
-
   const recalibrate = React.useCallback(() => {
     // ensure that connections are re-rendered against the final positions of the steps
     setPipelineJson((value) => value, true);

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -1,4 +1,5 @@
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { useForceUpdate } from "@/hooks/useForceUpdate";
 import {
   Environment,
   IOrchestSession,
@@ -164,6 +165,19 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     document.body.addEventListener("mousemove", startTracking);
     return () => document.body.removeEventListener("mousemove", startTracking);
   }, [trackMouseMovement]);
+
+  // in read-only mode, PipelineEditor doesn't re-render after stepDomRefs collects all DOM elements of the steps
+  // we need to force re-render one more time to show the connection lines
+  const shouldForceRerender =
+    isReadOnly &&
+    eventVars.connections.length > 0 &&
+    Object.keys(stepDomRefs.current).length === 0;
+
+  const [, forceUpdate] = useForceUpdate();
+
+  React.useLayoutEffect(() => {
+    if (shouldForceRerender) forceUpdate();
+  }, [shouldForceRerender, forceUpdate]);
 
   return (
     <PipelineEditorContext.Provider

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
@@ -12,18 +12,14 @@ export const useIsReadOnly = (
   const { dispatch } = useProjectsContext();
   const { requestBuild } = useAppContext();
 
-  const [isReadOnly, _setIsReadOnly] = React.useState(initialValue);
+  const [isReadOnly, setIsReadOnly] = React.useState(initialValue);
 
-  const setIsReadOnly = React.useCallback(
-    (readOnly: boolean) => {
-      dispatch({
-        type: "SET_PIPELINE_IS_READONLY",
-        payload: readOnly,
-      });
-      _setIsReadOnly(readOnly);
-    },
-    [dispatch]
-  );
+  React.useEffect(() => {
+    dispatch({
+      type: "SET_PIPELINE_IS_READONLY",
+      payload: isReadOnly,
+    });
+  }, [dispatch, isReadOnly]);
 
   const hasActiveRun = runUuid && jobUuid;
   const isNonPipelineRun = !hasActiveRun && isReadOnly;

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
@@ -224,7 +224,7 @@ const StepDetailsComponent: React.FC<{
             onClick={(e) => onOpenFilePreviewView(e, step.uuid)}
             onAuxClick={(e) => onOpenFilePreviewView(e, step.uuid)}
             data-test-id="step-view-file"
-            disabled={!fileExists}
+            disabled={!isReadOnly && !fileExists} // file exists endpoint doesn't consider job runs
           >
             View file
           </Button>

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -1,6 +1,7 @@
 import { IconButton } from "@/components/common/IconButton";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
+import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/Routes";
@@ -15,6 +16,7 @@ import RefreshIcon from "@mui/icons-material/Refresh";
 import Button from "@mui/material/Button";
 import LinearProgress from "@mui/material/LinearProgress";
 import {
+  hasValue,
   makeCancelable,
   makeRequest,
   PromiseManager,
@@ -35,6 +37,7 @@ const MODE_MAPPING = {
 const FilePreviewView: React.FC = () => {
   // global states
   const { setAlert } = useAppContext();
+  const { dispatch } = useProjectsContext();
   useSendAnalyticEvent("view load", { name: siteMap.filePreview.path });
 
   // data from route
@@ -48,7 +51,7 @@ const FilePreviewView: React.FC = () => {
     runUuid,
   } = useCustomRoute();
 
-  const isJobRun = jobUuid && runUuid;
+  const isJobRun = hasValue(jobUuid && runUuid);
 
   // local states
   const [state, setState] = React.useState({
@@ -101,6 +104,15 @@ const FilePreviewView: React.FC = () => {
       fetchPipelinePromise.promise
         .then((response) => {
           let pipelineJSON = JSON.parse(JSON.parse(response)["pipeline_json"]);
+
+          dispatch({
+            type: "pipelineSet",
+            payload: {
+              pipelineUuid,
+              projectUuid,
+              pipelineName: pipelineJSON.name,
+            },
+          });
 
           setState((prevState) => ({
             ...prevState,


### PR DESCRIPTION
## Description

Some bug fixes when viewing pipelines in read-only mode.

- allow file preview in read-only mode
- update isReadOnly in ProjectsContext whenever usIsReadOnly is updated
- show pipeline name in FilePreviewView
- sometimes connection lines are not rendered in read-only mode.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
