### PR TITLE
Set `DEBIAN_FRONTEND=noninteractive` for `sudo` in environments

### DIFF
--- a/services/base-images/base-kernel-julia/Dockerfile
+++ b/services/base-images/base-kernel-julia/Dockerfile
@@ -13,8 +13,14 @@ USER root
 RUN apt-get update \
     && apt-get install default-libmysqlclient-dev sudo -y
 
-# enable sudo for the NB_USER by default
-RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
+RUN passwd -d $NB_USER \
+    # Enable `sudo` for the $NB_USER by default.
+    && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER \
+    # Persist the value of `DEBIAN_FRONTEND` when running with `sudo`,
+    # so that installing packages works as expected.
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" | tee /etc/sudoers.d/$NB_USER \
+    # All files in this directory should be mode 0440.
+    && chmod 0440 /etc/sudoers.d/$NB_USER
 
 # Get all requirements in place.
 COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/

--- a/services/base-images/base-kernel-py-gpu/Dockerfile
+++ b/services/base-images/base-kernel-py-gpu/Dockerfile
@@ -12,8 +12,14 @@ USER root
 RUN apt-get update \
     && apt-get install default-libmysqlclient-dev sudo -y
 
-# enable sudo for the NB_USER by default
-RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
+RUN passwd -d $NB_USER \
+    # Enable `sudo` for the $NB_USER by default.
+    && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER \
+    # Persist the value of `DEBIAN_FRONTEND` when running with `sudo`,
+    # so that installing packages works as expected.
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" | tee /etc/sudoers.d/$NB_USER \
+    # All files in this directory should be mode 0440.
+    && chmod 0440 /etc/sudoers.d/$NB_USER
 
 # Get all requirements in place.
 COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/

--- a/services/base-images/base-kernel-py/Dockerfile
+++ b/services/base-images/base-kernel-py/Dockerfile
@@ -10,8 +10,14 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends default-libmysqlclient-dev libkrb5-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Enable `sudo` for the $NB_USER by default.
-RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
+RUN passwd -d $NB_USER \
+    # Enable `sudo` for the $NB_USER by default.
+    && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER \
+    # Persist the value of `DEBIAN_FRONTEND` when running with `sudo`,
+    # so that installing packages works as expected.
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" | tee /etc/sudoers.d/$NB_USER \
+    # All files in this directory should be mode 0440.
+    && chmod 0440 /etc/sudoers.d/$NB_USER
 
 # Get Enterprise Gateway kernel files.
 WORKDIR /usr/local/bin

--- a/services/base-images/base-kernel-r/Dockerfile
+++ b/services/base-images/base-kernel-r/Dockerfile
@@ -14,8 +14,14 @@ USER root
 RUN apt-get update \
     && apt-get install default-libmysqlclient-dev sudo -y
 
-# enable sudo for the NB_USER by default
-RUN passwd -d $NB_USER && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER
+RUN passwd -d $NB_USER \
+    # Enable `sudo` for the $NB_USER by default.
+    && echo "$NB_USER   ALL=(ALL)   NOPASSWD:ALL" | tee /etc/sudoers.d/$NB_USER \
+    # Persist the value of `DEBIAN_FRONTEND` when running with `sudo`,
+    # so that installing packages works as expected.
+    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" | tee /etc/sudoers.d/$NB_USER \
+    # All files in this directory should be mode 0440.
+    && chmod 0440 /etc/sudoers.d/$NB_USER
 
 # Get all requirements in place.
 COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/


### PR DESCRIPTION
## Description
Persists `DEBIAN_FRONTEND=noninteractive` from base images.

Adds `env_keep` entry in the sudoers file to ensure the
`DEBIAN_FRONTEND` value of `noninteractive` is persisted. Meaning that
packages, such as `git` can be installed as expected, i.e.:
`sudo apt-get update && sudo apt-get install -y git`

@astrojuanlu Let me know whether installation now works like you would expect :)