### PR TITLE
Automatically delete unused Orchest images from nodes

### DIFF
--- a/services/node-agent/Dockerfile
+++ b/services/node-agent/Dockerfile
@@ -12,3 +12,5 @@ RUN pip3 install -r requirements.txt
 COPY . ./
 
 CMD [ "python3", "./app/main.py" ]
+ARG ORCHEST_VERSION
+ENV ORCHEST_VERSION=${ORCHEST_VERSION}

--- a/services/orchest-api/app/app/core/registry.py
+++ b/services/orchest-api/app/app/core/registry.py
@@ -64,7 +64,7 @@ def get_manifest(repository: str, tag: str) -> List[str]:
     return r.json()
 
 
-def get_manifest_digest(repository: str, tag: str) -> str:
+def get_manifest_digest(repository: str, tag: str) -> Optional[str]:
     """Gets the digest of a manifest.
 
     Can be used, for example, in other registry API endpoints.
@@ -77,7 +77,7 @@ def get_manifest_digest(repository: str, tag: str) -> str:
         verify=_VERIFY,
         headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
     )
-    digest = resp.headers["Docker-Content-Digest"]
+    digest = resp.headers.get("Docker-Content-Digest")
     return digest
 
 


### PR DESCRIPTION
This PR introduces lifecycle management for orchest images. Images that are considered unused, due to their version not matching the current orchest deployment version, will be removed from nodes.