### PR TITLE
Make dependency pinnings explicit

### DIFF
--- a/services/auth-server/requirements.in
+++ b/services/auth-server/requirements.in
@@ -2,7 +2,7 @@ Flask-SQLAlchemy
 Flask<2
 jinja2<3.1.0  # https://github.com/pallets/jinja/issues/1626
 SQLAlchemy-Utils
-Werkzeug
+Werkzeug<2.1.0  # Newer versions are broken with old Flask
 eventlet
 flask-migrate
 flask-script

--- a/services/auth-server/requirements.in
+++ b/services/auth-server/requirements.in
@@ -1,5 +1,6 @@
 Flask-SQLAlchemy
-Flask
+Flask<2
+jinja2<3.1.0  # https://github.com/pallets/jinja/issues/1626
 SQLAlchemy-Utils
 Werkzeug
 eventlet

--- a/services/auth-server/requirements.txt
+++ b/services/auth-server/requirements.txt
@@ -43,8 +43,10 @@ itsdangerous==2.0.1
     # via
     #   -r requirements.in
     #   flask
-jinja2==3.1.1
-    # via flask
+jinja2==3.0.3
+    # via
+    #   -r requirements.in
+    #   flask
 mako==1.2.0
     # via alembic
 markupsafe==2.1.1

--- a/services/orchest-api/requirements.in
+++ b/services/orchest-api/requirements.in
@@ -1,8 +1,8 @@
 APScheduler
 Flask-Cors
 Flask-SQLAlchemy
-Flask
-Jinja2
+Flask<2
+Jinja2<3.1.0  # https://github.com/pallets/jinja/issues/1626
 PyYAML
 SQLAlchemy-Utils
 Werkzeug

--- a/services/orchest-api/requirements.in
+++ b/services/orchest-api/requirements.in
@@ -5,7 +5,7 @@ Flask<2
 Jinja2<3.1.0  # https://github.com/pallets/jinja/issues/1626
 PyYAML
 SQLAlchemy-Utils
-Werkzeug
+Werkzeug<2.1.0  # Newer versions are broken with old Flask
 aiohttp
 amqp
 celery

--- a/services/orchest-webserver/requirements.in
+++ b/services/orchest-webserver/requirements.in
@@ -3,7 +3,8 @@ nbconvert~=6.0.0
 # https://github.com/jupyter/nbconvert/issues/1443
 ipython
 itsdangerous
-Flask
+jinja2<3.1.0  # https://github.com/pallets/jinja/issues/1626
+Flask<2
 flask_sqlalchemy
 Flask-RESTful
 flask-marshmallow

--- a/services/orchest-webserver/requirements.in
+++ b/services/orchest-webserver/requirements.in
@@ -17,7 +17,7 @@ requests
 APScheduler
 nbformat
 six>=1.13.0
-Werkzeug
+Werkzeug<2.1.0  # Newer versions are broken with old Flask
 python-engineio
 python-socketio
 SQLAlchemy-Utils

--- a/services/orchest-webserver/requirements.txt
+++ b/services/orchest-webserver/requirements.txt
@@ -78,8 +78,9 @@ itsdangerous==2.0.1
     #   flask
 jedi==0.18.1
     # via ipython
-jinja2==3.1.1
+jinja2==3.0.3
     # via
+    #   -r requirements.in
     #   flask
     #   nbconvert
 jsonschema==4.4.0


### PR DESCRIPTION
## Description

After #843, some of the dependencies were not made explicit and accidental upgrades of problematic dependencies (recent releases of werkzeug and jinja2) sneaked in. This fixes it.

The culprit is using an unsupported Flask version by the way. But we can think about upgrading it at some other time.

Fixes: #issue

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [x] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
