### PR TITLE
Rework development docs

### DIFF
--- a/docs/source/development/development_workflow.rst
+++ b/docs/source/development/development_workflow.rst
@@ -3,10 +3,13 @@
 Development workflow
 ====================
 
+Installing Orchest for development
+----------------------------------
+
 .. _development prerequisites:
 
 Prerequisites
--------------
+~~~~~~~~~~~~~
 In order to code on Orchest, you need to have the following installed on your system:
 
 * Python version ``3.x``
@@ -17,22 +20,35 @@ In order to code on Orchest, you need to have the following installed on your sy
 * `pre-commit <https://pre-commit.com/#installation>`_
 * `npm <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_ and `pnpm
   <https://pnpm.io/installation#using-npm>`_
+* `jq <https://stedolan.github.io/jq/>`_
 * `Google Chrome <https://www.google.com/chrome/>`_ (integration tests only)
 
-Regular installation
---------------------
+.. _cluster mount:
+
+Cluster for development
+~~~~~~~~~~~~~~~~~~~~~~~
 Currently, the development scripts/tools assume that you are have Orchest installed in minikube.
-To do so, follow the steps of a :ref:`regular installation <installation>` first.
+It is recommended, but not mandatory, to mount the Orchest repository in minikube,
+which allows redeploying services and :ref:`incremental development <incremental development>`:
+
+.. code-block:: bash
+
+   # Start minikube with the repository mounted in the required place.
+   # Run this command while you are in the Orchest repository directory.
+   minikube start \
+     --memory 16000 \  # Requires additional steps on Ubuntu-based systems
+     --cpus 6 \
+     --mount-string="$(pwd):/orchest-dev-repo" --mount
+
+After the minikube cluster is created, follow the steps of a
+:ref:`regular installation <regular installation>`.
 
 .. warning::
-   If you plan to use :ref:`incremental development <incremental development>`,
-   adjust your ``minikube start`` command accordingly
-   (see :ref:`below <incremental development>`).
    If you have an existing minikube cluster, you will have to delete it
    by calling ``minikube delete``.
 
 Development environment
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 Run the code below to install all dependencies needed for :ref:`incremental development <incremental
 development>`, :ref:`building the docs <building the docs>`, :ref:`running tests <tests>` and
 automatically running pre-commit hooks:
@@ -53,86 +69,39 @@ automatically running pre-commit hooks:
    # Dependencies to build the docs
    python3 -m pip install -r docs/requirements.txt
 
-IDE & language servers
-~~~~~~~~~~~~~~~~~~~~~~
-.. note::
-   👉 This section is for VS Code and `pyright <https://github.com/microsoft/pyright>`_ users.
+Building services locally
+~~~~~~~~~~~~~~~~~~~~~~~~~
+To easily test code changes of an arbitrary service, you will need to 1) rebuild the service image and
+2) make it available to the k8s deployment. The procedure changes slightly depending on the deployment type.
 
-Who doesn't like to use the smarts of their IDE by using features such as auto complete, go to
-definition, find all references etc. For everyone who is using VS Code (or the `pyright
-<https://github.com/microsoft/pyright>`_ language server to be more precise) the different services
-contain their own ``pyrightconfig.json`` file that configures these features. All that is needed is
-to install the dependencies of the services in the correct virtual environment. This is done using:
-
-.. code-block:: bash
-
-   scripts/run_tests.sh
-
-Next you can create a workspace file that sets up VS Code to use the right Python interpreters (do
-note that this won't include all the files defined in the Orchest repo), e.g.:
-
-.. code-block:: json
-
-    {
-        "folders": [
-            {
-                "path": "services/orchest-api"
-            },
-            {
-                "path": "services/orchest-webserver"
-            },
-            {
-                "path": "services/base-images/runnable-shared"
-            },
-            {
-                "path": "services/orchest-ctl"
-            },
-            {
-                "path": "services/session-sidecar"
-            },
-            {
-                "path": "services/memory-server"
-            },
-            {
-                "name": "orchest-sdk",
-                "path": "orchest-sdk/python"
-            },
-            {
-                "name": "internal lib Python",
-                "path": "lib/python/orchest-internals/"
-            }
-        ],
-        "settings": {}
-    }
-
-Working with Orchest
---------------------
-To easily test code changes of an arbitrary service, you will need to 1) rebuild the service image and 2)
-make it so that the k8s deployment backing that Orchest service gets redeployed in order to use the
-newly built image. You could be running minikube in multi node or single node, generally speaking,
-single node deployments make it far easier to test changes, for example, you could do the following:
+Single node
++++++++++++
+Generally speaking, single node deployments make it far easier to test changes.
+For example, to make changes on the ``orchest-api`` service, do the following:
 
 .. code-block:: bash
 
