### PR TITLE
Add project-not-found error

### DIFF
--- a/services/orchest-webserver/client/src/components/ProjectBasedView.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectBasedView.tsx
@@ -1,3 +1,4 @@
+import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { siteMap } from "@/Routes";
 import AddIcon from "@mui/icons-material/Add";
@@ -7,25 +8,24 @@ import Button from "@mui/material/Button";
 import React from "react";
 
 export interface IProjectBasedViewProps {
-  projectUuid?: string;
   sx?: SxProps<Theme>;
 }
 
 const message =
   "It looks like you don't have any projects yet! To get started using Orchest create your first project.";
 
-const ProjectBasedView: React.FC<IProjectBasedViewProps> = ({
-  projectUuid,
-  children,
-}) => {
+const ProjectBasedView: React.FC<IProjectBasedViewProps> = ({ children }) => {
   const { navigateTo } = useCustomRoute();
+  const {
+    state: { hasLoadedProjects, projectUuid },
+  } = useProjectsContext();
 
   const goToProjects = (e: React.MouseEvent) =>
     navigateTo(siteMap.projects.path, undefined, e);
 
   return (
     <Box className="view-page">
-      {projectUuid ? (
+      {!hasLoadedProjects ? null : projectUuid ? (
         children
       ) : (
         <div>

--- a/services/orchest-webserver/client/src/components/ProjectSelector.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectSelector.tsx
@@ -120,9 +120,9 @@ export const ProjectSelector = () => {
           "Project not found",
           <Stack direction="column" spacing={2}>
             <Box>
-              {`Project with the given uuid `}
+              {`Couldn't find project `}
               <Code>{projectUuidFromRoute}</Code>
-              {` is not found. This project might have been deleted, or you might have had a wrong URL.`}
+              {` . The project might have been deleted, or you might have had a wrong URL.`}
             </Box>
             <Box>Will try to load another existing project if any.</Box>
           </Stack>

--- a/services/orchest-webserver/client/src/components/ProjectSelector.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectSelector.tsx
@@ -1,21 +1,26 @@
 // @ts-check
+import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useMatchRoutePaths } from "@/hooks/useMatchProjectRoot";
 import { siteMap, withinProjectPaths } from "@/routingConfig";
 import type { Project } from "@/types";
+import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
 import InputBase from "@mui/material/InputBase";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
 import { styled } from "@mui/material/styles";
 import {
+  hasValue,
   makeCancelable,
   makeRequest,
   PromiseManager,
 } from "@orchest/lib-utils";
 import React from "react";
+import { Code } from "./common/Code";
 
 const CustomInput = styled(InputBase)(({ theme }) => ({
   "&.Mui-focused .MuiInputBase-input": {
@@ -33,8 +38,15 @@ const CustomInput = styled(InputBase)(({ theme }) => ({
 }));
 
 export const ProjectSelector = () => {
+  const { setAlert } = useAppContext();
   const { state, dispatch } = useProjectsContext();
-  const { navigateTo, projectUuid: projectUuidFromRoute } = useCustomRoute();
+  const {
+    navigateTo,
+    projectUuid: projectUuidFromRoute,
+    pipelineUuid,
+    jobUuid,
+    runUuid,
+  } = useCustomRoute();
   // if current view only involves ONE project, ProjectSelector would appear
   const matchWithinProjectPaths = useMatchRoutePaths(withinProjectPaths);
 
@@ -46,7 +58,9 @@ export const ProjectSelector = () => {
         ? matchWithinProjectPaths.root || matchWithinProjectPaths.path
         : siteMap.pipeline.path;
 
-      navigateTo(path, { query: { projectUuid: uuid } });
+      navigateTo(path, {
+        query: { projectUuid: uuid, pipelineUuid, jobUuid, runUuid },
+      });
     }
   };
 
@@ -54,12 +68,12 @@ export const ProjectSelector = () => {
   const validateProjectUuid = (
     uuidToValidate: string | undefined | null,
     projects: Project[]
-  ): string | null | undefined => {
-    let isValid = uuidToValidate
+  ): uuidToValidate is string => {
+    if (!hasValue(uuidToValidate)) return false;
+
+    return uuidToValidate
       ? projects.some((project) => project.uuid == uuidToValidate)
       : false;
-
-    return isValid ? uuidToValidate : undefined;
   };
 
   const fetchProjects = () => {
@@ -96,18 +110,30 @@ export const ProjectSelector = () => {
 
   React.useEffect(() => {
     if (state.hasLoadedProjects && matchWithinProjectPaths) {
-      const invalidProjectUuid = !validateProjectUuid(
-        projectUuidFromRoute,
-        state.projects
-      );
+      const validProjectUuid =
+        state.projects.length > 0 &&
+        projectUuidFromRoute &&
+        validateProjectUuid(projectUuidFromRoute, state.projects);
 
-      if (invalidProjectUuid) {
-        if (state.projects.length === 0) return;
-        // Select the first one from the given projects
-        let newProjectUuid = state.projects[0].uuid;
-        // navigate ONLY if user is at the project root and
-        // we're switching projects (because of detecting an
-        // invalidProjectUuid)
+      if (projectUuidFromRoute && !validProjectUuid) {
+        setAlert(
+          "Project not found",
+          <Stack direction="column" spacing={2}>
+            <Box>
+              {`Project with the given uuid `}
+              <Code>{projectUuidFromRoute}</Code>
+              {` is not found. This project might have been deleted, or you might have had a wrong URL.`}
+            </Box>
+            <Box>Will try to load another existing project if any.</Box>
+          </Stack>
+        );
+      }
+
+      const newProjectUuid = validProjectUuid
+        ? projectUuidFromRoute
+        : state.projects[0]?.uuid;
+
+      if (newProjectUuid) {
         dispatch({ type: "SET_PROJECT", payload: newProjectUuid });
         onChangeProject(newProjectUuid);
       }

--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -125,13 +125,29 @@ const reducer = (
       return { ...state, pipelineSaveStatus: action.payload };
     case "SET_PIPELINE_IS_READONLY":
       return { ...state, pipelineIsReadOnly: action.payload };
-    case "SET_PROJECT":
+    case "SET_PROJECT": {
+      if (!action.payload) {
+        return {
+          ...state,
+          projectUuid: undefined,
+          pipelines: undefined,
+          pipeline: undefined,
+        };
+      }
+      // Ensure that projectUuid is valid in the state.
+      // So that we could show proper warnings in case user provides
+      // an invalid projectUuid from the route args.
+      const foundProject = state.projects?.find(
+        (project) => project.uuid === action.payload
+      );
+      if (!foundProject) return state;
       return {
         ...state,
-        projectUuid: action.payload,
+        projectUuid: foundProject.uuid,
         pipelines: undefined,
         pipeline: undefined,
       };
+    }
     case "SET_PROJECTS":
       return { ...state, projects: action.payload, hasLoadedProjects: true };
     default: {

--- a/services/orchest-webserver/client/src/contexts/__tests__/ProjectsContext.test.tsx
+++ b/services/orchest-webserver/client/src/contexts/__tests__/ProjectsContext.test.tsx
@@ -32,6 +32,13 @@ describe("useProjectsContext", () => {
     // Test case starts
 
     act(() => {
+      // Temporarily not mocking the payload fully.
+      result.current.dispatch({
+        // @ts-ignore
+        type: "SET_PROJECTS",
+        // @ts-ignore
+        payload: [{ uuid: MOCK_PROJECT_ID_1 }, { uuid: MOCK_PROJECT_ID_2 }],
+      });
       result.current.dispatch({
         type: "SET_PROJECT",
         payload: MOCK_PROJECT_ID_1,

--- a/services/orchest-webserver/client/src/hooks/useEnsureValidPipeline.tsx
+++ b/services/orchest-webserver/client/src/hooks/useEnsureValidPipeline.tsx
@@ -45,9 +45,9 @@ export const useEnsureValidPipeline = () => {
         "Pipeline not found",
         <Stack direction="column" spacing={2}>
           <Box>
-            {`Pipeline with the given uuid `}
+            {`Couldn't find pipeline `}
             <Code>{pipelineUuid}</Code>
-            {` is not found. This pipeline might have been deleted, or you might have had a wrong URL.`}
+            {` . The pipeline might have been deleted, or you might have had a wrong URL.`}
           </Box>
           <Box>Will try to load another pipeline in this project.</Box>
         </Stack>

--- a/services/orchest-webserver/client/src/hooks/useEnsureValidPipeline.tsx
+++ b/services/orchest-webserver/client/src/hooks/useEnsureValidPipeline.tsx
@@ -47,9 +47,9 @@ export const useEnsureValidPipeline = () => {
           <Box>
             {`Pipeline with the given uuid `}
             <Code>{pipelineUuid}</Code>
-            {` is not found. You might have had a wrong URL, or this pipeline might have been deleted.`}
+            {` is not found. This pipeline might have been deleted, or you might have had a wrong URL.`}
           </Box>
-          <Box>Will try to load other pipelines in this project.</Box>
+          <Box>Will try to load another pipeline in this project.</Box>
         </Stack>
       );
     }

--- a/services/orchest-webserver/client/src/jobs-view/JobsView.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/JobsView.tsx
@@ -13,7 +13,7 @@ const JobsView: React.FC = () => {
 
   return (
     <Layout>
-      <ProjectBasedView projectUuid={projectUuid}>
+      <ProjectBasedView>
         <JobList projectUuid={projectUuid}></JobList>
       </ProjectBasedView>
     </Layout>

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineView.tsx
@@ -46,7 +46,7 @@ const PipelineView = () => {
           </FileManagerContextProvider>
         </PipelineEditorContextProvider>
       ) : (
-        <ProjectBasedView projectUuid={projectUuid} />
+        <ProjectBasedView />
       )}
     </Layout>
   );

--- a/services/orchest-webserver/client/src/views/EnvironmentsView.tsx
+++ b/services/orchest-webserver/client/src/views/EnvironmentsView.tsx
@@ -12,7 +12,7 @@ const EnvironmentsView: React.FC = () => {
 
   return (
     <Layout>
-      <ProjectBasedView projectUuid={projectUuid}>
+      <ProjectBasedView>
         <EnvironmentList projectUuid={projectUuid} />
       </ProjectBasedView>
     </Layout>


### PR DESCRIPTION
## Description

Currently Orechest switches to an existing project if the given project UUID is invalid. This PR adds an alert if the said case occurs.

<img width="1917" alt="Screenshot 2022-04-25 at 13 37 10" src="https://user-images.githubusercontent.com/627607/165081605-7a39a0e8-1c53-4d35-9559-a721992a1aa4.png">



## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.
