### PR TITLE
Allow increasing jobs and interactive runs parallelism without restarting Orchest

### DIFF
--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -58,6 +58,7 @@ class Config:
     result_backend_sqlalchemy_uri = f"postgresql://{_result_backend_server}"
     # this format is used by celery
     result_backend = f"db+postgresql+psycopg2://{_result_backend_server}"
+    worker_prefetch_multiplier = 1
 
     imports = ("app.core.tasks",)
     task_create_missing_queues = True


### PR DESCRIPTION
Allows increasing parallelism levels for jobs and interactive runs without restarting Orchest. Slightly refactors the `OrchestConfig` class.