### PR TITLE
Fix the error when moving a folder while its sub folders or files are also selected

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -75,6 +75,10 @@ const containsFilesByExtension = async (
   }
 };
 
+// ancesterPath has to be an folder because a file cannot be a parent
+const isAncester = (ancesterPath: string, childPath: string) =>
+  ancesterPath.endsWith("/") && childPath.startsWith(ancesterPath);
+
 export const FileTree = React.memo(function FileTreeComponent({
   baseUrl,
   treeRoots,
@@ -176,12 +180,38 @@ export const FileTree = React.memo(function FileTreeComponent({
     ]
   );
 
+  // dragFiles cannot have nodes that are ancester/offspring of each other
+  // because offspring nodes will be moved along with their ancesters.
+  // e.g. given selection ["/a/", "/a/b.py"], "/a/b.py" should be removed
   const dragFiles = React.useMemo(() => {
     if (!dragFile) return [];
 
-    const dragFilesSet = new Set(selectedFiles);
-    if (dragFile) dragFilesSet.add(dragFile.path);
-    return [...dragFilesSet];
+    const filteredItemsSet = new Set<string>([dragFile.path]);
+
+    for (let selectedPath of selectedFiles) {
+      const filteredItems = [...filteredItemsSet];
+
+      // If filteredItem is an ancestor of selectedPath
+      const hasIncluded = filteredItems.some((filteredItem) =>
+        isAncester(filteredItem, selectedPath)
+      );
+
+      if (hasIncluded) continue;
+
+      // Replace the current item with its ancester.
+      filteredItems.forEach((filteredItem) => {
+        if (isAncester(selectedPath, filteredItem)) {
+          filteredItemsSet.delete(filteredItem);
+          filteredItemsSet.add(selectedPath);
+        }
+      });
+
+      // If selectedPath is not an ancester or an offspring of any item in filteredItems,
+      // add it into the list.
+      filteredItemsSet.add(selectedPath);
+    }
+
+    return [...filteredItemsSet];
   }, [dragFile, selectedFiles]);
 
   // by default, handleRename will reload


### PR DESCRIPTION
## Description

When moving a folder while its files are also selected, it throws an error saying that the selected files do not exist. This is because those files are moved along with the folder already.

Solution: only execute the "moving the folder" operation and skip the operations on moving its offspring nodes.

Fixes: #838 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
