### PR TITLE
move postgres and rabbitmq dir to userdir pvc

### DIFF
--- a/deploy/helm/charts/postgres/templates/deployment.yaml
+++ b/deploy/helm/charts/postgres/templates/deployment.yaml
@@ -5,10 +5,10 @@ deployment
 {{ include "library.deployment" . }}
     spec:
       volumes:
-        - name: pgdata
-          hostPath:
-            path: /var/lib/orchest/userdir/.orchest/database/data
-            type: DirectoryOrCreate                      
+        - name: userdir-pvc
+          persistentVolumeClaim:
+            claimName: userdir-pvc
+            readOnly: false                    
       containers:
       - name: orchest-database
         image: "{{ .Values.images.registry }}/{{ .Values.images.name }}:{{ .Values.images.tag }}"
@@ -23,8 +23,9 @@ deployment
         - name: "POSTGRES_HOST_AUTH_METHOD"
           value: "trust"
         volumeMounts:
-         - name: pgdata
-           mountPath: /userdir/.orchest/database/data           
+         - name: userdir-pvc
+           mountPath: /userdir/.orchest/database/data
+           subPath: .orchest/database/data
         readinessProbe:
           exec:
             command:

--- a/deploy/helm/charts/rabbitmq/templates/deployment.yaml
+++ b/deploy/helm/charts/rabbitmq/templates/deployment.yaml
@@ -5,10 +5,10 @@ deployment
 {{ include "library.deployment" . }}
     spec:
       volumes:
-        - name: mnesia
-          hostPath:
-            path: /var/lib/orchest/userdir/.orchest/rabbitmq-mnesia
-            type: DirectoryOrCreate                      
+        - name: userdir-pvc
+          persistentVolumeClaim:
+            claimName: userdir-pvc
+            readOnly: false                     
       containers:
       - name: rabbitmq-server
         image: "{{ .Values.images.registry }}/{{ .Values.images.name }}:{{ .Values.images.tag }}"
@@ -18,5 +18,6 @@ deployment
         - containerPort: {{ .Values.service.port }}
         {{ end }}
         volumeMounts:
-         - name: mnesia
+         - name: userdir-pvc
            mountPath: /var/lib/rabbitmq/mnesia
+           subPath: .orchest/rabbitmq-mnesia


### PR DESCRIPTION
## Description

The rabbitmq and postgres volumes were not in userdir pvc

Fixes: #issue

## Checklist

- [ ] The PR branch is set up to merge into `feat/k8s` instead of `master`.
