### PR TITLE
CICD pushes images with version equal to build_tag

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,8 +18,7 @@ jobs:
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      # BUILD_TAG: ${{ github.event.client_payload.build_tag }}
-      BUILD_TAG: "latest"
+      BUILD_TAG: ${{ github.event.client_payload.build_tag }}
 
     strategy:
       matrix:


### PR DESCRIPTION
Leaving the PR here to remind us to update the internal `update-info` repo action.