### PR TITLE
Fix session not auto-started when changing pipeline in PipelineEditor

### DIFF
--- a/services/orchest-webserver/client/src/components/EnvironmentList.tsx
+++ b/services/orchest-webserver/client/src/components/EnvironmentList.tsx
@@ -2,6 +2,7 @@ import { useAppContext } from "@/contexts/AppContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useMounted } from "@/hooks/useMounted";
 import { siteMap } from "@/Routes";
+import { IOrchestSession } from "@/types";
 import AddIcon from "@mui/icons-material/Add";
 import LensIcon from "@mui/icons-material/Lens";
 import Box from "@mui/material/Box";
@@ -230,7 +231,7 @@ const EnvironmentList: React.FC<IEnvironmentListProps> = ({ projectUuid }) => {
     environmentName: string
   ) => {
     if (!projectUuid) return false;
-    const sessionData = await fetcher<{ sessions: any[] }>(
+    const sessionData = await fetcher<{ sessions: IOrchestSession[] }>(
       `/catch/api-proxy/api/sessions/?project_uuid=${projectUuid}`
     );
     if (sessionData.sessions.length > 0) {

--- a/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
+++ b/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
@@ -30,7 +30,8 @@ const SessionToggleButton = (props: ISessionToggleButtonProps) => {
     getSession({
       pipelineUuid,
       projectUuid,
-    })?.status;
+    })?.status ||
+    "";
 
   const disabled =
     state.sessionsIsLoading || ["STOPPING", "LAUNCHING"].includes(status);

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -93,13 +93,11 @@ export const useSessionsPoller = () => {
     }
   }, [error, setAlert]);
 
-  const sessions: IOrchestSession[] = React.useMemo(() => {
+  const sessions: IOrchestSession[] | undefined = React.useMemo(() => {
     return (
       data?.sessions.map((session) =>
         convertKeyToCamelCase(session, ["project_uuid", "pipeline_uuid"])
-      ) ||
-      cache.get(ENDPOINT)?.sessions || // in case sessions are needed when polling is not active
-      []
+      ) || cache.get(ENDPOINT)?.sessions // in case sessions are needed when polling is not active
     );
   }, [data, cache]);
 


### PR DESCRIPTION
## Description

Session auto-start is not working as expected as it was designed to manage one session at a time. With the removal of `PipelinesView`, session auto-start should be triggered when changing pipeline (i.e. pipeline uuid).

