### PR TITLE
Allow specifying user dir, builder cache and nfs claim size on install.

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -75,6 +75,9 @@ else ifeq (${ROOK_NFS_TARGET},rook-nfs)
   STORAGE_CTL_TARGET := rook-nfs
 endif
 
+USERDIR_PVC_SIZE := ${if ${USERDIR_PVC_SIZE},${USERDIR_PVC_SIZE},50Gi}
+IMAGEBUILDERCACHE_PVC_SIZE := ${if ${IMAGEBUILDERCACHE_PVC_SIZE},${IMAGEBUILDERCACHE_PVC_SIZE},50Gi}
+
 DEBUG := ${if ${DEBUG},--debug --dry-run,}
 
 ORCHEST_LOG_LEVEL := ${if ${ORCHEST_LOG_LEVEL},${ORCHEST_LOG_LEVEL},INFO}
@@ -146,6 +149,8 @@ ORCHEST_RSC_DEPLOY_CONFIG := orchest-resources \
 							${SHARED_DEPLOY_CONFIG}	\
 							${CLUSTER_RSC_ENABLE_CONFIG} \
 							${ORCHEST_RSC_USERDIR_STORAGE} \
+							--set cluster-resources.orchest.userdir.storage="${USERDIR_PVC_SIZE}" \
+							--set cluster-resources.orchest.imagebuildercache.storage="${IMAGEBUILDERCACHE_PVC_SIZE}" \
 							${ORCHEST_RSC_ENABLE_CONFIG} helm
 
 # rook-ceph deplyment configs

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -77,6 +77,7 @@ endif
 
 USERDIR_PVC_SIZE := ${if ${USERDIR_PVC_SIZE},${USERDIR_PVC_SIZE},50Gi}
 IMAGEBUILDERCACHE_PVC_SIZE := ${if ${IMAGEBUILDERCACHE_PVC_SIZE},${IMAGEBUILDERCACHE_PVC_SIZE},50Gi}
+NFS_CLAIM_SIZE := ${if ${NFS_CLAIM_SIZE},${NFS_CLAIM_SIZE},50Gi}
 
 DEBUG := ${if ${DEBUG},--debug --dry-run,}
 
@@ -175,6 +176,7 @@ NFS_RSC_DEPLOY_CONFIG := nfs-resources \
 						${SHARED_DEPLOY_CONFIG}	\
 						${NFS_RSC_STORAGE_CLASS_NAME} \
 						${CLUSTER_RSC_ENABLE_CONFIG} \
+						--set cluster-resources.nfs.nfs.claim.storage="${NFS_CLAIM_SIZE}" \
 						${NFS_RSC_ENABLE_CONFIG} helm
 
 # orchest Api deployment configs

--- a/deploy/helm/charts/cluster-resources/charts/nfs/values.yaml
+++ b/deploy/helm/charts/cluster-resources/charts/nfs/values.yaml
@@ -11,4 +11,4 @@ nfs:
   claim:
     storageClassName: standard
     name: rook-nfs-claim
-    storage: 20Gi
+    storage: 50Gi

--- a/deploy/helm/charts/cluster-resources/charts/orchest/values.yaml
+++ b/deploy/helm/charts/cluster-resources/charts/orchest/values.yaml
@@ -3,7 +3,7 @@ filesystem:
 
 userdir:
   name: userdir-pvc
-  storage: 20Gi
+  storage: 50Gi
 
 config:
   name: config-pvc
@@ -11,5 +11,5 @@ config:
 
 imagebuildercache:
   name: image-builder-cache-pvc
-  storage: 20Gi
+  storage: 50Gi
 

--- a/orchest
+++ b/orchest
@@ -44,6 +44,29 @@ minikube kubectl -- create namespace orchest  > /dev/null 2>&1
 # K8S_TODO: don't silence stderr, and make it so that repeating "make
 # orchest-resources" will not produce an error.
 if [ "$1"  == "install" ]; then
+    WARNING="This can't be changed later."
+    if [ -z "$USERDIR_PVC_SIZE" ]
+    then
+        echo "Specify the user directory size, leave blank for default (50Gi). ${WARNING}" 
+        read -p "Size: " USERDIR_PVC_SIZE
+        export USERDIR_PVC_SIZE
+    fi
+    if [ -z "$IMAGEBUILDERCACHE_PVC_SIZE" ]
+    then
+        echo "Specify the image builder cache size, leave blank for default (50Gi). ${WARNING}" 
+        read -p "Size: " IMAGEBUILDERCACHE_PVC_SIZE
+        export IMAGEBUILDERCACHE_PVC_SIZE
+    fi
+    if [ ! -z "$ENABLE_ROOK_NFS" ]
+    then
+        if [ -z "$NFS_CLAIM_SIZE" ]
+        then
+            echo "Specify the NFS claim size, leave blank for default (50Gi). ${WARNING}" 
+            read -p "Size: " NFS_CLAIM_SIZE
+            export NFS_CLAIM_SIZE
+        fi
+    fi
+
     echo "Creating orchest-namespace and installing dependencies."
     rm -rf "${DIR}/deploy/bin" > /dev/null
     make -C "${DIR}/deploy" orchest-resources > /dev/null 

--- a/orchest
+++ b/orchest
@@ -46,7 +46,12 @@ minikube kubectl -- create namespace orchest  > /dev/null 2>&1
 if [ "$1"  == "install" ]; then
     echo "Creating orchest-namespace and installing dependencies."
     rm -rf "${DIR}/deploy/bin" > /dev/null
-    make -C "${DIR}/deploy" orchest-resources > /dev/null 2>&1
+    make -C "${DIR}/deploy" orchest-resources > /dev/null 
+    if [ $?  != 0 ]; then
+        echo "Failed to install Orchest resources. Installation aborted."
+        exit 1
+    fi
+
     echo "Running orchest-ctl."
 elif ! minikube kubectl get namespace orchest > /dev/null 2>&1 ; then
     echo "You need to install Orchest before running other commands."


### PR DESCRIPTION
## Description

Makes it so that it's now possible to specify the aforementioned sizes on install, moreover, if no related env var is required it prompts the user for the desired size. This helps in making it clear to the user the size of storage that will be available and explains that it (currently) cannot be altered later.
