### PR TITLE
Apply useCancelablePromise and useCancelableFetch

### DIFF
--- a/lib/javascript/utils/src/typed.ts
+++ b/lib/javascript/utils/src/typed.ts
@@ -7,69 +7,6 @@ export function uuidv4() {
   });
 }
 
-type CancelablePromise<T = string> = {
-  cancel: () => void;
-  promise: Promise<T>;
-};
-
-// used in orchest-webserver only
-export class PromiseManager {
-  cancelablePromises: CancelablePromise<any>[]; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-  constructor() {
-    this.cancelablePromises = [];
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  appendCancelablePromise(cancelablePromise: CancelablePromise<any>) {
-    this.cancelablePromises.push(cancelablePromise);
-  }
-
-  cancelCancelablePromises() {
-    for (let cancelablePromise of this.cancelablePromises) {
-      cancelablePromise.cancel();
-    }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  clearCancelablePromise(cancelablePromise: CancelablePromise<any>) {
-    let index = this.cancelablePromises.indexOf(cancelablePromise);
-    this.cancelablePromises.splice(index, 1);
-  }
-}
-
-// used in orchest-webserver only
-export function makeCancelable<T = string>(
-  promise: Promise<T>,
-  promiseManager: PromiseManager
-) {
-  let hasCanceled_ = false;
-
-  let cancelablePromise: CancelablePromise<T> = {
-    cancel() {
-      hasCanceled_ = true;
-    },
-    promise: new Promise<T>((resolve, reject) => {
-      promise.then(
-        (val) => {
-          hasCanceled_ ? reject({ isCanceled: true }) : resolve(val);
-
-          promiseManager.clearCancelablePromise(cancelablePromise);
-        },
-        (error) => {
-          hasCanceled_ ? reject({ isCanceled: true }) : reject(error);
-
-          promiseManager.clearCancelablePromise(cancelablePromise);
-        }
-      );
-    }),
-  };
-
-  promiseManager.appendCancelablePromise(cancelablePromise);
-
-  return cancelablePromise;
-}
-
 // used in orchest-webserver only
 export const ALLOWED_STEP_EXTENSIONS = ["ipynb", "py", "R", "sh", "jl"];
 
@@ -160,11 +97,7 @@ export function someParentHasClass(element, classname) {
 }
 
 // used in mdc-components only
-export function checkHeartbeat(url, retries?) {
-  if (retries === undefined) {
-    retries = 250;
-  }
-
+export function checkHeartbeat(url: string, retries = 250) {
   let tries = 0;
 
   let requestLambda = (resolve, reject) => {

--- a/services/orchest-webserver/client/src/components/EnvVarList.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarList.tsx
@@ -16,7 +16,11 @@ export type EnvVarPair = {
 
 export const EnvVarList: React.FC<{
   value: EnvVarPair[];
-  setValue?: (callback: (currentValue: EnvVarPair[]) => EnvVarPair[]) => void;
+  setValue?: (
+    callback: (
+      currentValue: EnvVarPair[] | undefined
+    ) => EnvVarPair[] | undefined
+  ) => void;
   readOnly?: boolean;
   ["data-test-id"]?: string;
 }> = ({
@@ -28,6 +32,7 @@ export const EnvVarList: React.FC<{
   const onChange = (payload: string, index: number, type: "name" | "value") => {
     if (!setValue) return;
     setValue((current) => {
+      if (!current) return current;
       const found = current[index];
       const updated = { ...found, [type]: payload };
       return [...current.slice(0, index), updated, ...current.slice(index + 1)];
@@ -36,12 +41,13 @@ export const EnvVarList: React.FC<{
 
   const onAdd = () => {
     if (!setValue) return;
-    setValue((current) => [...current, { name: "", value: "" }]);
+    setValue((current) => [...(current || []), { name: "", value: "" }]);
   };
 
   const remove = (index: number) => {
     if (!setValue) return;
     setValue((current) => {
+      if (!current) return [];
       if (index < 0 || index >= current.length) return current;
       return [...current.slice(0, index), ...current.slice(index + 1)];
     });

--- a/services/orchest-webserver/client/src/components/ProjectSelector.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectSelector.tsx
@@ -1,7 +1,7 @@
 // @ts-check
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useMatchRoutePaths } from "@/hooks/useMatchProjectRoot";
 import { siteMap, withinProjectPaths } from "@/routingConfig";
@@ -46,7 +46,7 @@ export const ProjectSelector = () => {
   // if current view only involves ONE project, ProjectSelector would appear
   const matchWithinProjectPaths = useMatchRoutePaths(withinProjectPaths);
 
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
 
   const onChangeProject = (uuid: string) => {
     if (uuid) {

--- a/services/orchest-webserver/client/src/components/ProjectSelector.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectSelector.tsx
@@ -46,7 +46,7 @@ export const ProjectSelector = () => {
   // if current view only involves ONE project, ProjectSelector would appear
   const matchWithinProjectPaths = useMatchRoutePaths(withinProjectPaths);
 
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   const onChangeProject = (uuid: string) => {
     if (uuid) {
@@ -83,13 +83,13 @@ export const ProjectSelector = () => {
     // ProjectSelector only appears at Project Root, i.e. pipelines, jobs, and environments
     // in case that project is deleted
     if (matchWithinProjectPaths) {
-      fetcher<Project[]>("/async/projects?skip_discovery=true")
+      cancelableFetch<Project[]>("/async/projects?skip_discovery=true")
         .then((fetchedProjects) => {
           dispatch({ type: "SET_PROJECTS", payload: fetchedProjects });
         })
         .catch((error) => console.log(error));
     }
-  }, [matchWithinProjectPaths, fetcher, dispatch]);
+  }, [matchWithinProjectPaths, cancelableFetch, dispatch]);
 
   React.useEffect(() => {
     if (state.hasLoadedProjects && matchWithinProjectPaths) {

--- a/services/orchest-webserver/client/src/components/SystemDialog.tsx
+++ b/services/orchest-webserver/client/src/components/SystemDialog.tsx
@@ -15,12 +15,12 @@ import React from "react";
 
 type CancellableMessage = Extract<PromptMessage, Confirm>;
 type CancellableType = Extract<PromptMessageType, "confirm">;
-const cancellableTypes: CancellableType[] = ["confirm"];
-// use type guard to ensure the promptMessage is cancellable
+const cancelableTypes: CancellableType[] = ["confirm"];
+// use type guard to ensure the promptMessage is cancelable
 const checkCancellable = (
   message: PromptMessage
 ): message is CancellableMessage => {
-  return typedIncludes(cancellableTypes, message.type);
+  return typedIncludes(cancelableTypes, message.type);
 };
 
 // If the trigger of the Dialog is also a keydown, setting the default prop `autoFocus` to `true` will also trigger the button click.
@@ -86,14 +86,14 @@ export const SystemDialog: React.FC = () => {
 
   // handles when user click away the dialog
   const dialogOnClose = () => {
-    // if the prompt message is cancellable, we cancel it and do nothing
+    // if the prompt message is cancelable, we cancel it and do nothing
     if (isCancellable) {
       cancel();
       return;
     }
     // below we handle click-away behavior case by case
     // ==============================================================================
-    // alert is not cancellable, when user click away, it's seen as "confirm"
+    // alert is not cancelable, when user click away, it's seen as "confirm"
     if (promptMessage.type === "alert") confirm();
   };
 

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -357,7 +357,7 @@ const convertConfirm: PromptMessageConverter<Confirm> = ({
 export const AppContextProvider: React.FC = ({ children }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage("drawer", true);
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   /**
    * =========================== side effects
@@ -368,7 +368,7 @@ export const AppContextProvider: React.FC = ({ children }) => {
   React.useEffect(() => {
     const fetchServerConfig = async () => {
       try {
-        const serverConfig = await fetcher<OrchestServerConfig>(
+        const serverConfig = await cancelableFetch<OrchestServerConfig>(
           "/async/server-config"
         );
         dispatch({ type: "SET_SERVER_CONFIG", payload: serverConfig });

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -1,3 +1,4 @@
+import { useCancellableFetch } from "@/hooks/useCancellablePromise";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   BuildRequest,
@@ -6,7 +7,6 @@ import {
   OrchestServerConfig,
   OrchestUserConfig,
 } from "@/types";
-import { fetcher } from "@orchest/lib-utils";
 import React from "react";
 
 /** Utility functions
@@ -357,6 +357,7 @@ const convertConfirm: PromptMessageConverter<Confirm> = ({
 export const AppContextProvider: React.FC = ({ children }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage("drawer", true);
+  const { fetcher } = useCancellableFetch();
 
   /**
    * =========================== side effects

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
   BuildRequest,
@@ -357,7 +357,7 @@ const convertConfirm: PromptMessageConverter<Confirm> = ({
 export const AppContextProvider: React.FC = ({ children }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage("drawer", true);
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
 
   /**
    * =========================== side effects

--- a/services/orchest-webserver/client/src/hooks/useAsync.ts
+++ b/services/orchest-webserver/client/src/hooks/useAsync.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { useCancellablePromise } from "./useCancellablePromise";
+import { useCancelablePromise } from "./useCancelablePromise";
 
 export type STATUS = "IDLE" | "PENDING" | "RESOLVED" | "REJECTED";
 
@@ -58,7 +58,7 @@ const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
   });
 
   const { data, error, status } = state as State<T, E>;
-  const { makeCancelable } = useCancellablePromise();
+  const { makeCancelable } = useCancelablePromise();
 
   const run = React.useCallback(
     (promise: Promise<T>) => {

--- a/services/orchest-webserver/client/src/hooks/useAsync.ts
+++ b/services/orchest-webserver/client/src/hooks/useAsync.ts
@@ -58,12 +58,12 @@ const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
   });
 
   const { data, error, status } = state as State<T, E>;
-  const { makeCancellable } = useCancellablePromise();
+  const { makeCancelable } = useCancellablePromise();
 
   const run = React.useCallback(
     (promise: Promise<T>) => {
       dispatch({ type: "PENDING", caching });
-      return makeCancellable(
+      return makeCancelable(
         promise.then(
           (data) => {
             dispatch({ type: "RESOLVED", data });
@@ -76,7 +76,7 @@ const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
         )
       );
     },
-    [dispatch, caching, makeCancellable]
+    [dispatch, caching, makeCancelable]
   );
 
   const setData = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useCancelablePromise.ts
+++ b/services/orchest-webserver/client/src/hooks/useCancelablePromise.ts
@@ -55,5 +55,5 @@ export function useCancelableFetch() {
     [makeCancelable]
   );
 
-  return { fetcher: cancelableFetch };
+  return { cancelableFetch };
 }

--- a/services/orchest-webserver/client/src/hooks/useCancelablePromise.ts
+++ b/services/orchest-webserver/client/src/hooks/useCancelablePromise.ts
@@ -22,7 +22,7 @@ function _makeCancelable<T>(promise: Promise<T>) {
   };
 }
 
-export function useCancellablePromise() {
+export function useCancelablePromise() {
   const cancelablePromises = React.useRef<CancelablePromise<unknown>[]>([]);
   React.useEffect(() => {
     return () => {
@@ -40,9 +40,9 @@ export function useCancellablePromise() {
   return { makeCancelable };
 }
 
-export function useCancellableFetch() {
-  const { makeCancelable } = useCancellablePromise();
-  const cancellableFetch = React.useCallback(
+export function useCancelableFetch() {
+  const { makeCancelable } = useCancelablePromise();
+  const cancelableFetch = React.useCallback(
     function <T>(
       url: string,
       params?: RequestInit | undefined,
@@ -55,5 +55,5 @@ export function useCancellableFetch() {
     [makeCancelable]
   );
 
-  return { fetcher: cancellableFetch };
+  return { fetcher: cancelableFetch };
 }

--- a/services/orchest-webserver/client/src/hooks/useCancellablePromise.ts
+++ b/services/orchest-webserver/client/src/hooks/useCancellablePromise.ts
@@ -1,0 +1,53 @@
+import { fetcher } from "@orchest/lib-utils";
+import React from "react";
+
+type CancelablePromise<T> = {
+  promise: Promise<T>;
+  cancel: () => void;
+};
+
+// https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+function makeCancelable<T>(promise: Promise<T>) {
+  let isCanceled = false;
+  const wrappedPromise = new Promise<T>((resolve, reject) => {
+    promise
+      .then((val) => (isCanceled ? reject({ isCanceled }) : resolve(val)))
+      .catch((error) => (isCanceled ? reject({ isCanceled }) : reject(error)));
+  });
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      isCanceled = true;
+    },
+  };
+}
+
+export function useCancellablePromise() {
+  const cancelablePromises = React.useRef<CancelablePromise<unknown>[]>([]);
+  React.useEffect(() => {
+    return () => {
+      cancelablePromises.current.forEach((p) => p.cancel());
+      cancelablePromises.current = [];
+    };
+  }, []);
+
+  const makeCancellable = React.useCallback(function <T>(p: Promise<T>) {
+    const cPromise = makeCancelable(p);
+    cancelablePromises.current.push(cPromise);
+    return cPromise.promise;
+  }, []);
+
+  return { makeCancellable };
+}
+
+export function useCancalableFetch() {
+  const { makeCancellable } = useCancellablePromise();
+  const cancellableFetch = React.useCallback(
+    function <T>(url: string, params?: RequestInit | undefined) {
+      return makeCancellable(fetcher<T>(url, params));
+    },
+    [makeCancellable]
+  );
+
+  return { fecther: cancellableFetch };
+}

--- a/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
+++ b/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
@@ -13,9 +13,9 @@ import { useHistory, useLocation } from "react-router-dom";
 // console.log(isReadOnly); // true
 const useLocationState = <T>(stateNames: string[]) => {
   const location = useLocation<{ state: Record<string, T> }>();
-  return stateNames.map((stateName) =>
+  return (stateNames.map((stateName) =>
     location.state ? location.state[stateName] : null
-  );
+  ) as unknown) as T;
 };
 
 // see https://reactrouter.com/web/example/query-parameters

--- a/services/orchest-webserver/client/src/hooks/useOverflowListener.ts
+++ b/services/orchest-webserver/client/src/hooks/useOverflowListener.ts
@@ -1,0 +1,13 @@
+import { OverflowListener } from "@/utils/webserver-utils";
+import React from "react";
+
+export const useOverflowListener = (shouldLoad = true) => {
+  const overflowListener = React.useMemo(() => new OverflowListener(), []);
+
+  React.useEffect(() => {
+    if (shouldLoad) overflowListener.attach();
+    return () => {
+      overflowListener.detach();
+    };
+  }, [overflowListener, shouldLoad]);
+};

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -12,6 +12,7 @@ import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useEnsureValidPipeline } from "@/hooks/useEnsureValidPipeline";
+import { useOverflowListener } from "@/hooks/useOverflowListener";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/Routes";
 import type {
@@ -22,7 +23,6 @@ import type {
 import {
   envVariablesArrayToDict,
   isValidEnvironmentVariableName,
-  OverflowListener,
   validatePipeline,
 } from "@/utils/webserver-utils";
 import AddIcon from "@mui/icons-material/Add";
@@ -170,15 +170,12 @@ const PipelineSettingsView: React.FC = () => {
   }
 
   const hasLoaded =
-    pipelineJson && envVariables && (isReadOnly || projectEnvVariables);
+    pipelineJson &&
+    envVariables &&
+    (isReadOnly || hasValue(projectEnvVariables));
 
   // If the component has loaded, attach the resize listener
-  const overflowListener = React.useMemo(() => new OverflowListener(), []);
-  React.useEffect(() => {
-    if (hasLoaded) {
-      overflowListener.attach();
-    }
-  }, [hasLoaded, overflowListener]);
+  useOverflowListener(hasLoaded);
 
   const onChangeService = (uuid: string, service: Service) => {
     setServices((current) => {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
@@ -1,4 +1,4 @@
-import EnvVarList from "@/components/EnvVarList";
+import EnvVarList, { EnvVarPair } from "@/components/EnvVarList";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useFetchEnvironments } from "@/hooks/useFetchEnvironments";
 import { Service } from "@/types";
@@ -471,10 +471,15 @@ const ServiceForm: React.FC<{
                 <EnvVarList
                   value={envVarsDictToList(service.env_variables || {})}
                   readOnly={disabled}
-                  setValue={(dispatcher) => {
-                    const updated = dispatcher(
-                      envVarsDictToList(service.env_variables || {})
-                    );
+                  setValue={(
+                    dispatcher: (
+                      currentValue: EnvVarPair[] | undefined
+                    ) => EnvVarPair[] | undefined
+                  ) => {
+                    const updated =
+                      dispatcher(
+                        envVarsDictToList(service.env_variables || {})
+                      ) || [];
                     handleServiceChange(
                       "env_variables",
                       updated.reduce((obj, current) => {

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContainer.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContainer.tsx
@@ -20,7 +20,7 @@ export const FileManagerContainer = React.forwardRef<
     uploadFiles: (files: File[] | FileList) => Promise<void>;
   }
 >(function FileManagerContainerComponent({ children, uploadFiles, sx }, ref) {
-  const localRef = React.useRef<typeof Stack>(null);
+  const localRef = React.useRef<typeof Stack | null>(null);
 
   const { pipelineUuid } = useCustomRoute();
   const disabled = !pipelineUuid;

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
@@ -82,7 +82,7 @@ export const StepDetailsProperties = ({
     EnvironmentOption[]
   >([]);
 
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
   const refManager = React.useMemo(() => new RefManager(), []);
 
   const isNotebookStep = extensionFromFilename(step.file_path) === "ipynb";
@@ -118,7 +118,7 @@ export const StepDetailsProperties = ({
         "?language=" + kernelNameToLanguage(step.kernel.name);
     }
 
-    fetcher<Environment[]>(environmentsEndpoint)
+    cancelableFetch<Environment[]>(environmentsEndpoint)
       .then((result) => {
         let options: EnvironmentOption[] = [];
 

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
@@ -1,3 +1,4 @@
+import { useCancellableFetch } from "@/hooks/useCancellablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import ProjectFilePicker from "@/pipeline-view/step-details/ProjectFilePicker";
 import { Environment, PipelineStepState, Step } from "@/types";
@@ -14,9 +15,7 @@ import Typography from "@mui/material/Typography";
 import {
   collapseDoubleDots,
   extensionFromFilename,
-  fetcher,
   kernelNameToLanguage,
-  PromiseManager,
   RefManager,
 } from "@orchest/lib-utils";
 import "codemirror/mode/javascript/javascript";
@@ -83,7 +82,7 @@ export const StepDetailsProperties = ({
     EnvironmentOption[]
   >([]);
 
-  const promiseManager = React.useMemo(() => new PromiseManager(), []);
+  const { fetcher } = useCancellableFetch();
   const refManager = React.useMemo(() => new RefManager(), []);
 
   const isNotebookStep = extensionFromFilename(step.file_path) === "ipynb";
@@ -325,7 +324,6 @@ export const StepDetailsProperties = ({
     fetchEnvironmentOptions();
 
     return () => {
-      promiseManager.cancelCancelablePromises();
       clearConnectionListener();
     };
   }, []);

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
@@ -1,4 +1,4 @@
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import ProjectFilePicker from "@/pipeline-view/step-details/ProjectFilePicker";
 import { Environment, PipelineStepState, Step } from "@/types";
@@ -82,7 +82,7 @@ export const StepDetailsProperties = ({
     EnvironmentOption[]
   >([]);
 
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
   const refManager = React.useMemo(() => new RefManager(), []);
 
   const isNotebookStep = extensionFromFilename(step.file_path) === "ipynb";

--- a/services/orchest-webserver/client/src/projects-view/EditProjectPathDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/EditProjectPathDialog.tsx
@@ -19,7 +19,7 @@ export const EditProjectPathDialog = ({
   setProjects,
   projects,
 }: {
-  projectUuid: string;
+  projectUuid: string | undefined;
   onClose: () => void;
   setProjects: (
     data?: Project[] | Promise<Project[]> | MutatorCallback<Project[]>
@@ -44,7 +44,7 @@ export const EditProjectPathDialog = ({
   }, [projectUuid, projects, setProjectName]);
 
   const isFormValid =
-    (projectName.length > 0 && validation.length === 0) ||
+    (projectName.length > 0 && validation && validation.length === 0) ||
     isUpdatingProjectPath;
 
   const closeDialog = () => {
@@ -64,9 +64,10 @@ export const EditProjectPathDialog = ({
         body: JSON.stringify({ name: projectName }),
       });
       setProjects((projects) => {
+        if (!projects) return projects;
         const copy = [...projects];
         const found = copy.find((p) => p.uuid === projectUuid);
-        found.path = projectName;
+        if (found) found.path = projectName;
         return copy;
       });
     } catch (error) {

--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -26,8 +26,8 @@ const ERROR_MAPPING: Record<CreateProjectError, string> = {
     "project name contains illegal character(s).",
 } as const;
 
-const getMappedErrorMessage = (key: CreateProjectError | string) => {
-  if (ERROR_MAPPING[key] !== undefined) {
+const getMappedErrorMessage = (key: CreateProjectError | string | null) => {
+  if (key && ERROR_MAPPING[key] !== undefined) {
     return ERROR_MAPPING[key];
   } else {
     return "undefined error. Please try again.";
@@ -57,7 +57,7 @@ const getProjectNameFromUrl = (importUrl: string) => {
 const ImportDialog: React.FC<{
   projectName: string;
   setProjectName: React.Dispatch<React.SetStateAction<string>>;
-  importUrl?: string;
+  importUrl: string;
   setImportUrl: (url: string) => void;
   onImportComplete?: (backgroundTaskResult: BackgroundTask) => void;
   open: boolean;

--- a/services/orchest-webserver/client/src/projects-view/common.tsx
+++ b/services/orchest-webserver/client/src/projects-view/common.tsx
@@ -1,4 +1,6 @@
-export const validProjectName = (projectName: string | undefined) => {
+export const validProjectName = (
+  projectName: string | undefined
+): { valid: true } | { valid: false; reason: string } => {
   if (projectName === undefined || projectName.length === 0) {
     return {
       valid: false,

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -222,7 +222,8 @@ export function checkGate(project_uuid: string) {
 }
 
 export class OverflowListener {
-  triggerOverflow: any;
+  private observer: ResizeObserver | undefined;
+  private triggerOverflow: HTMLElement | undefined;
 
   constructor() {} // eslint-disable-line @typescript-eslint/no-empty-function
 
@@ -233,19 +234,25 @@ export class OverflowListener {
 
       let triggerOverflow = $(".trigger-overflow").first()[0];
       if (triggerOverflow && this.triggerOverflow !== triggerOverflow) {
-        new ResizeObserver(() => {
-          if (triggerOverflow) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            if ($(triggerOverflow).overflowing()) {
-              $(".observe-overflow").addClass("overflowing");
-            } else {
-              $(".observe-overflow").removeClass("overflowing");
-            }
-          }
-        }).observe(triggerOverflow);
         this.triggerOverflow = triggerOverflow;
+        this.observer = new ResizeObserver(() => {
+          if (!this.triggerOverflow) return;
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          if ($(this.triggerOverflow).overflowing()) {
+            $(".observe-overflow").addClass("overflowing");
+          } else {
+            $(".observe-overflow").removeClass("overflowing");
+          }
+        });
+        this.observer.observe(this.triggerOverflow);
       }
+    }
+  }
+
+  detach() {
+    if (this.observer && this.triggerOverflow) {
+      this.observer.unobserve(this.triggerOverflow);
     }
   }
 }

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -4,7 +4,7 @@ import { ImageBuildLog } from "@/components/ImageBuildLog";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/Routes";
 import { EnvironmentImageBuild } from "@/types";
@@ -32,7 +32,7 @@ const ConfigureJupyterLabView: React.FC = () => {
   } = useSessionsContext();
 
   useSendAnalyticEvent("view load", { name: siteMap.configureJupyterLab.path });
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
 
   // local states
   const [ignoreIncomingLogs, setIgnoreIncomingLogs] = React.useState(false);

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -32,7 +32,7 @@ const ConfigureJupyterLabView: React.FC = () => {
   } = useSessionsContext();
 
   useSendAnalyticEvent("view load", { name: siteMap.configureJupyterLab.path });
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   // local states
   const [ignoreIncomingLogs, setIgnoreIncomingLogs] = React.useState(false);
@@ -66,7 +66,7 @@ const ConfigureJupyterLabView: React.FC = () => {
     formData.append("setup_script", jupyterSetupScript);
 
     try {
-      await fetcher("/async/jupyter-setup-script", {
+      await cancelableFetch("/async/jupyter-setup-script", {
         method: "POST",
         body: formData,
       });
@@ -85,7 +85,7 @@ const ConfigureJupyterLabView: React.FC = () => {
 
     try {
       await save();
-      let response = await fetcher<{ jupyter_image_build: any }>(
+      let response = await cancelableFetch<{ jupyter_image_build: any }>(
         "/catch/api-proxy/api/jupyter-builds",
         { method: "POST" }
       );
@@ -141,7 +141,7 @@ const ConfigureJupyterLabView: React.FC = () => {
       setIsCancellingBuild(true);
 
       try {
-        await fetcher(
+        await cancelableFetch(
           `/catch/api-proxy/api/jupyter-builds/${jupyterBuild.uuid}`,
           { method: "DELETE" }
         );
@@ -164,7 +164,7 @@ const ConfigureJupyterLabView: React.FC = () => {
 
   const getSetupScript = React.useCallback(async () => {
     try {
-      const { script } = await fetcher<{ script: string }>(
+      const { script } = await cancelableFetch<{ script: string }>(
         "/async/jupyter-setup-script"
       );
       setJupyterSetupScript(script || "");

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -3,9 +3,9 @@ import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import {
-  useCancellableFetch,
-  useCancellablePromise,
-} from "@/hooks/useCancellablePromise";
+  useCancelableFetch,
+  useCancelablePromise,
+} from "@/hooks/useCancelablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelineJson } from "@/hooks/useFetchPipelineJson";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -39,8 +39,8 @@ const FilePreviewView: React.FC = () => {
   const { setAlert } = useAppContext();
   const { state: projectsState, dispatch } = useProjectsContext();
   useSendAnalyticEvent("view load", { name: siteMap.filePreview.path });
-  const { fetcher } = useCancellableFetch();
-  const { makeCancelable } = useCancellablePromise();
+  const { fetcher } = useCancelableFetch();
+  const { makeCancelable } = useCancelablePromise();
 
   // data from route
   const {

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -2,6 +2,10 @@ import { IconButton } from "@/components/common/IconButton";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
+import {
+  useCancellableFetch,
+  useCancellablePromise,
+} from "@/hooks/useCancellablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelineJson } from "@/hooks/useFetchPipelineJson";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -17,14 +21,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import Button from "@mui/material/Button";
 import LinearProgress from "@mui/material/LinearProgress";
-import {
-  fetcher,
-  hasValue,
-  makeCancelable,
-  makeRequest,
-  PromiseManager,
-  RefManager,
-} from "@orchest/lib-utils";
+import { hasValue, RefManager } from "@orchest/lib-utils";
 import "codemirror/mode/python/python";
 import "codemirror/mode/r/r";
 import "codemirror/mode/shell/shell";
@@ -42,6 +39,8 @@ const FilePreviewView: React.FC = () => {
   const { setAlert } = useAppContext();
   const { state: projectsState, dispatch } = useProjectsContext();
   useSendAnalyticEvent("view load", { name: siteMap.filePreview.path });
+  const { fetcher } = useCancellableFetch();
+  const { makeCancelable } = useCancellablePromise();
 
   // data from route
   const {
@@ -76,7 +75,6 @@ const FilePreviewView: React.FC = () => {
   const [retryIntervals, setRetryIntervals] = React.useState([]);
 
   const [refManager] = React.useState(new RefManager());
-  const [promiseManager] = React.useState(new PromiseManager());
 
   const loadPipelineView = (e: React.MouseEvent) => {
     const isJobRun = jobUuid && runUuid;
@@ -102,10 +100,12 @@ const FilePreviewView: React.FC = () => {
       ? getPipelineJSONEndpoint({ pipelineUuid, projectUuid, jobUuid, runUuid })
       : getPipelineJSONEndpoint({ pipelineUuid, projectUuid });
 
-    const [pipelineJson, job] = await Promise.all([
-      fetchPipelineJson(pipelineURL),
-      jobUuid ? fetcher<Job>(`/catch/api-proxy/api/jobs/${jobUuid}`) : null,
-    ]);
+    const [pipelineJson, job] = await makeCancelable(
+      Promise.all([
+        fetchPipelineJson(pipelineURL),
+        jobUuid ? fetcher<Job>(`/catch/api-proxy/api/jobs/${jobUuid}`) : null,
+      ])
+    );
 
     const pipelineFilePath =
       job?.pipeline_run_spec.run_config.pipeline_path ||
@@ -130,12 +130,7 @@ const FilePreviewView: React.FC = () => {
         loadingFile: true,
       }));
 
-      let fetchAllPromise = makeCancelable(
-        Promise.all([fetchFile(), fetchPipeline()]),
-        promiseManager
-      );
-
-      fetchAllPromise.promise
+      makeCancelable(Promise.all([fetchFile(), fetchPipeline()]))
         .then(() => {
           setState((prevState) => ({
             ...prevState,
@@ -152,32 +147,20 @@ const FilePreviewView: React.FC = () => {
         });
     });
 
-  const fetchFile = () =>
-    new Promise((resolve, reject) => {
-      let fileURL = `/async/file-viewer/${projectUuid}/${pipelineUuid}/${stepUuid}`;
-      if (isJobRun) {
-        fileURL += "?pipeline_run_uuid=" + runUuid;
-        fileURL += "&job_uuid=" + jobUuid;
-      }
+  const fetchFile = () => {
+    let fileURL = `/async/file-viewer/${projectUuid}/${pipelineUuid}/${stepUuid}`;
+    if (isJobRun) {
+      fileURL += "?pipeline_run_uuid=" + runUuid;
+      fileURL += "&job_uuid=" + jobUuid;
+    }
 
-      let fetchFilePromise = makeCancelable(
-        makeRequest("GET", fileURL),
-        promiseManager
-      );
-
-      fetchFilePromise.promise
-        .then((response) => {
-          setState((prevState) => ({
-            ...prevState,
-            fileDescription: JSON.parse(response),
-          }));
-          resolve(undefined);
-        })
-        .catch((err) => {
-          console.log(err);
-          reject();
-        });
+    return fetcher(fileURL).then((response) => {
+      setState((prevState) => ({
+        ...prevState,
+        fileDescription: response,
+      }));
     });
+  };
 
   const stepNavigate = (e: React.MouseEvent, newStepUuid: string) => {
     navigateTo(
@@ -290,8 +273,6 @@ const FilePreviewView: React.FC = () => {
     loadFile();
 
     return () => {
-      promiseManager.cancelCancelablePromises();
-
       retryIntervals.map((retryInterval) => clearInterval(retryInterval));
     };
   }, []);

--- a/services/orchest-webserver/client/src/views/FilePreviewView.tsx
+++ b/services/orchest-webserver/client/src/views/FilePreviewView.tsx
@@ -39,7 +39,7 @@ const FilePreviewView: React.FC = () => {
   const { setAlert } = useAppContext();
   const { state: projectsState, dispatch } = useProjectsContext();
   useSendAnalyticEvent("view load", { name: siteMap.filePreview.path });
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
   const { makeCancelable } = useCancelablePromise();
 
   // data from route
@@ -103,7 +103,9 @@ const FilePreviewView: React.FC = () => {
     const [pipelineJson, job] = await makeCancelable(
       Promise.all([
         fetchPipelineJson(pipelineURL),
-        jobUuid ? fetcher<Job>(`/catch/api-proxy/api/jobs/${jobUuid}`) : null,
+        jobUuid
+          ? cancelableFetch<Job>(`/catch/api-proxy/api/jobs/${jobUuid}`)
+          : null,
       ])
     );
 
@@ -154,7 +156,7 @@ const FilePreviewView: React.FC = () => {
       fileURL += "&job_uuid=" + jobUuid;
     }
 
-    return fetcher(fileURL).then((response) => {
+    return cancelableFetch(fileURL).then((response) => {
       setState((prevState) => ({
         ...prevState,
         fileDescription: response,

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -2,6 +2,10 @@ import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useInterval } from "@/hooks/use-interval";
+import {
+  useCancellableFetch,
+  useCancellablePromise,
+} from "@/hooks/useCancellablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelineJson } from "@/hooks/useFetchPipelineJson";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -12,12 +16,7 @@ import Box from "@mui/material/Box";
 import LinearProgress from "@mui/material/LinearProgress";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import {
-  collapseDoubleDots,
-  fetcher,
-  makeCancelable,
-  PromiseManager,
-} from "@orchest/lib-utils";
+import { collapseDoubleDots } from "@orchest/lib-utils";
 import React from "react";
 
 export type IJupyterLabViewProps = TViewPropsWithRequiredQueryArgs<
@@ -28,6 +27,8 @@ const JupyterLabView: React.FC = () => {
   // global states
   const { requestBuild } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.jupyterLab.path });
+  const { makeCancelable } = useCancellablePromise();
+  const { fetcher } = useCancellableFetch();
 
   // data from route
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();
@@ -54,8 +55,6 @@ const JupyterLabView: React.FC = () => {
     [pipelineUuid, projectUuid, getSession]
   );
 
-  const [promiseManager] = React.useState(new PromiseManager());
-
   React.useEffect(() => {
     // mount
     checkEnvironmentGate();
@@ -64,7 +63,7 @@ const JupyterLabView: React.FC = () => {
       if (window.orchest.jupyter) {
         window.orchest.jupyter.hide();
       }
-      promiseManager.cancelCancelablePromises();
+
       setVerifyKernelsInterval(null);
     };
   }, []);
@@ -89,12 +88,7 @@ const JupyterLabView: React.FC = () => {
   }, [session, hasEnvironmentCheckCompleted]);
 
   const checkEnvironmentGate = () => {
-    let gateCancelablePromise = makeCancelable(
-      checkGate(projectUuid),
-      promiseManager
-    );
-
-    gateCancelablePromise.promise
+    makeCancelable(checkGate(projectUuid))
       .then(() => {
         setHasEnvironmentCheckCompleted(true);
         conditionalRenderingOfJupyterLab();
@@ -151,17 +145,21 @@ const JupyterLabView: React.FC = () => {
 
   const fetchPipeline = async () => {
     let pipelineJSONEndpoint = getPipelineJSONEndpoint({
-      pipelineUuid,
       projectUuid,
+      pipelineUuid,
     });
 
     try {
-      const [pipelineJson, pipeline] = await Promise.all([
-        fetchPipelineJson(pipelineJSONEndpoint),
-        pipelineUuid
-          ? fetcher<Pipeline>(`/async/pipelines/${projectUuid}/${pipelineUuid}`)
-          : null,
-      ]);
+      const [pipelineJson, pipeline] = await makeCancelable(
+        Promise.all([
+          fetchPipelineJson(pipelineJSONEndpoint),
+          pipelineUuid
+            ? fetcher<Pipeline>(
+                `/async/pipelines/${projectUuid}/${pipelineUuid}`
+              )
+            : null,
+        ])
+      );
 
       verifyKernelsCallback(pipelineJson);
 

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -28,7 +28,7 @@ const JupyterLabView: React.FC = () => {
   const { requestBuild } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.jupyterLab.path });
   const { makeCancelable } = useCancelablePromise();
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   // data from route
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();
@@ -154,7 +154,7 @@ const JupyterLabView: React.FC = () => {
         Promise.all([
           fetchPipelineJson(pipelineJSONEndpoint),
           pipelineUuid
-            ? fetcher<Pipeline>(
+            ? cancelableFetch<Pipeline>(
                 `/async/pipelines/${projectUuid}/${pipelineUuid}`
               )
             : null,

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -3,9 +3,9 @@ import { useAppContext } from "@/contexts/AppContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useInterval } from "@/hooks/use-interval";
 import {
-  useCancellableFetch,
-  useCancellablePromise,
-} from "@/hooks/useCancellablePromise";
+  useCancelableFetch,
+  useCancelablePromise,
+} from "@/hooks/useCancelablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelineJson } from "@/hooks/useFetchPipelineJson";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -27,8 +27,8 @@ const JupyterLabView: React.FC = () => {
   // global states
   const { requestBuild } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.jupyterLab.path });
-  const { makeCancelable } = useCancellablePromise();
-  const { fetcher } = useCancellableFetch();
+  const { makeCancelable } = useCancelablePromise();
+  const { fetcher } = useCancelableFetch();
 
   // data from route
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
@@ -32,7 +32,7 @@ const ProjectSettingsView: React.FC = () => {
     state: { hasUnsavedChanges },
   } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.projectSettings.path });
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   // data from route
   const { navigateTo, projectUuid } = useCustomRoute();
@@ -83,7 +83,7 @@ const ProjectSettingsView: React.FC = () => {
     }
 
     // perform PUT to update
-    fetcher(
+    cancelableFetch(
       `/async/projects/${projectUuid}`,
       {
         method: "PUT",
@@ -102,7 +102,7 @@ const ProjectSettingsView: React.FC = () => {
   useOverflowListener();
 
   const fetchSettings = () => {
-    fetcher<Project>(`/async/projects/${projectUuid}`)
+    cancelableFetch<Project>(`/async/projects/${projectUuid}`)
       .then((result) => {
         const {
           env_variables,

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
@@ -2,7 +2,7 @@ import { PageTitle } from "@/components/common/PageTitle";
 import EnvVarList, { EnvVarPair } from "@/components/EnvVarList";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useOverflowListener } from "@/hooks/useOverflowListener";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -32,7 +32,7 @@ const ProjectSettingsView: React.FC = () => {
     state: { hasUnsavedChanges },
   } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.projectSettings.path });
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
 
   // data from route
   const { navigateTo, projectUuid } = useCustomRoute();

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -2,7 +2,7 @@ import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
-import { useCancellableFetch } from "@/hooks/useCancellablePromise";
+import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useCheckUpdate } from "@/hooks/useCheckUpdate";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -35,7 +35,7 @@ const SettingsView: React.FC = () => {
   } = useAppContext();
 
   useSendAnalyticEvent("view load", { name: siteMap.settings.path });
-  const { fetcher } = useCancellableFetch();
+  const { fetcher } = useCancelableFetch();
 
   const [state, setState] = React.useState({
     status: "...",

--- a/services/orchest-webserver/client/src/views/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/SettingsView.tsx
@@ -35,7 +35,7 @@ const SettingsView: React.FC = () => {
   } = useAppContext();
 
   useSendAnalyticEvent("view load", { name: siteMap.settings.path });
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
 
   const [state, setState] = React.useState({
     status: "...",
@@ -51,13 +51,13 @@ const SettingsView: React.FC = () => {
   });
 
   const getVersion = () => {
-    fetcher<{ version: string }>("/async/version").then((response) => {
+    cancelableFetch<{ version: string }>("/async/version").then((response) => {
       setState((prevState) => ({ ...prevState, version: response.version }));
     });
   };
 
   const getHostInfo = () => {
-    fetcher("/async/host-info")
+    cancelableFetch("/async/host-info")
       .then((hostInfo: any) => {
         try {
           setState((prevState) => ({ ...prevState, hostInfo }));
@@ -69,7 +69,7 @@ const SettingsView: React.FC = () => {
   };
 
   const getConfig = () => {
-    fetcher<{ user_config: any }>("/async/user-config")
+    cancelableFetch<{ user_config: any }>("/async/user-config")
       .then(({ user_config: configJSON }) => {
         try {
           let visibleJSON = configToVisibleConfig(configJSON);
@@ -141,7 +141,11 @@ const SettingsView: React.FC = () => {
 
       setAsSaved(true);
 
-      fetcher("/async/user-config", { method: "POST", body: formData }, false)
+      cancelableFetch(
+        "/async/user-config",
+        { method: "POST", body: formData },
+        false
+      )
         .catch((e) => {
           console.error(e);
           setAlert("Error", JSON.parse(e.body).message);
@@ -174,7 +178,7 @@ const SettingsView: React.FC = () => {
   };
 
   const checkOrchestStatus = () => {
-    fetcher("/heartbeat")
+    cancelableFetch("/heartbeat")
       .then(() => {
         setState((prevState) => ({
           ...prevState,
@@ -203,7 +207,7 @@ const SettingsView: React.FC = () => {
           requiresRestart: [],
         }));
         try {
-          await fetcher("/async/restart", { method: "POST" }, false);
+          await cancelableFetch("/async/restart", { method: "POST" }, false);
           resolve(true);
 
           setTimeout(() => {

--- a/services/orchest-webserver/client/src/views/UpdateView.tsx
+++ b/services/orchest-webserver/client/src/views/UpdateView.tsx
@@ -20,7 +20,7 @@ const UpdateView: React.FC = () => {
   const { setConfirm, setAlert } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.update.path });
 
-  const { fetcher } = useCancelableFetch();
+  const { cancelableFetch } = useCancelableFetch();
   const { makeCancelable } = useCancelablePromise();
 
   const [state, setState] = React.useState((prevState) => ({
@@ -46,7 +46,7 @@ const UpdateView: React.FC = () => {
         console.log("Starting update.");
 
         try {
-          fetcher<{ token: string }>(
+          cancelableFetch<{ token: string }>(
             "/async/start-update",
             { method: "POST" },
             false
@@ -88,7 +88,7 @@ const UpdateView: React.FC = () => {
   };
 
   useInterval(() => {
-    fetcher<{ updating: boolean; update_output: any }>(
+    cancelableFetch<{ updating: boolean; update_output: any }>(
       `/update-sidecar/update-status?token=${state.token}`
     )
       .then((json) => {

--- a/services/orchest-webserver/client/src/views/UpdateView.tsx
+++ b/services/orchest-webserver/client/src/views/UpdateView.tsx
@@ -3,9 +3,9 @@ import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useInterval } from "@/hooks/use-interval";
 import {
-  useCancellableFetch,
-  useCancellablePromise,
-} from "@/hooks/useCancellablePromise";
+  useCancelableFetch,
+  useCancelablePromise,
+} from "@/hooks/useCancelablePromise";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
 import SystemUpdateAltIcon from "@mui/icons-material/SystemUpdateAlt";
@@ -20,8 +20,8 @@ const UpdateView: React.FC = () => {
   const { setConfirm, setAlert } = useAppContext();
   useSendAnalyticEvent("view load", { name: siteMap.update.path });
 
-  const { fetcher } = useCancellableFetch();
-  const { makeCancelable } = useCancellablePromise();
+  const { fetcher } = useCancelableFetch();
+  const { makeCancelable } = useCancelablePromise();
 
   const [state, setState] = React.useState((prevState) => ({
     ...prevState,


### PR DESCRIPTION
## Description

Combine the `makeCancelable` wrapper and `React.useEffect` as `useCancelablePromise`, which cancels the promise when unmounted automatically.

This PR also improves the usage of OverflowListener: call `unobserve` when unmount.

## Explanation

Cancelable fetch cannot be used in all cases. `useCancelablePromise` is a replacement of the old `PromiseManager`.
How you should use `PromiseManager`:
```ts
const promiseManager = React.useMemo(() => new PromiseManager(), [])

promiseManager.appendCancelablePromise(cancelablePromise);

let cancelablePromise = makeCancelable(
      fetch("/async/something"),
      promiseManager
    );

    fetchProjectsPromise.promise
      .then(() => {
        //....do things
      })

React.useEffect(() => {
    return () => promiseManager.cancelCancelablePromises();
}, []);
```
how you should use `useCancelablePromise`:
```ts
const { makeCancelable } = useCancelablePromise()

makeCancelable(fetch("/async/something"))
.then(() => {
 // do things...
})
```
Under the hood, they're the same.  `useCancelablePromise`  has a built-in cancellation effect, so no need to repeat it everywhere (making the code DRYer).

## Checklist
- [x] The PR branch is set up to merge into `dev` instead of `master`.

