### PR TITLE
Add jest tests to ProjectsContext

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -45,10 +45,10 @@ jobs:
         run: npm run setup && pnpm install
 
       - name: Build pnpm packages
-        run: pnpm run test
+        run: pnpm run build
 
       - name: Run unit tests
-        run: pnpm run build
+        run: pnpm run test
 
       - name: Lint pnpm packages
         run: pnpm run check

--- a/lib/javascript/build-frontend.sh
+++ b/lib/javascript/build-frontend.sh
@@ -43,7 +43,7 @@ CSS_BUNDLE_PATH="dist/style.css"
 TS_SRC_PATH="src/main.tsx"
 SASS_SRC_PATH="src/styles/main.scss"
 
-ESBUILD_ARGS="$TS_SRC_PATH --bundle --minify --target=es6 --outfile=$JS_BUNDLE_PATH"
+ESBUILD_ARGS="$TS_SRC_PATH --bundle --minify --target=es6 --tsconfig=tsconfig.build.json --define:__BASE_URL__=\"\" --outfile=$JS_BUNDLE_PATH"
 SASS_ARGS="$SASS_SRC_PATH --load-path=$NODE_MODULES_PATH $CSS_BUNDLE_PATH"
 
 if $WATCH; then

--- a/lib/javascript/utils/src/fetcher.ts
+++ b/lib/javascript/utils/src/fetcher.ts
@@ -4,8 +4,12 @@ export type FetchError = {
   body?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
-export const fetcher = async <T>(url: RequestInfo, params?: RequestInit) => {
-  const response = await window.fetch(url, params);
+const getExactUrl = (url: string) => `${__BASE_URL__}${url}`;
+
+export const fetcher = async <T>(url: string, params?: RequestInit) => {
+  const targetUrl = getExactUrl(url);
+
+  const response = await window.fetch(targetUrl, params);
   const responseAsString = await response.text();
   const jsonResponse =
     responseAsString === "" ? {} : JSON.parse(responseAsString);

--- a/lib/javascript/utils/src/index.ts
+++ b/lib/javascript/utils/src/index.ts
@@ -2,3 +2,7 @@ export * from "./fetcher";
 export * from "./typed";
 export * from "./typedIncludes";
 export * from "./untyped";
+
+declare global {
+  const __BASE_URL__: string;
+}

--- a/lib/javascript/utils/tsconfig.build.json
+++ b/lib/javascript/utils/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.[t|j]sx?$",
+    "**/*.mock.[t|j]sx?$"
+  ],
+  "include": ["src/**/*.d.ts", "src/**/*.[t|j]sx?$"]
+}

--- a/lib/javascript/utils/tsconfig.json
+++ b/lib/javascript/utils/tsconfig.json
@@ -1,8 +1,20 @@
 {
   "extends": "../../../tsconfig.json",
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"],
   "compilerOptions": {
-    "baseUrl": "."
-  },
-  "exclude": ["node_modules"],
-  "include": ["src/**/*.ts", "src/typed.tsx"]
+    "types": ["jest", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noFallthroughCasesInSwitch": true,
+    "downlevelIteration": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
       '@babel/core': ^7.16.0
       '@emotion/react': ^11.6.0
       '@emotion/styled': ^11.6.0
+      '@jest/transform': ^27.5.1
       '@mui/icons-material': ^5.2.1
       '@mui/lab': ^5.0.0-alpha.72
       '@mui/material': ^5.2.3
@@ -240,6 +241,7 @@ importers:
       xterm-for-react: 1.0.4_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@babel/core': 7.16.7
+      '@jest/transform': 27.5.1
       '@testing-library/jest-dom': 5.16.1
       '@testing-library/react-hooks': 7.0.2_react-dom@17.0.2+react@17.0.2
       '@types/codemirror': 5.60.5
@@ -1438,6 +1440,29 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/transform/27.5.1:
+    resolution: {integrity: sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@babel/core': 7.16.7
+      '@jest/types': 27.5.1
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 1.8.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.9
+      jest-haste-map: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-util: 27.5.1
+      micromatch: 4.0.4
+      pirates: 4.0.4
+      slash: 3.0.0
+      source-map: 0.6.1
+      write-file-atomic: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@jest/types/26.6.2:
     resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
     engines: {node: '>= 10.14.2'}
@@ -1451,6 +1476,17 @@ packages:
 
   /@jest/types/27.4.2:
     resolution: {integrity: sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 15.0.1
+      '@types/yargs': 16.0.4
+      chalk: 4.1.2
+    dev: true
+
+  /@jest/types/27.5.1:
+    resolution: {integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
@@ -5881,6 +5917,26 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /jest-haste-map/27.5.1:
+    resolution: {integrity: sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.5.1
+      '@types/graceful-fs': 4.1.5
+      '@types/node': 15.0.1
+      anymatch: 3.1.2
+      fb-watchman: 2.0.1
+      graceful-fs: 4.2.9
+      jest-regex-util: 27.5.1
+      jest-serializer: 27.5.1
+      jest-util: 27.5.1
+      jest-worker: 27.5.1
+      micromatch: 4.0.4
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /jest-jasmine2/27.4.5:
     resolution: {integrity: sha512-oUnvwhJDj2LhOiUB1kdnJjkx8C5PwgUZQb9urF77mELH9DGR4e2GqpWQKBOYXWs5+uTN9BGDqRz3Aeg5Wts7aw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -5977,6 +6033,11 @@ packages:
 
   /jest-regex-util/27.4.0:
     resolution: {integrity: sha512-WeCpMpNnqJYMQoOjm1nTtsgbR4XHAk1u00qDoNBQoykM280+/TmgA5Qh5giC1ecy6a5d4hbSsHzpBtu5yvlbEg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
+
+  /jest-regex-util/27.5.1:
+    resolution: {integrity: sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dev: true
 
@@ -6090,6 +6151,14 @@ packages:
       graceful-fs: 4.2.9
     dev: true
 
+  /jest-serializer/27.5.1:
+    resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@types/node': 15.0.1
+      graceful-fs: 4.2.9
+    dev: true
+
   /jest-snapshot/27.4.5:
     resolution: {integrity: sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6146,6 +6215,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /jest-util/27.5.1:
+    resolution: {integrity: sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      '@jest/types': 27.5.1
+      '@types/node': 15.0.1
+      chalk: 4.1.2
+      ci-info: 3.3.0
+      graceful-fs: 4.2.9
+      picomatch: 2.3.1
+    dev: true
+
   /jest-validate/27.4.2:
     resolution: {integrity: sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -6182,6 +6263,15 @@ packages:
 
   /jest-worker/27.4.5:
     resolution: {integrity: sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 15.0.1
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+    dev: true
+
+  /jest-worker/27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/node': 15.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,7 @@ importers:
       codemirror: ^5.55.0
       cron-parser: ^3.3.0
       cronstrue: ^1.108.0
+      cross-env: ^7.0.3
       d3-dag: ~0.8.2
       dashify: ^2.0.0
       date-fns: ^2.25.0
@@ -170,11 +171,13 @@ importers:
       immer: ^9.0.12
       isomorphic-unfetch: 3.1.0
       jest: ^27.4.5
+      jest-fetch-mock: ^3.0.3
       jest-junit: ^13.0.0
       jquery: ^3.5.1
       lodash.clonedeep: ^4.5.0
       lodash.isstring: ^4.0.1
       lodash.merge: ^4.6.2
+      msw: ^0.39.2
       pascalcase: ^1.0.0
       react: ^17.0.2
       react-codemirror2: ^7.2.1
@@ -251,10 +254,13 @@ importers:
       '@types/react': 17.0.3
       '@types/react-dom': 17.0.11
       '@types/react-router-dom': 5.3.2
+      cross-env: 7.0.3
       esbuild: 0.14.27
       esbuild-jest: 0.5.0_esbuild@0.14.27
       jest: 27.4.5
+      jest-fetch-mock: 3.0.3
       jest-junit: 13.0.0
+      msw: 0.39.2
       sass-bin: 1.43.2
       ts-jest: 27.1.2_31cbaf66f233764650221659d32b6390
       typescript: 4.5.4
@@ -379,7 +385,7 @@ packages:
     resolution: {integrity: sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.7
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/helper-function-name/7.16.0:
@@ -534,7 +540,7 @@ packages:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.7
+      '@babel/types': 7.17.0
     dev: true
 
   /@babel/helper-validator-identifier/7.14.9:
@@ -855,6 +861,14 @@ packages:
 
   /@babel/types/7.16.7:
     resolution: {integrity: sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types/7.17.0:
+    resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
@@ -1446,6 +1460,28 @@ packages:
       chalk: 4.1.2
     dev: true
 
+  /@mswjs/cookies/0.2.0:
+    resolution: {integrity: sha512-GTKYnIfXVP8GL8HRWrse+ujqDXCLKvu7+JoL6pvZFzS/d2i9pziByoWD69cOe35JNoSrx2DPNqrhUF+vgV3qUA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@types/set-cookie-parser': 2.4.2
+      set-cookie-parser: 2.4.8
+    dev: true
+
+  /@mswjs/interceptors/0.15.1:
+    resolution: {integrity: sha512-D5B+ZJNlfvBm6ZctAfRBdNJdCHYAe2Ix4My5qfbHV5WH+3lkt3mmsjiWJzEh5ZwGDauzY487TldI275If7DJVw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@open-draft/until': 1.0.3
+      '@xmldom/xmldom': 0.7.5
+      debug: 4.3.3
+      headers-polyfill: 3.0.7
+      outvariant: 1.3.0
+      strict-event-emitter: 0.2.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@mui/base/5.0.0-alpha.59_ba191c0052acfa37659f3ba04a2d9405:
     resolution: {integrity: sha512-rPgN2FW0FAjQ9+LQ+XBsq3DFcuiiMFhf8uoLJAWnnzft27IJvJqbrhfpCZ68G6l+umJLbbl5RIIbpt8ALZDDNQ==}
     engines: {node: '>=12.0.0'}
@@ -1574,8 +1610,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.16.3
-      '@emotion/react': 11.6.0_224c005a9aae57ced2ce2da687f66614
-      '@emotion/styled': 11.6.0_b776a098af178845b9a687c0f1e09552
+      '@emotion/react': 11.6.0_b31e2e930191052696b5daf8df9af787
+      '@emotion/styled': 11.6.0_0a99bf3499149946574f430ef37a741d
       '@mui/base': 5.0.0-alpha.59_ba191c0052acfa37659f3ba04a2d9405
       '@mui/system': 5.2.3_98944ee4dd5f6cfd31442cef9ca2b57e
       '@mui/types': 7.1.0_@types+react@17.0.3
@@ -1641,8 +1677,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.16.3
       '@emotion/cache': 11.6.0
-      '@emotion/react': 11.6.0_224c005a9aae57ced2ce2da687f66614
-      '@emotion/styled': 11.6.0_b776a098af178845b9a687c0f1e09552
+      '@emotion/react': 11.6.0_b31e2e930191052696b5daf8df9af787
+      '@emotion/styled': 11.6.0_0a99bf3499149946574f430ef37a741d
       prop-types: 15.7.2
       react: 17.0.2
     dev: false
@@ -1685,8 +1721,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.16.3
-      '@emotion/react': 11.6.0_224c005a9aae57ced2ce2da687f66614
-      '@emotion/styled': 11.6.0_b776a098af178845b9a687c0f1e09552
+      '@emotion/react': 11.6.0_b31e2e930191052696b5daf8df9af787
+      '@emotion/styled': 11.6.0_0a99bf3499149946574f430ef37a741d
       '@mui/private-theming': 5.2.3_@types+react@17.0.3+react@17.0.2
       '@mui/styled-engine': 5.2.0_3ca9f49da28f3590cbe49aab51aa421d
       '@mui/types': 7.1.0_@types+react@17.0.3
@@ -1797,6 +1833,10 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@open-draft/until/1.0.3:
+    resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
     dev: true
 
   /@popperjs/core/2.11.0:
@@ -2133,6 +2173,10 @@ packages:
       '@types/tern': 0.23.4
     dev: true
 
+  /@types/cookie/0.4.1:
+    resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
+    dev: true
+
   /@types/estree/0.0.50:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
     dev: true
@@ -2174,6 +2218,10 @@ packages:
     resolution: {integrity: sha512-B8pDk+sH/tSv/HKdx6EQER6BfUOb2GtKs0LOmozziS4h7cbe8u/eYySfUAeTwD+J09SqV3man7AMWIA5mgzCBA==}
     dependencies:
       '@types/sizzle': 2.3.3
+    dev: true
+
+  /@types/js-levenshtein/1.1.1:
+    resolution: {integrity: sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==}
     dev: true
 
   /@types/json-schema/7.0.9:
@@ -2296,6 +2344,12 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+
+  /@types/set-cookie-parser/2.4.2:
+    resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
+    dependencies:
+      '@types/node': 15.0.1
+    dev: true
 
   /@types/sinonjs__fake-timers/6.0.4:
     resolution: {integrity: sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==}
@@ -2467,6 +2521,11 @@ packages:
       '@use-gesture/core': 10.2.10
       react: 17.0.2
     dev: false
+
+  /@xmldom/xmldom/0.7.5:
+    resolution: {integrity: sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==}
+    engines: {node: '>=10.0.0'}
+    dev: true
 
   /abab/2.0.5:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
@@ -2893,10 +2952,27 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: false
 
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
+
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
     dependencies:
       tweetnacl: 0.14.5
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /bl/4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.0
     dev: true
 
   /blob-util/2.0.2:
@@ -2994,6 +3070,13 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
+  /buffer/5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
+
   /cache-base/1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
@@ -3077,6 +3160,14 @@ packages:
       supports-color: 7.2.0
     dev: true
 
+  /chalk/4.1.1:
+    resolution: {integrity: sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3090,9 +3181,28 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /chardet/0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+    dev: true
+
   /check-more-types/2.24.0:
     resolution: {integrity: sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /ci-info/2.0.0:
@@ -3133,6 +3243,11 @@ packages:
       restore-cursor: 3.1.0
     dev: true
 
+  /cli-spinners/2.6.1:
+    resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
+    engines: {node: '>=6'}
+    dev: true
+
   /cli-table3/0.6.1:
     resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
     engines: {node: 10.* || >= 12.*}
@@ -3150,12 +3265,22 @@ packages:
       string-width: 4.2.3
     dev: true
 
+  /cli-width/3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /cliui/7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: true
+
+  /clone/1.0.4:
+    resolution: {integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4=}
+    engines: {node: '>=0.8'}
     dev: true
 
   /clsx/1.1.1:
@@ -3281,6 +3406,11 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
 
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /copy-descriptor/0.1.1:
     resolution: {integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=}
     engines: {node: '>=0.10.0'}
@@ -3327,6 +3457,22 @@ packages:
   /cronstrue/1.122.0:
     resolution: {integrity: sha512-PFuhZd+iPQQ0AWTXIEYX+t3nFGzBrWxmTWUKJOrsGRewaBSLKZ4I1f8s2kryU75nNxgyugZgiGh2OJsCTA/XlA==}
     dev: false
+
+  /cross-env/7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
+
+  /cross-fetch/3.1.5:
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: true
 
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -3631,6 +3777,12 @@ packages:
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /defaults/1.0.3:
+    resolution: {integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=}
+    dependencies:
+      clone: 1.0.4
     dev: true
 
   /define-properties/1.1.3:
@@ -4323,6 +4475,11 @@ packages:
     resolution: {integrity: sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==}
     dev: true
 
+  /events/3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+    dev: true
+
   /exec-sh/0.3.6:
     resolution: {integrity: sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==}
     dev: true
@@ -4428,6 +4585,15 @@ packages:
 
   /extend/3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: true
+
+  /external-editor/3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
     dev: true
 
   /extglob/2.0.4:
@@ -4831,6 +4997,11 @@ packages:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
     dev: true
 
+  /graphql/16.3.0:
+    resolution: {integrity: sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==}
+    engines: {node: ^12.22.0 || ^14.16.0 || >=16.0.0}
+    dev: true
+
   /has-bigints/1.0.1:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
 
@@ -4904,6 +5075,10 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+
+  /headers-polyfill/3.0.7:
+    resolution: {integrity: sha512-JoLCAdCEab58+2/yEmSnOlficyHFpIl0XJqwu3l+Unkm1gXpFUYsThz6Yha3D6tNhocWkCPfyW0YVIGWFqTi7w==}
+    dev: true
 
   /hey-listen/1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
@@ -4992,6 +5167,10 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: true
+
   /ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -5052,6 +5231,26 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /inquirer/8.2.2:
+    resolution: {integrity: sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      external-editor: 3.1.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.5.5
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+    dev: true
+
   /internal-slot/1.0.3:
     resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
     engines: {node: '>= 0.4'}
@@ -5099,6 +5298,13 @@ packages:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
       has-bigints: 1.0.1
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: true
 
   /is-boolean-object/1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -5220,6 +5426,11 @@ packages:
       is-path-inside: 3.0.3
     dev: true
 
+  /is-interactive/1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+    dev: true
+
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: true
@@ -5235,6 +5446,10 @@ packages:
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
+
+  /is-node-process/1.0.1:
+    resolution: {integrity: sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==}
+    dev: true
 
   /is-number-object/1.0.6:
     resolution: {integrity: sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==}
@@ -5609,6 +5824,15 @@ packages:
       '@types/node': 15.0.1
       jest-mock: 27.4.2
       jest-util: 27.4.2
+    dev: true
+
+  /jest-fetch-mock/3.0.3:
+    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+    dependencies:
+      cross-fetch: 3.1.5
+      promise-polyfill: 8.2.3
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /jest-get-type/27.4.0:
@@ -5989,6 +6213,11 @@ packages:
   /jquery/3.6.0:
     resolution: {integrity: sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==}
     dev: false
+
+  /js-levenshtein/1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6417,6 +6646,40 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /msw/0.39.2:
+    resolution: {integrity: sha512-ju/HpqQpE4/qCxZ23t5Gaau0KREn4QuFzdG28nP1EpidMrymMJuIvNd32+2uGTGG031PMwrC41YW7vCxHOwyHA==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@mswjs/cookies': 0.2.0
+      '@mswjs/interceptors': 0.15.1
+      '@open-draft/until': 1.0.3
+      '@types/cookie': 0.4.1
+      '@types/js-levenshtein': 1.1.1
+      chalk: 4.1.1
+      chokidar: 3.5.3
+      cookie: 0.4.2
+      graphql: 16.3.0
+      headers-polyfill: 3.0.7
+      inquirer: 8.2.2
+      is-node-process: 1.0.1
+      js-levenshtein: 1.1.6
+      node-fetch: 2.6.7
+      path-to-regexp: 6.2.0
+      statuses: 2.0.1
+      strict-event-emitter: 0.2.4
+      type-fest: 1.4.0
+      yargs: 17.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /mute-stream/0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+    dev: true
+
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
@@ -6448,6 +6711,18 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: false
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
@@ -6632,8 +6907,32 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
+  /ora/5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+    dev: true
+
+  /os-tmpdir/1.0.2:
+    resolution: {integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /ospath/1.2.2:
     resolution: {integrity: sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=}
+    dev: true
+
+  /outvariant/1.3.0:
+    resolution: {integrity: sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==}
     dev: true
 
   /p-finally/1.0.0:
@@ -6732,6 +7031,10 @@ packages:
     dependencies:
       isarray: 0.0.1
     dev: false
+
+  /path-to-regexp/6.2.0:
+    resolution: {integrity: sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==}
+    dev: true
 
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -6850,6 +7153,10 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /promise-polyfill/8.2.3:
+    resolution: {integrity: sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==}
     dev: true
 
   /prompts/2.4.2:
@@ -7128,6 +7435,22 @@ packages:
       strip-bom: 4.0.0
     dev: true
 
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -7283,6 +7606,11 @@ packages:
     engines: {node: 6.* || >= 7.*}
     dev: true
 
+  /run-async/2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -7298,6 +7626,12 @@ packages:
 
   /rxjs/7.5.2:
     resolution: {integrity: sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==}
+    dependencies:
+      tslib: 2.3.1
+    dev: true
+
+  /rxjs/7.5.5:
+    resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
     dependencies:
       tslib: 2.3.1
     dev: true
@@ -7428,6 +7762,10 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /set-cookie-parser/2.4.8:
+    resolution: {integrity: sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==}
     dev: true
 
   /set-value/2.0.1:
@@ -7687,6 +8025,11 @@ packages:
       object-copy: 0.1.0
     dev: true
 
+  /statuses/2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
   /stitches-mixins/1.0.0_73fcdc46612131d6a260c62ab2f3b5ab:
     resolution: {integrity: sha512-h9sHAAZL3M+CrMeBm6C1u9ncvqtnV/+U0uNTYieYediGC1z9CiutbuFMsnzhXOTCQ0ygv1cscneR5na8sdmGvA==}
     peerDependencies:
@@ -7701,6 +8044,12 @@ packages:
       '@stitches/core': 1.2.5
       '@stitches/react': 1.2.5_react@17.0.2
     dev: false
+
+  /strict-event-emitter/0.2.4:
+    resolution: {integrity: sha512-xIqTLS5azUH1djSUsLH9DbP6UnM/nI18vu8d43JigCQEoVsnY+mrlE+qv6kYqs6/1OkMnMIiL6ffedQSZStuoQ==}
+    dependencies:
+      events: 3.3.0
+    dev: true
 
   /string-length/4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -7743,6 +8092,12 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
 
   /strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -7932,6 +8287,13 @@ packages:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
 
+  /tmp/0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: true
+
   /tmp/0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
     engines: {node: '>=8.17.0'}
@@ -8002,7 +8364,6 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
-    dev: false
 
   /tr46/2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
@@ -8137,6 +8498,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /type-fest/1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
@@ -8245,6 +8611,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    dev: true
+
   /util.promisify/1.0.1:
     resolution: {integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==}
     dependencies:
@@ -8311,9 +8681,14 @@ packages:
       makeerror: 1.0.12
     dev: true
 
+  /wcwidth/1.0.1:
+    resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
+    dependencies:
+      defaults: 1.0.3
+    dev: true
+
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
-    dev: false
 
   /webidl-conversions/5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
@@ -8340,7 +8715,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /whatwg-url/8.7.0:
     resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
@@ -8518,6 +8892,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /yargs-parser/21.0.1:
+    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs/16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
@@ -8529,6 +8908,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+    dev: true
+
+  /yargs/17.4.1:
+    resolution: {integrity: sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.0.1
     dev: true
 
   /yauzl/2.10.0:

--- a/services/auth-server/client/tsconfig.build.json
+++ b/services/auth-server/client/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.[t|j]sx?$",
+    "**/*.mock.[t|j]sx?$"
+  ],
+  "include": ["src/**/*.d.ts", "src/**/*.[t|j]sx?$"]
+}

--- a/services/auth-server/client/tsconfig.json
+++ b/services/auth-server/client/tsconfig.json
@@ -1,9 +1,20 @@
 {
   "extends": "../../../tsconfig.json",
-  "exclude": ["node_modules"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"],
   "compilerOptions": {
-    "types": ["jest", "@emotion/react/types/css-prop"],
-    "baseUrl": "."
+    "types": ["jest", "node", "@emotion/react/types/css-prop"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noFallthroughCasesInSwitch": true,
+    "downlevelIteration": true
   }
 }

--- a/services/orchest-webserver/client/customTransformer.js
+++ b/services/orchest-webserver/client/customTransformer.js
@@ -1,17 +1,27 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+const { createTransformer } = require("esbuild-jest");
 const { transformSync } = require("esbuild");
 
 // For mocking API calls with `msw`, it requires complete URL's.
 // https://mswjs.io/docs/getting-started/integrate/node#direct-usage
 // Therefore we need to replace the string literal `__BASE_URL__`
-// with `testURL` in `jest.config.js`.
+// with testURL (NOTE: this `testURL` be the same as `testURL` in `jest.config.js`
+
+const transformer = createTransformer({
+  sourcemap: true,
+  loaders: { ".test.ts": "tsx" },
+});
 
 module.exports = {
-  process(src) {
-    const result = transformSync(src, {
-      define: { __BASE_URL__: '"http://localhost:8080"' },
-    });
-    return result;
+  process(fileContent, filePath, jestConfig) {
+    return transformer.process(
+      transformSync(fileContent, {
+        define: { __BASE_URL__: '"http://localhost:8080"' },
+      }),
+      fileContent,
+      filePath,
+      jestConfig
+    );
   },
 };

--- a/services/orchest-webserver/client/customTransformer.js
+++ b/services/orchest-webserver/client/customTransformer.js
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { createTransformer } = require("esbuild-jest");
+
+// For mocking API calls with `msw`, it requires complete URL's.
+// https://mswjs.io/docs/getting-started/integrate/node#direct-usage
+// Therefore we need to replace the string literal `__BASE_URL__`
+// with testURL (NOTE: this `testURL` be the same as `testURL` in `jest.config.js`
+const testURL = "http://localhost:8080";
+
+const token = "__BASE_URL__";
+const regex = new RegExp(token, "g");
+
+const transformer = createTransformer({
+  sourcemap: true,
+  loaders: {
+    ".test.ts": "tsx",
+  },
+});
+
+module.exports = {
+  process(fileContent, filePath, jestConfig) {
+    return transformer.process(
+      fileContent.replace(regex, `"${testURL}"`),
+      fileContent,
+      filePath,
+      jestConfig
+    );
+  },
+};

--- a/services/orchest-webserver/client/customTransformer.js
+++ b/services/orchest-webserver/client/customTransformer.js
@@ -1,27 +1,100 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { createTransformer } = require("esbuild-jest");
 const { transformSync } = require("esbuild");
+const path = require("path");
 
-// For mocking API calls with `msw`, it requires complete URL's.
-// https://mswjs.io/docs/getting-started/integrate/node#direct-usage
-// Therefore we need to replace the string literal `__BASE_URL__`
-// with testURL (NOTE: this `testURL` be the same as `testURL` in `jest.config.js`
+/**
+ * Disclaimer
+ *
+ * This jest transformer code is modified from https://github.com/aelbore/esbuild-jest
+ * The reason for extending the oritinal code is that the original repo does not support esbuild options.
+ */
 
-const transformer = createTransformer({
+const loaders = ["js", "jsx", "ts", "tsx", "json"];
+
+const getExt = (str) => {
+  const basename = path.basename(str);
+  const firstDot = basename.indexOf(".");
+  const lastDot = basename.lastIndexOf(".");
+  const extname = path.extname(basename).replace(/(\.[a-z0-9]+).*/i, "$1");
+
+  if (firstDot === lastDot) return extname;
+
+  return basename.slice(firstDot, lastDot) + extname;
+};
+
+const options = {
   sourcemap: true,
   loaders: { ".test.ts": "tsx" },
-});
+};
+
+const esbuildOptions = {
+  // For mocking API calls with `msw`, it requires complete URL's.
+  // https://mswjs.io/docs/getting-started/integrate/node#direct-usage
+  // Therefore we need to replace the string literal `__BASE_URL__`
+  // with testURL (NOTE: this `testURL` be the same as `testURL` in `jest.config.js`
+  define: { __BASE_URL__: `"http://localhost:8080"` },
+};
 
 module.exports = {
-  process(fileContent, filePath, jestConfig) {
-    return transformer.process(
-      transformSync(fileContent, {
-        define: { __BASE_URL__: '"http://localhost:8080"' },
-      }),
-      fileContent,
-      filePath,
-      jestConfig
-    );
+  process(content, filename, config, opts) {
+    const sources = { code: content };
+    const ext = getExt(filename),
+      extName = path.extname(filename).slice(1);
+
+    const enableSourcemaps = options.sourcemap || false;
+    const loader =
+      options.loaders && options.loaders[ext]
+        ? options.loaders[ext]
+        : loaders.includes(extName)
+        ? extName
+        : "text";
+    const sourcemaps = enableSourcemaps
+      ? { sourcemap: true, sourcesContent: false, sourcefile: filename }
+      : {};
+
+    /// this logic or code from
+    /// https://github.com/threepointone/esjest-transform/blob/main/src/index.js
+    /// this will support the jest.mock
+    /// https://github.com/aelbore/esbuild-jest/issues/12
+    /// TODO: transform the jest.mock to a function using babel traverse/parse then hoist it
+    if (sources.code.indexOf("ock(") >= 0 || (opts && opts.instrument)) {
+      const source = require("./transformer").babelTransform({
+        sourceText: content,
+        sourcePath: filename,
+        config,
+        options: opts,
+      });
+      sources.code = source;
+    }
+
+    const result = transformSync(sources.code, {
+      loader,
+      format: options.format || "cjs",
+      target: options.target || "es2018",
+      ...(options.jsxFactory ? { jsxFactory: options.jsxFactory } : {}),
+      ...(options.jsxFragment ? { jsxFragment: options.jsxFragment } : {}),
+      ...sourcemaps,
+      ...esbuildOptions,
+    });
+
+    let { map, code } = result;
+    if (enableSourcemaps) {
+      map = {
+        ...JSON.parse(result.map),
+        sourcesContent: null,
+      };
+
+      // Append the inline sourcemap manually to ensure the "sourcesContent"
+      // is null. Otherwise, breakpoints won't pause within the actual source.
+      code =
+        code +
+        "\n//# sourceMappingURL=data:application/json;base64," +
+        Buffer.from(JSON.stringify(map)).toString("base64");
+    } else {
+      map = null;
+    }
+
+    return { code, map };
   },
 };

--- a/services/orchest-webserver/client/customTransformer.js
+++ b/services/orchest-webserver/client/customTransformer.js
@@ -1,30 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { createTransformer } = require("esbuild-jest");
+const { transformSync } = require("esbuild");
 
 // For mocking API calls with `msw`, it requires complete URL's.
 // https://mswjs.io/docs/getting-started/integrate/node#direct-usage
 // Therefore we need to replace the string literal `__BASE_URL__`
-// with testURL (NOTE: this `testURL` be the same as `testURL` in `jest.config.js`
-const testURL = "http://localhost:8080";
-
-const token = "__BASE_URL__";
-const regex = new RegExp(token, "g");
-
-const transformer = createTransformer({
-  sourcemap: true,
-  loaders: {
-    ".test.ts": "tsx",
-  },
-});
+// with `testURL` in `jest.config.js`.
 
 module.exports = {
-  process(fileContent, filePath, jestConfig) {
-    return transformer.process(
-      fileContent.replace(regex, `"${testURL}"`),
-      fileContent,
-      filePath,
-      jestConfig
-    );
+  process(src) {
+    const result = transformSync(src, {
+      define: { __BASE_URL__: "http://localhost:8080" },
+    });
+    return result;
   },
 };

--- a/services/orchest-webserver/client/customTransformer.js
+++ b/services/orchest-webserver/client/customTransformer.js
@@ -10,7 +10,7 @@ const { transformSync } = require("esbuild");
 module.exports = {
   process(src) {
     const result = transformSync(src, {
-      define: { __BASE_URL__: "http://localhost:8080" },
+      define: { __BASE_URL__: '"http://localhost:8080"' },
     });
     return result;
   },

--- a/services/orchest-webserver/client/jest.config.js
+++ b/services/orchest-webserver/client/jest.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { pathsToModuleNameMapper } = require("ts-jest/utils");
+const { pathsToModuleNameMapper } = require("ts-jest");
 const { compilerOptions } = require("./tsconfig");
 
 module.exports = {
@@ -10,15 +10,7 @@ module.exports = {
     prefix: "<rootDir>/",
   }),
   transform: {
-    "^.+\\.[t|j]sx?$": [
-      "esbuild-jest",
-      {
-        sourcemap: true,
-        loaders: {
-          ".test.ts": "tsx",
-        },
-      },
-    ],
+    "^.+\\.[t|j]sx?$": "<rootDir>/customTransformer.js",
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   coverageDirectory: "<rootDir>/reports",
@@ -40,4 +32,5 @@ module.exports = {
   collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}"],
   modulePathIgnorePatterns: ["__mocks__"],
   testEnvironment: "jsdom",
+  testURL: "http://localhost:8080",
 };

--- a/services/orchest-webserver/client/jest.config.js
+++ b/services/orchest-webserver/client/jest.config.js
@@ -9,13 +9,6 @@ module.exports = {
     prefix: "<rootDir>/",
   }),
   transform: {
-    "^.+\\.[t|j]sx?$": [
-      "esbuild-jest",
-      {
-        sourcemap: true,
-        loaders: { ".test.ts": "tsx" },
-      },
-    ],
     "^.+\\.[t|j]sx?$": "<rootDir>/customTransformer.js",
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],

--- a/services/orchest-webserver/client/jest.config.js
+++ b/services/orchest-webserver/client/jest.config.js
@@ -5,11 +5,17 @@ const { compilerOptions } = require("./tsconfig");
 module.exports = {
   verbose: true,
   preset: "ts-jest",
-  testEnvironment: "node",
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: "<rootDir>/",
   }),
   transform: {
+    "^.+\\.[t|j]sx?$": [
+      "esbuild-jest",
+      {
+        sourcemap: true,
+        loaders: { ".test.ts": "tsx" },
+      },
+    ],
     "^.+\\.[t|j]sx?$": "<rootDir>/customTransformer.js",
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],

--- a/services/orchest-webserver/client/jest.setup.js
+++ b/services/orchest-webserver/client/jest.setup.js
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom/extend-expect";
+import "jest-fetch-mock";
+import { server } from "./src/__mocks__/server.mock";
+
+// Establish API mocking before all tests.
+beforeAll(() => server.listen());
+// Reset any request handlers that we may add during the tests,
+// so they don't affect other tests.
+afterEach(() => server.resetHandlers());
+// Clean up after the tests are finished.
+afterAll(() => server.close());

--- a/services/orchest-webserver/client/jest.setup.js
+++ b/services/orchest-webserver/client/jest.setup.js
@@ -1,6 +1,6 @@
-import "@testing-library/jest-dom/extend-expect";
-import "jest-fetch-mock";
-import { server } from "./src/__mocks__/server.mock";
+require("@testing-library/jest-dom/extend-expect");
+require("jest-fetch-mock");
+const { server } = require("./src/__mocks__/server.mock"); // eslint-disable-line @typescript-eslint/no-var-requires
 
 // Establish API mocking before all tests.
 beforeAll(() => server.listen());

--- a/services/orchest-webserver/client/jest.setup.js
+++ b/services/orchest-webserver/client/jest.setup.js
@@ -1,6 +1,6 @@
-require("@testing-library/jest-dom/extend-expect");
-require("jest-fetch-mock");
-const { server } = require("./src/__mocks__/server.mock"); // eslint-disable-line @typescript-eslint/no-var-requires
+import "@testing-library/jest-dom/extend-expect";
+import "jest-fetch-mock";
+import { server } from "./src/__mocks__/server.mock";
 
 // Establish API mocking before all tests.
 beforeAll(() => server.listen());

--- a/services/orchest-webserver/client/package.json
+++ b/services/orchest-webserver/client/package.json
@@ -72,10 +72,13 @@
     "@types/react": "17.0.3",
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.2",
+    "cross-env": "^7.0.3",
     "esbuild": "~0.14.0",
     "esbuild-jest": "^0.5.0",
     "jest": "^27.4.5",
+    "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^13.0.0",
+    "msw": "^0.39.2",
     "sass-bin": "^1.43.2",
     "ts-jest": "^27.1.2",
     "typescript": "4.5.4"

--- a/services/orchest-webserver/client/package.json
+++ b/services/orchest-webserver/client/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
+    "@jest/transform": "^27.5.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/codemirror": "^5.60.5",

--- a/services/orchest-webserver/client/src/__mocks__/handlers.mock.tsx
+++ b/services/orchest-webserver/client/src/__mocks__/handlers.mock.tsx
@@ -1,0 +1,41 @@
+// src/handlers.js
+import { rest } from "msw";
+import type { PipelineMetaData } from "../types";
+
+export const MOCK_PROJECT_ID_1 = "mock-project-id-1";
+export const MOCK_PROJECT_ID_2 = "mock-project-id-2";
+
+export const MOCK_PIPELINES: Record<string, PipelineMetaData[]> = {
+  [MOCK_PROJECT_ID_1]: [
+    {
+      uuid: `${MOCK_PROJECT_ID_1}-pipeline-1`,
+      path: "project_1_pipeline_1.orchest",
+      name: "Project 1 Pipeline 1",
+    },
+    {
+      uuid: `${MOCK_PROJECT_ID_1}-pipeline-2`,
+      path: "project_1_pipeline_2.orchest",
+      name: "Project 1 Pipeline 2",
+    },
+  ],
+  [MOCK_PROJECT_ID_2]: [
+    {
+      uuid: `${MOCK_PROJECT_ID_2}-pipeline-1`,
+      path: "project_2_pipeline_1.orchest",
+      name: "Project 2 Pipeline 1",
+    },
+    {
+      uuid: `${MOCK_PROJECT_ID_2}-pipeline-2`,
+      path: "project_2_pipeline_2.orchest",
+      name: "Project 2 Pipeline 2",
+    },
+  ],
+};
+
+export const handlers = [
+  rest.get(`/async/pipelines/:projectUuid`, (req, res, ctx) => {
+    const { projectUuid } = req.params;
+
+    return res(ctx.json({ result: MOCK_PIPELINES[projectUuid as string] }));
+  }),
+];

--- a/services/orchest-webserver/client/src/__mocks__/server.mock.tsx
+++ b/services/orchest-webserver/client/src/__mocks__/server.mock.tsx
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers.mock";
+
+export const server = setupServer(...handlers);

--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -158,7 +158,7 @@ export const ProjectsContextProvider: React.FC = ({ children }) => {
     isFetchingPipelines,
     error,
     fetchPipelines,
-  } = useFetchPipelines(state.projectUuid);
+  } = useFetchPipelines({ projectUuid: state.projectUuid });
 
   const hasPipelinesChanged = useHasChanged(state.pipelines);
 

--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -4,7 +4,7 @@ import type { PipelineMetaData, Project } from "@/types";
 import React from "react";
 import { KeyedMutator } from "swr";
 
-export const ProjectsContext = React.createContext<IProjectsContext>(
+const ProjectsContext = React.createContext<IProjectsContext>(
   {} as IProjectsContext
 );
 

--- a/services/orchest-webserver/client/src/contexts/__tests__/ProjectsContext.test.tsx
+++ b/services/orchest-webserver/client/src/contexts/__tests__/ProjectsContext.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import React from "react";
+import {
+  MOCK_PIPELINES,
+  MOCK_PROJECT_ID_1,
+  MOCK_PROJECT_ID_2,
+} from "../../__mocks__/handlers.mock";
+import {
+  ProjectsContextProvider,
+  useProjectsContext,
+} from "../ProjectsContext";
+
+const wrapper = ({ children }) => {
+  return <ProjectsContextProvider>{children}</ProjectsContextProvider>;
+};
+
+describe("useProjectsContext", () => {
+  const { result, waitForNextUpdate, rerender, unmount } = renderHook(
+    () => useProjectsContext(),
+    { wrapper }
+  );
+
+  beforeEach(async () => {
+    rerender();
+
+    // Before each case, MOCK_PROJECT_ID_1 should be loaded
+
+    expect(result.current.state.projectUuid).toEqual(undefined);
+    expect(result.current.state.pipelines).toEqual(undefined);
+    expect(result.current.state.pipeline).toEqual(undefined);
+
+    // Test case starts
+
+    act(() => {
+      result.current.dispatch({
+        type: "SET_PROJECT",
+        payload: MOCK_PROJECT_ID_1,
+      });
+    });
+
+    // First render
+
+    expect(result.current.state.projectUuid).toEqual(MOCK_PROJECT_ID_1);
+    expect(result.current.state.pipelines).toEqual(undefined);
+    expect(result.current.state.pipeline).toEqual(undefined);
+
+    await waitForNextUpdate();
+
+    expect(result.current.state.pipelines).toEqual(
+      MOCK_PIPELINES[MOCK_PROJECT_ID_1]
+    );
+
+    expect(result.current.state.pipeline).toEqual(undefined);
+  });
+
+  afterEach(() => {
+    unmount();
+  });
+
+  it("should clean up pipelines and pipeilne when changing project uuid", async () => {
+    act(() => {
+      result.current.dispatch({
+        type: "SET_PROJECT",
+        payload: MOCK_PROJECT_ID_2,
+      });
+    });
+
+    expect(result.current.state.projectUuid).toEqual(MOCK_PROJECT_ID_2);
+    expect(result.current.state.pipelines).toEqual(undefined);
+    expect(result.current.state.pipeline).toEqual(undefined);
+  });
+
+  it("should refetch pipelines when changing project uuid", async () => {
+    act(() => {
+      result.current.dispatch({
+        type: "SET_PROJECT",
+        payload: MOCK_PROJECT_ID_2,
+      });
+    });
+
+    expect(result.current.state.projectUuid).toEqual(MOCK_PROJECT_ID_2);
+    expect(result.current.state.pipelines).toEqual(
+      MOCK_PIPELINES[MOCK_PROJECT_ID_2]
+    );
+    expect(result.current.state.pipeline).toEqual(undefined);
+  });
+
+  it("should be able to switch pipeline by uuid", async () => {
+    const pipelineUuid = `${MOCK_PROJECT_ID_1}-pipeline-2`;
+    act(() => {
+      result.current.dispatch({
+        type: "UPDATE_PIPELINE",
+        payload: { uuid: pipelineUuid },
+      });
+    });
+
+    expect(result.current.state.projectUuid).toEqual(MOCK_PROJECT_ID_1);
+    expect(result.current.state.pipelines).toEqual(
+      MOCK_PIPELINES[MOCK_PROJECT_ID_1]
+    );
+    expect(result.current.state.pipeline).toEqual(
+      MOCK_PIPELINES[MOCK_PROJECT_ID_1][1]
+    );
+  });
+
+  it("should be able to update pipeline by uuid", async () => {
+    const pipeline = MOCK_PIPELINES[MOCK_PROJECT_ID_1][0];
+
+    act(() => {
+      result.current.dispatch({
+        type: "UPDATE_PIPELINE",
+        payload: {
+          uuid: pipeline.uuid,
+          path: "new-path.orchest",
+          name: "New Name",
+        },
+      });
+    });
+
+    expect(result.current.state.projectUuid).toEqual(MOCK_PROJECT_ID_1);
+    expect(result.current.state.pipeline).toEqual({
+      uuid: pipeline.uuid,
+      path: "new-path.orchest",
+      name: "New Name",
+    });
+  });
+});

--- a/services/orchest-webserver/client/src/environment-edit-view/__tests__/useAutoSaveEnvironment.test.tsx
+++ b/services/orchest-webserver/client/src/environment-edit-view/__tests__/useAutoSaveEnvironment.test.tsx
@@ -19,7 +19,7 @@ describe("useAutoSaveEnvironment", () => {
   it("should not save when given environment is unchanged", () => {
     jest.useFakeTimers();
 
-    const save = jest.fn(() => null);
+    const save = jest.fn(() => Promise.resolve(null));
 
     const { rerender } = renderHook(
       ({ environment }) => useAutoSaveEnvironment(environment, save),
@@ -40,7 +40,7 @@ describe("useAutoSaveEnvironment", () => {
   it("should fire save when given environment is changed", () => {
     jest.useFakeTimers();
 
-    const save = jest.fn(() => null);
+    const save = jest.fn(() => Promise.resolve(null));
 
     const { rerender } = renderHook(
       ({ environment }) => useAutoSaveEnvironment(environment, save),

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
@@ -4,10 +4,13 @@ import React from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { MutatorCallback } from "swr/dist/types";
 
-export const useFetchPipelines = (
-  projectUuid: string | undefined,
-  shouldFetch = true
-) => {
+export const useFetchPipelines = ({
+  projectUuid,
+  shouldFetch = true,
+}: {
+  projectUuid: string | undefined;
+  shouldFetch?: boolean;
+}) => {
   const { cache } = useSWRConfig();
   const { data, error, isValidating, mutate } = useSWR<PipelineMetaData[]>(
     projectUuid && shouldFetch ? `/async/pipelines/${projectUuid}` : null,

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
@@ -17,6 +17,10 @@ export const useFetchPipelines = (
       )
   );
 
+  if (error) {
+    console.log(error);
+  }
+
   const setPipelines = React.useCallback(
     (
       data?:

--- a/services/orchest-webserver/client/tsconfig.build.json
+++ b/services/orchest-webserver/client/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.[t|j]sx?$",
+    "**/*.mock.[t|j]sx?$"
+  ],
+  "include": ["src/**/*.d.ts", "src/**/*.[t|j]sx?$"]
+}

--- a/services/orchest-webserver/client/tsconfig.json
+++ b/services/orchest-webserver/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.mock.ts"],
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"],
   "compilerOptions": {
     "types": ["jest", "node", "@emotion/react/types/css-prop"],
     "baseUrl": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
-  },
+    "incremental": true
+  }
 }


### PR DESCRIPTION
## Description

This PR adds tests on the logic of switching pipelines in `ProjectsContext`. These test cases could help ruling out the logic errors in the `ProjectsContext`.

This PR also sets up API mocking with [msw](https://mswjs.io/), so that we can test against the FE side of the integration.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.