### PR TITLE
make orchest reachable if ORCHEST_FQDN is not defined via cluster ip(…

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,7 +51,7 @@ The Makefile is configured to do the most common actions and it can be configure
 16. `RABBITMQ_TAG` defines the tag of `rabbitmq`, default: `3`
 17. `ROOK_NFS_IMAGE_TAGE` defines the rook-nfs docker tag, default: `v1.7.3`
 18. `ROOK_CEPH_IMAGE_TAGE` defines the rook-ceph docker tag, default: `v1.8.2`
-19. `ORCHEST_FQDN` defines the orchest FQDN. default: `localorchest.io`
+19. `ORCHEST_FQDN` defines the orchest FQDN.`
 20. `REGISTRY_STORAGE_CLASS` the storage class for docker-registry volume, default : `standard`
 
 The following targets are defined:

--- a/deploy/helm/charts/auth-server/templates/ingress.yaml
+++ b/deploy/helm/charts/auth-server/templates/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ template "library.ingress.host" . }}
-      http:
+    {{- $ingress := .Values.global.ingress | default dict }}
+    {{ if $ingress.host }}
+    - host: {{ $ingress.host }}
+      http:  
+    {{ else }}
+    - http:
+    {{ end }}
         paths:
           - path: /login
             pathType: Prefix

--- a/deploy/helm/charts/celery-worker/templates/deployment.yaml
+++ b/deploy/helm/charts/celery-worker/templates/deployment.yaml
@@ -3,6 +3,7 @@ deployment
 */}}
 ---
 {{ include "library.deployment" . }}
+    {{- $ingress := .Values.global.ingress | default dict }}
     spec:
       volumes:
         - name: userdir-pvc
@@ -17,8 +18,10 @@ deployment
         env:
         - name: "ORCHEST_LOG_LEVEL"
           value: "{{ .Values.ORCHEST_LOG_LEVEL }}"
+        {{ if $ingress.host }}  
         - name: "ORCHEST_FQDN"
-          value: "{{ .Values.global.ingress.host }}"
+          value: "{{ $ingress.host }}"
+        {{ end }} 
         - name: "MAX_JOB_RUNS_PARALLELISM"
           value: "{{ .Values.MAX_JOB_RUNS_PARALLELISM }}"
         - name: "MAX_INTERACTIVE_RUNS_PARALLELISM"

--- a/deploy/helm/charts/orchest-api/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-api/templates/deployment.yaml
@@ -3,6 +3,7 @@ deployment
 */}}
 ---
 {{ include "library.deployment" . }}
+    {{- $ingress := .Values.global.ingress | default dict }}
     spec:
       volumes:
         - name: userdir-pvc
@@ -19,8 +20,10 @@ deployment
         env:
         - name: "ORCHEST_LOG_LEVEL"
           value: "{{ .Values.ORCHEST_LOG_LEVEL }}"
+        {{ if $ingress.host }}  
         - name: "ORCHEST_FQDN"
-          value: "{{ .Values.global.ingress.host }}"
+          value: "{{ $ingress.host }}"
+        {{ end }}  
         - name: "ORCHEST_HOST_GID"
           value: "1"
         - name: "PYTHONUNBUFFERED"

--- a/deploy/helm/charts/orchest-api/templates/ingress.yaml
+++ b/deploy/helm/charts/orchest-api/templates/ingress.yaml
@@ -7,8 +7,13 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: {{ include "library.service.auth" . }}
 spec:
   rules:
-    - host: {{ template "library.ingress.host" . }}
-      http:
+    {{- $ingress := .Values.global.ingress | default dict }}
+    {{ if $ingress.host }}
+    - host: {{ $ingress.host }}
+      http:  
+    {{ else }}
+    - http:
+    {{ end }}
         paths:
           - path: /orchest-api
             pathType: Prefix

--- a/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
+++ b/deploy/helm/charts/orchest-webserver/templates/deployment.yaml
@@ -3,6 +3,7 @@ deployment
 */}}
 ---
 {{ include "library.deployment" . }}
+    {{- $ingress := .Values.global.ingress | default dict }}
     spec:
       volumes:
         - name: userdir-pvc
@@ -27,8 +28,10 @@ deployment
         env:
         - name: "ORCHEST_LOG_LEVEL"
           value: "{{ .Values.ORCHEST_LOG_LEVEL }}"
+        {{ if $ingress.host }}  
         - name: "ORCHEST_FQDN"
-          value: "{{ .Values.global.ingress.host }}"
+          value: "{{ $ingress.host }}"
+        {{ end }}  
         - name: "CLOUD"
           value: "{{ .Values.CLOUD }}"
         - name: "ORCHEST_PORT"

--- a/deploy/helm/charts/orchest-webserver/templates/ingress.yaml
+++ b/deploy/helm/charts/orchest-webserver/templates/ingress.yaml
@@ -8,8 +8,13 @@ metadata:
     nginx.ingress.kubernetes.io/auth-signin: /login
 spec:
   rules:
-    - host: {{ template "library.ingress.host" . }}
-      http:
+    {{- $ingress := .Values.global.ingress | default dict }}
+    {{ if $ingress.host }}
+    - host: {{ $ingress.host }}
+      http:  
+    {{ else }}
+    - http:
+    {{ end }}
         paths:
           - path: /
             pathType: Prefix

--- a/deploy/helm/charts/update-sidecar/templates/ingress.yaml
+++ b/deploy/helm/charts/update-sidecar/templates/ingress.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-    - host: {{ template "library.ingress.host" . }}
-      http:
+    {{- $ingress := .Values.global.ingress | default dict }}
+    {{ if $ingress.host }}
+    - host: {{ $ingress.host }}
+      http:  
+    {{ else }}
+    - http:
+    {{ end }}
         paths:
           - path: /update-sidecar
             pathType: Prefix

--- a/deploy/helm/templates/_service.tpl
+++ b/deploy/helm/templates/_service.tpl
@@ -39,18 +39,3 @@ fqdn of the auth-server url.
 {{- define "library.service.auth" -}}
 {{ printf "http://auth-server.%s.svc.cluster.local/auth" .Release.Namespace }}
 {{- end -}}
-
-{{/*
-Ingress host
-*/}}
-{{- define "library.ingress.host" -}}
-  {{- if .Values.ingressOverride -}}
-    {{- .Values.ingressOverride | trunc 63 | trimSuffix "-" -}}
-  {{- else -}}
-    {{- if .Values.global.ingress.host -}}
-      {{ .Values.global.ingress.host }}
-    {{- else -}}
-      {{ "localorchest.io" }}
-    {{- end -}}
-  {{- end -}}  
-{{- end -}}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,9 @@
-global:
-  ingress:
-    host: localorchest.io
+
+
+# uncomment to set the FQDN in ingress resources
+#global:
+#  ingress:
+#    host: localorchest.io
 
 auth-server:
   enabled: false

--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -17,7 +17,7 @@ PROJECT_DIR = "/project-dir"
 PIPELINE_FILE = "/pipeline.json"
 PIPELINE_PARAMETERS_RESERVED_KEY = "pipeline_parameters"
 CLOUD = os.environ.get("CLOUD") == "True"
-ORCHEST_FQDN = os.environ.get("ORCHEST_FQDN", "localorchest.io")
+ORCHEST_FQDN = os.environ.get("ORCHEST_FQDN")
 GPU_ENABLED_INSTANCE = os.environ.get("ORCHEST_GPU_ENABLED_INSTANCE") == "True"
 # This represents a container priority w.r.t. CPU time. By default,
 # containers run with a value of 1024. User code/containers such as

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -466,31 +466,31 @@ def _get_jupyter_server_deployment_service_manifest(
         },
     }
 
+    ingress_rule = {}
+    if _config.ORCHEST_FQDN is not None:
+        ingress_rule["host"] = _config.ORCHEST_FQDN
+    ingress_rule["http"] = {
+        "paths": [
+            {
+                "backend": {
+                    "service": {
+                        "name": f"jupyter-server-{session_uuid}",
+                        "port": {"number": 80},
+                    }
+                },
+                "path": f"/jupyter-server-{session_uuid}",
+                "pathType": "Prefix",
+            }
+        ]
+    }
+
     ingress_manifest = {
         "apiVersion": "networking.k8s.io/v1",
         "kind": "Ingress",
         "metadata": metadata,
         "spec": {
             "ingressClassName": "nginx",
-            "rules": [
-                {
-                    "host": _config.ORCHEST_FQDN,
-                    "http": {
-                        "paths": [
-                            {
-                                "backend": {
-                                    "service": {
-                                        "name": f"jupyter-server-{session_uuid}",
-                                        "port": {"number": 80},
-                                    }
-                                },
-                                "path": f"/jupyter-server-{session_uuid}",
-                                "pathType": "Prefix",
-                            }
-                        ]
-                    },
-                }
-            ],
+            "rules": [ingress_rule],
         },
     }
 
@@ -962,18 +962,18 @@ def _get_user_service_deployment_service_manifest(
                 "nginx.ingress.kubernetes.io/auth-signin"
             ] = "/login"
 
+        ingress_rule = {}
+        if _config.ORCHEST_FQDN is not None:
+            ingress_rule["host"] = _config.ORCHEST_FQDN
+        ingress_rule["http"] = {"paths": ingress_paths}
+
         ingress_manifest = {
             "apiVersion": "networking.k8s.io/v1",
             "kind": "Ingress",
             "metadata": ingress_metadata,
             "spec": {
                 "ingressClassName": "nginx",
-                "rules": [
-                    {
-                        "host": _config.ORCHEST_FQDN,
-                        "http": {"paths": ingress_paths},
-                    }
-                ],
+                "rules": [ingress_rule],
             },
         }
     else:

--- a/services/orchest-ctl/app/cli/main.py
+++ b/services/orchest-ctl/app/cli/main.py
@@ -171,14 +171,15 @@ def install(
         False, show_default="--no-cloud", help=__CLOUD_HELP_MESSAGE, hidden=True
     ),
     fqdn: Optional[str] = typer.Option(
-        "localorchest.io",
+        None,
         "--fqdn",
         show_default=True,
         help=(
             "Fully qualified domain name of the application. It can be used, for "
             "example, to reach the application locally after mapping the cluster ip "
             "to 'localorchest.io' in your /etc/hosts file. To do that, you can use "
-            "'minikube ip' to get the cluster ip."
+            "'minikube ip' to get the cluster ip, if it is not specified, the cluster "
+            "can be reached via ip(:port)"
         ),
         callback=_validate_fqdn,
     ),

--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -120,7 +120,7 @@ def _run_helm_with_progress_bar(
 def install(
     log_level: utils.LogLevel,
     cloud: bool,
-    fqdn: str,
+    fqdn: Optional[str],
     registry_storage_class: Optional[str],
 ):
     k8sw.abort_if_unsafe()
@@ -159,12 +159,12 @@ def install(
 
     k8sw.set_orchest_cluster_log_level(log_level, patch_deployments=False)
     k8sw.set_orchest_cluster_cloud_mode(cloud, patch_deployments=False)
+    injected_env_vars = {}
+    if fqdn is not None:
+        injected_env_vars["ORCHEST_FQDN"] = fqdn
+    injected_env_vars["REGISTRY_STORAGE_CLASS"] = registry_storage_class
     return_code = _run_helm_with_progress_bar(
-        HelmMode.INSTALL,
-        injected_env_vars={
-            "ORCHEST_FQDN": fqdn,
-            "REGISTRY_STORAGE_CLASS": registry_storage_class,
-        },
+        HelmMode.INSTALL, injected_env_vars=injected_env_vars
     )
 
     if return_code != 0:


### PR DESCRIPTION
…:port)

## Description

This PR removes the requirement of ORCHEST_FQDN by default, if it is not specified, the cluster will be reachable via ip:port

Fixes: #issue

## Checklist

- [ ] The PR branch is set up to merge into `dev` instead of `master`.