-    # Make use of the in-node docker engine.
+    # Make use of the in-node docker engine
     eval $(minikube -p minikube docker-env)
 
-    # Build the desired image. The tag to be passed is the image tag
-    # that the deployment of the Orchest service is using, see "kubectl
-    # get deployments -n orchest orchest-api -o wide" as an example.
-    # Example tag: 2022.03.8.
-    scripts/build_container.sh -i orchest-api \
-        -t <image tag of the deployment of the orchest service> \
-        -o <image tag of the deployment of the orchest service>
+    # Save the Orchest version in use
+    export TAG=$(./orchest version --json | jq .cluster_version)
+
+    # Build the desired image
+    scripts/build_container.sh -i orchest-api -t $TAG -o $TAG
 
     # Kill the pods of the orchest-api, so that the new image gets used
-    # when new pods are deployed. This assumes that Orchest has already
-    # been installed.
+    # when new pods are deployed
     kubectl delete pods -n orchest -l "app.kubernetes.io/name=orchest-api"
 
-This, however, wouldn't be possible in multi node deployments, and it's also error prone
-when it comes to setting the right tag, label, etc. For this reason, we provide the
-following scripts:
+Alternatively, you can run ``scripts/build_container.sh -m -t $TAG -o $TAG``
+to rebuild all images.
+
+Multi node
+++++++++++
+The procedure above is not possible in multi node deployments though,
+and it's also error prone when it comes to setting the right tag, label, etc.
+For this reason, we provide the following scripts:
 
 .. code-block:: bash
 
@@ -152,40 +121,39 @@ following scripts:
     # Run arbitrary commands on all nodes.
     bash scripts/run_in_minikube.sh echo "hello"
 
-**The redeploy and build_image scripts require the Orchest repository
-to be mounted in minikube**. One way to do that is to mount it on start, for example, ``minikube
-start --memory 16000 --cpus 6 --mount-string="$(pwd):/orchest-dev-repo" --mount``, you will need to
-be in the Orchest repository (note the ``$(pwd)``). Note that multi node mounting might not be
-supported by all minikube drivers. We have tested with the default driver, docker.
+.. warning::
+   The redeploy and build_image scripts require the Orchest repository
+   :ref:`to be mounted in minikube <cluster mount>`.
+   However, note that multi node mounting might not be supported by all minikube drivers.
+   We have tested with docker, the default driver.
 
 .. _incremental development:
 
 Incremental development (hot reloading)
----------------------------------------
-Now that you have Orchest and all development dependencies installed you are ready to start Orchest
-in dev mode by using the ``--dev`` flag. This way code changes are instantly reflected, without
-having to build the containers again (although it is good practice to rebuild all containers
-:ref:`before committing <before committing>` your changes). The services that support
-dev mode are:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The steps above allow you to rebuild the images for the services.
+In addition, you can also install Orchest in dev mode by using the ``--dev`` flag
+so that code changes are instantly reflected, without having to build the containers again.
+The services that support dev mode are:
 
 - ``orchest-webserver``
 - ``orchest-api``
 - ``auth-server``
 
-.. code-block:: bash
+.. note::
+   It is good practice to rebuild all containers :ref:`before committing <before committing>` your changes.
 
-   # Start minikube with the repository mounted in the required place.
-   # Run this command while you are in the Orchest repository directory.
-   minikube start --memory 16000 --cpus 6 \
-    --mount-string="$(pwd):/orchest-dev-repo" --mount
+.. code-block:: bash
 
    # In case any new dependencies were changed or added they need to
    # be installed.
    pnpm i
 
-   # Run the client dev server for hot reloading of client (i.e. FE)
-   # files. Note: This command does not finish.
-   pnpm run dev
+   # Run the client dev server for hot reloading of client (i.e. FE) files.
+   pnpm run dev &
+
+   # If Orchest is running, stop it.
+   ./orchest stop
 
    # Start Orchest in --dev mode.
    ./orchest start --dev
@@ -194,117 +162,6 @@ dev mode are:
    🎉 Awesome! Everything is set up now and you are ready to start coding. Have a look at our
    :ref:`best practices <best practices>` and our `GitHub
    <https://github.com/orchest/orchest/issues>`_ to find interesting issues to work on.
