### PR TITLE
Fix unable to disable auto-clean up in Edit Job view

### DIFF
--- a/services/orchest-webserver/client/src/edit-job-view/EditJobView.tsx
+++ b/services/orchest-webserver/client/src/edit-job-view/EditJobView.tsx
@@ -407,7 +407,7 @@ const EditJobView: React.FC = () => {
       env_variables: updatedEnvVariables.value,
       max_retained_pipeline_runs: isAutoCleanUpEnabled
         ? numberOfRetainedRuns
-        : undefined,
+        : -1,
     };
 
     if (scheduleOption === "scheduled") {
@@ -482,7 +482,7 @@ const EditJobView: React.FC = () => {
             env_variables: updatedEnvVariables.value,
             max_retained_pipeline_runs: isAutoCleanUpEnabled
               ? numberOfRetainedRuns
-              : undefined,
+              : -1,
           }),
         }).then(() => {
           navigateTo(


### PR DESCRIPTION
## Description

Fix the bug that auto-clean-up cannot be disabled.

Fixes: #issue

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