-
-.. _building the docs:
-
-Building the docs
-~~~~~~~~~~~~~~~~~
-
-Our docs are build using `Read the Docs <https://docs.readthedocs.io/>`_ with Sphinx and written in
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
-
-To build the docs, run:
-
-.. code-block:: bash
-
-   cd docs
-   make html
-
-.. tip::
-   👉 If you didn't follow the :ref:`prerequisites <development prerequisites>`, then make sure
-   you've installed the needed requirements to builds the docs:
-
-   .. code-block:: sh
-
-      python3 -m pip install -r docs/requirements.txt
-
-.. _before committing:
-
-Before committing
------------------
-
-Make sure your development environment is set up correctly (see :ref:`prerequisites <development
-prerequisites>`) so that pre-commit can automatically take care of running the appropriate
-formatters and linters when running ``git commit``. Lastly, it is good practice to rebuild all
-containers (and restart Orchest) to do some manual testing and running the :ref:`unit tests <unit
-tests>` to make sure your changes didn't break anything:
-
-.. code-block:: bash
-
-    # Rebuild containers to do manual testing.
-    scripts/build_containers.sh
-
-    # Run unit tests.
-    scripts/run_tests.sh
-
-In our CI we also run all of these checks together with :ref:`integration tests <integration tests>`
-to make sure the codebase remains stable. To read more about testing, check out the :ref:`testing
-<tests>` section.
-
-.. _opening a pr:
-
-Opening a PR
-------------
-
-.. note::
-   When opening a PR please change the base in which you want to merge from ``master`` to ``dev``.
-   The `GitHub docs
-   <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request>`_
-   describe how this can be done.
-
-We use `gitflow <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow>`_ as
-our branching model with ``master`` and ``dev`` being the described ``master`` and ``develop``
-branches respectively. Therefore, we require PRs to be merged into ``dev`` instead of ``master``.
-
-When opening the PR a checklist will automatically appear to guide you to successfully completing
-your PR 🏁.
-
-Python dependencies
-~~~~~~~~~~~~~~~~~~~
-Python dependencies for the microservices are specified using pip's ``requirements.txt`` files.
-Those files are automatically generated by `pip-tools <https://pypi.org/project/pip-tools/>`_
-from ``requirements.in`` files by calling ``pip-compile``, which locks all the transitive dependencies.
-After a locked ``requirements.txt`` file is in place,
-subsequent calls to ``pip-compile`` will not upgrade any of the dependencies
-unless the constraints in ``requirements.in`` are modified.
-
-To manually upgrade a dependency to a newer version, there are several options:
-
-.. code-block::
-
-   pip-compile -P <dep>  # Upgrades <dep> to latest version
-   pip-compile -U  # Try to upgrade everything
-
-As a general rule, avoid writing exact pins in ``requirements.in``
-unless there are known incompatibilities.
-In addition, avoid manually editing ``requirements.txt`` files,
-since they will be automatically generated.
-
-.. warning::
-   A `bug in pip-tools <https://github.com/jazzband/pip-tools/issues/1505>`_ affects local dependencies.
-   Older versions are not affected, but they are not compatible with modern pip.
-   At the time of writing, the best way forward is to install this fork
-   (see `this PR <https://github.com/jazzband/pip-tools/pull/1519>`_ for details):
-
-   .. code-block::
-
-      pip install -U "pip-tools @ git+https://github.com/richafrank/pip-tools.git@combine-without-copy"
-
-Database schema migrations
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Whenever one of the services's database models (in their respective ``models.py``) have been
-changed, a database migration has to be performed so that all existing users are unaffected by the
-schema change on update (since they can then be automatically migrated to the latest version).
-
-.. code-block:: sh
-
-   # Depending on the service that requires schema changes.
-   scripts/migration_manager.sh orchest-api migrate
-   scripts/migration_manager.sh orchest-webserver migrate
-
-   # For more options run:
-   scripts/migration_manager.sh --help
-
 
 .. _tests:
 
@@ -373,3 +230,166 @@ Integration tests are being ported to k8s, stay tuned :)!
     The script takes care of starting Orchest if it isn't already. On the other hand, if Orchest is
     already started, then the script expects Orchest to be running on its default port ``8000``.
 
+Making changes
+--------------
+
+.. _before committing:
+
+Before committing
+~~~~~~~~~~~~~~~~~
+Make sure your development environment is set up correctly (see :ref:`prerequisites <development
+prerequisites>`) so that pre-commit can automatically take care of running the appropriate
+formatters and linters when running ``git commit``. Lastly, it is good practice to rebuild all
+containers (and restart Orchest) to do some manual testing and running the :ref:`unit tests <unit
+tests>` to make sure your changes didn't break anything:
+
+.. code-block:: bash
+
+    # Rebuild containers to do manual testing.
+    scripts/build_containers.sh
+
+    # Run unit tests.
+    scripts/run_tests.sh
+
+In our CI we also run all of these checks together with :ref:`integration tests <integration tests>`
+to make sure the codebase remains stable. To read more about testing, check out the :ref:`testing
+<tests>` section.
+
+IDE & language servers
+~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+   👉 This section is for VS Code and `pyright <https://github.com/microsoft/pyright>`_ users.
+
+If you use VS Code (or the `pyright <https://github.com/microsoft/pyright>`_ language server to be more precise)
+the different services contain their own ``pyrightconfig.json`` file
+that configures smart features such as auto complete, go to definition, find all references, and more.
+For this to work, you need to install the dependencies of the services in the correct virtual environment
+by running:
+
+.. code-block:: bash
+
+   scripts/run_tests.sh
+
+Next you can create a workspace file that sets up VS Code to use the right Python interpreters (do
+note that this won't include all the files defined in the Orchest repo), e.g.:
+
+.. code-block:: json
+
+    {
+        "folders": [
+            {
+                "path": "services/orchest-api"
+            },
+            {
+                "path": "services/orchest-webserver"
+            },
+            {
+                "path": "services/base-images/runnable-shared"
+            },
+            {
+                "path": "services/orchest-ctl"
+            },
+            {
+                "path": "services/session-sidecar"
+            },
+            {
+                "path": "services/memory-server"
+            },
+            {
+                "name": "orchest-sdk",
+                "path": "orchest-sdk/python"
+            },
+            {
+                "name": "internal lib Python",
+                "path": "lib/python/orchest-internals/"
+            }
+        ],
+        "settings": {}
+    }
+
+Python dependencies
+~~~~~~~~~~~~~~~~~~~
+Python dependencies for the microservices are specified using pip's ``requirements.txt`` files.
+Those files are automatically generated by `pip-tools <https://pypi.org/project/pip-tools/>`_
+from ``requirements.in`` files by calling ``pip-compile``, which locks all the transitive dependencies.
+After a locked ``requirements.txt`` file is in place,
+subsequent calls to ``pip-compile`` will not upgrade any of the dependencies
+unless the constraints in ``requirements.in`` are modified.
+
+To manually upgrade a dependency to a newer version, there are several options:
+
+.. code-block::
+
+   pip-compile -P <dep>  # Upgrades <dep> to latest version
+   pip-compile -U  # Try to upgrade everything
+
+As a general rule, avoid writing exact pins in ``requirements.in``
+unless there are known incompatibilities.
+In addition, avoid manually editing ``requirements.txt`` files,
+since they will be automatically generated.
+
+.. warning::
+   A `bug in pip-tools <https://github.com/jazzband/pip-tools/issues/1505>`_ affects local dependencies.
+   Older versions are not affected, but they are not compatible with modern pip.
+   At the time of writing, the best way forward is to install this fork
+   (see `this PR <https://github.com/jazzband/pip-tools/pull/1519>`_ for details):
+
+   .. code-block::
+
+      pip install -U "pip-tools @ git+https://github.com/richafrank/pip-tools.git@combine-without-copy"
+
+Database schema migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Whenever one of the services's database models (in their respective ``models.py``) have been
+changed, a database migration has to be performed so that all existing users are unaffected by the
+schema change on update (since they can then be automatically migrated to the latest version).
+
+.. code-block:: sh
+
+   # Depending on the service that requires schema changes.
+   scripts/migration_manager.sh orchest-api migrate
+   scripts/migration_manager.sh orchest-webserver migrate
+
+   # For more options run:
+   scripts/migration_manager.sh --help
+
+.. _building the docs:
+
+Building the docs
+-----------------
+
+Our docs are build using `Read the Docs <https://docs.readthedocs.io/>`_ with Sphinx and written in
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
+
+To build the docs, run:
+
+.. code-block:: bash
+
+   cd docs
+   make html
+
+.. tip::
+   👉 If you didn't follow the :ref:`prerequisites <development prerequisites>`, then make sure
+   you've installed the needed requirements to builds the docs:
+
+   .. code-block:: sh
+
+      python3 -m pip install -r docs/requirements.txt
+
+.. _opening a pr:
+
+Opening a PR
+------------
+
+.. note::
+   When opening a PR please change the base in which you want to merge from ``master`` to ``dev``.
+   The `GitHub docs
+   <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request>`_
+   describe how this can be done.
+
+We use `gitflow <https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow>`_ as
+our branching model with ``master`` and ``dev`` being the described ``master`` and ``develop``
+branches respectively. Therefore, we require PRs to be merged into ``dev`` instead of ``master``.
+
+When opening the PR a checklist will automatically appear to guide you to successfully completing
+your PR 🏁

--- a/docs/source/development/development_workflow.rst
+++ b/docs/source/development/development_workflow.rst
@@ -19,9 +19,17 @@ In order to code on Orchest, you need to have the following installed on your sy
   <https://pnpm.io/installation#using-npm>`_
 * `Google Chrome <https://www.google.com/chrome/>`_ (integration tests only)
 
-Currently, the development scripts/tools assume that you are running Orchest in minikube.
-If you have managed to successfully :ref:`install <installation>` Orchest in minikube
-now it's the time to setup your development environment.
+Regular installation
+--------------------
+Currently, the development scripts/tools assume that you are have Orchest installed in minikube.
+To do so, follow the steps of a :ref:`regular installation <installation>` first.
+
+.. warning::
+   If you plan to use :ref:`incremental development <incremental development>`,
+   adjust your ``minikube start`` command accordingly
+   (see :ref:`below <incremental development>`).
+   If you have an existing minikube cluster, you will have to delete it
+   by calling ``minikube delete``.
 
 Development environment
 -----------------------

--- a/docs/source/development/development_workflow.rst
+++ b/docs/source/development/development_workflow.rst
@@ -39,15 +39,19 @@ automatically running pre-commit hooks:
 
 .. code-block:: bash
 
-   # Make sure you are inside the orchest root directory.
-   npm run setup --install && \
-       pnpm i && \
-       # Install dependencies to build the docs
-       python3 -m pip install -r docs/requirements.txt && \
-       # Install pre-commit hooks
-       pre-commit install && \
-       # Dependencies to run unit tests
-       sudo apt-get install -y default-libmysqlclient-dev
+   # Make sure you are inside the orchest root directory
+
+   # pre-commit hooks
+   pre-commit install
+
+   # Dependencies to run unit tests
+   sudo apt-get install -y default-libmysqlclient-dev
+
+   # Frontend dependencies for incremental development
+   npm run setup --install && pnpm i
+
+   # Dependencies to build the docs
+   python3 -m pip install -r docs/requirements.txt
 
 IDE & language servers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/development/development_workflow.rst
+++ b/docs/source/development/development_workflow.rst
@@ -17,7 +17,6 @@ In order to code on Orchest, you need to have the following installed on your sy
 * `pre-commit <https://pre-commit.com/#installation>`_
 * `npm <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_ and `pnpm
   <https://pnpm.io/installation#using-npm>`_
-* `virtualenv <https://virtualenv.pypa.io/en/latest/installation.html>`_
 * `Google Chrome <https://www.google.com/chrome/>`_ (integration tests only)
 
 Currently, the development scripts/tools assume that you are running Orchest in minikube.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -37,6 +37,15 @@ instead, for example clone orchest in the Linux user home directory:
 
    cd && git clone https://github.com/orchest/orchest.git
 
+Kubernetes cluster
+------------------
+The best option to create a Kubernetes (k8s) cluster locally is using minikube:
+
+.. code-block:: bash
+
+   # Start a minikube cluster with profile "minikube".
+   minikube start --cpus=4
+
 .. _regular installation:
 
 Install Orchest
@@ -44,9 +53,6 @@ Install Orchest
 .. code-block:: bash
 
    git clone https://github.com/orchest/orchest.git && cd orchest
-
-   # Start a minikube cluster with profile "minikube".
-   minikube start --cpus=4
 
    bash orchest install
 


### PR DESCRIPTION
## Description

This addresses several content and structure issues discussed in #832. The structure of the docs follows this logical order:

- First of all, recommend a `minikube start --mount`, since it helps with hot reloading. Even if it's optional, I believe it's better to say it up front. This also makes potential contributors clearly distinguish their development cluster vs their "production" Orchest instance. To make this recommendation more clear, I modified the installation instructions slightly, to avoid confusion.
- The "contribution journey" requires some steps, in order:
  1. Installing Orchest for development, otherwise the rest of the stuff doesn't work
  2. Running the tests even before making changes, to verify that things are working
  3. Making such changes, with recommendations for Python dependencies, IDE configs, and database migrations
  4. Building the docs, which is not always needed but often useful and encourages folks to document their changes
  5. Making a pull request, the very last step in the process

I am no longer a "minikube first timer" as I was one week ago, but still I believe this should be easier to grasp for folks like me. Suggestions and comments are more than welcome.

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [x] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
