### PR TITLE
Introduce event subscriptions and subscribers in `orchest-api`

### DIFF
--- a/services/orchest-api/app/app/apis/__init__.py
+++ b/services/orchest-api/app/app/apis/__init__.py
@@ -8,6 +8,7 @@ from app.apis.namespace_environments import api as ns_envs
 from app.apis.namespace_info import api as ns_info
 from app.apis.namespace_jobs import api as ns_jobs
 from app.apis.namespace_jupyter_image_builds import api as ns_jupyter_image_builds
+from app.apis.namespace_notifications import api as ns_notifications
 from app.apis.namespace_pipelines import api as ns_pipelines
 from app.apis.namespace_projects import api as ns_projects
 from app.apis.namespace_runs import api as ns_runs
@@ -31,6 +32,7 @@ api.add_namespace(ns_envs)
 api.add_namespace(ns_info)
 api.add_namespace(ns_jobs)
 api.add_namespace(ns_jupyter_image_builds)
+api.add_namespace(ns_notifications)
 api.add_namespace(ns_pipelines)
 api.add_namespace(ns_projects)
 api.add_namespace(ns_runs)

--- a/services/orchest-api/app/app/apis/namespace_notifications.py
+++ b/services/orchest-api/app/app/apis/namespace_notifications.py
@@ -1,0 +1,131 @@
+"""API endpoints related to notifications."""
+
+import sqlalchemy
+from flask import request
+from flask_restx import Namespace, Resource, marshal
+from sqlalchemy.orm import joinedload, noload
+
+from app import models, schema, utils
+from app.connections import db
+from app.core import notifications
+
+api = Namespace("notifications", description="Orchest-api notifications API.")
+api = utils.register_schema(api)
+
+logger = utils.get_logger()
+
+
+@api.route("/subscribable-events")
+class SubscribableEventList(Resource):
+    @api.doc("subscribable-events")
+    def get(self):
+        """Gets all subscribable events."""
+        return {"events": notifications.get_subscribable_events()}, 200
+
+
+@api.route("/subscribers")
+class SubscriberList(Resource):
+    @api.doc("get_subscribers")
+    @api.marshal_with(schema.subscribers)
+    def get(self):
+        """Gets all subscribers, without subscriptions."""
+        subscribers = models.Subscriber.query.options(
+            noload(models.Subscriber.subscriptions)
+        ).all()
+        return {"subscribers": subscribers}, 200
+
+    @api.doc("create_subscriber")
+    @api.expect(schema.subscriber_spec)
+    @api.response(200, "Success", schema.subscriber)
+    def post(self):
+        """Creates a subscriber with the given subscriptions.
+
+        Repeated subscription entries are ignored.
+        """
+        subscriber_spec = request.get_json()
+        subscriptions = subscriber_spec.get("subscriptions", [])
+
+        try:
+            subscriber = notifications.create_subscriber(subscriptions)
+        except (ValueError, sqlalchemy.exc.IntegrityError) as e:
+            return {"message": str(e)}, 400
+
+        db.session.commit()
+        return marshal(subscriber, schema.subscriber), 201
+
+
+@api.route("/subscribers/<string:uuid>")
+class Subscriber(Resource):
+    @api.doc("subscriber")
+    @api.marshal_with(schema.subscriber)
+    def get(self, uuid: str):
+        """Gets a subscriber, including its subscriptions."""
+        subscriber = (
+            models.Subscriber.query.options(joinedload(models.Subscriber.subscriptions))
+            .filter(models.Subscriber.uuid == uuid)
+            .one()
+        )
+
+        return subscriber, 200
+
+    @api.doc("delete_subscriber")
+    def delete(self, uuid: str):
+        models.Subscriber.query.filter(models.Subscriber.uuid == uuid).delete()
+        db.session.commit()
+        return {"message": ""}, 201
+
+
+@api.route("/subscribers/subscribed-to/<string:event_type>")
+class SubscribersSubscribedToEvent(Resource):
+    @api.doc("get_subscribers_subscribed_to_event")
+    @api.marshal_with(schema.subscribers)
+    @api.doc(
+        "get_subscribers_subscribed_to_event",
+        params={
+            "project_uuid": {
+                "description": (
+                    "Optional, uuid of the project to which the event is related."
+                ),
+                "type": str,
+            },
+            "job_uuid": {
+                "description": (
+                    "Optional, uuid of the job to which the event is related, if "
+                    "provided, 'project_uuid' must be provided as well."
+                ),
+                "type": str,
+            },
+        },
+    )
+    def get(self, event_type: str):
+        """Gets all subscribers subscribed to a given event_type.
+
+        Not passing anything (i.e. just specifying a `event_type`
+        through the path, no project/job uuid) means that you will be
+        querying for subscribers that are subscribed to the event
+        "globally", i.e. not specific to a project or a job, which
+        means that subscribers subscribed to a given event for a
+        specific project or job would not come up in the result. If you
+        know which project or job you are querying for you should
+        specify it.
+
+        This can be useful to know if, for example, a given job failure
+        would lead to any notification whatsoever.
+
+        Args:
+            event_type: An event_type from the list at
+                `/subscribable-events`, note that it must be
+                percent-encoded, see
+                https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding.
+        """
+
+        try:
+            alerted_subscribers = notifications.get_subscribers_subscribed_to_event(
+                event_type,
+                request.args.get("project_uuid"),
+                request.args.get("job_uuid"),
+            )
+        except ValueError as e:
+            return {"message": str(e)}, 400
+
+        return {"subscribers": alerted_subscribers}, 200

--- a/services/orchest-api/app/app/core/notifications/__init__.py
+++ b/services/orchest-api/app/app/core/notifications/__init__.py
@@ -1,0 +1,163 @@
+"""Module that covers the functionality related to notifications.
+
+A subscriber and its subscriptions are currently treated as a single
+block, meaning that a subscriber is created with a given set of
+subscriptions, which cannot later be altered. If wished for, this can be
+easily changed, since the db schema allows to do so.
+
+"""
+from typing import List, Optional
+
+from sqlalchemy.orm import noload
+
+from app import models, utils
+from app.connections import db
+
+logger = utils.get_logger()
+
+
+def get_subscribable_events() -> List[dict]:
+    event_types = models.EventType.query.all()
+    res = []
+    for event_type in event_types:
+        name = event_type.name
+        optional_filters = []
+
+        if name.startswith("project:"):
+            optional_filters.append(["project_uuid"])
+        if name.startswith("project:cron-job:") or name.startswith(
+            "project:one-off-job:"
+        ):
+            optional_filters.append(["project_uuid", "job_uuid"])
+        res.append({"name": name, "optional_filters": optional_filters})
+
+    return res
+
+
+def _subscription_specs_to_subscriptions(
+    subscriber_uuid: str, subscriptions: List[dict]
+) -> List[models.Subscription]:
+    subs_keys = set()
+    subscription_objects = []
+    for sub in subscriptions:
+        key = "|".join([f"{key}:{sub[key]}" for key in sorted(sub.keys())])
+        if key not in subs_keys:
+            subs_keys.add(key)
+            event_type = sub.get("event_type")
+            project_uuid = sub.get("project_uuid")
+            job_uuid = sub.get("job_uuid")
+            if event_type is None:
+                raise ValueError("Missing 'event_type'.")
+            if project_uuid is not None:
+                if job_uuid is None:
+                    subscription_objects.append(
+                        models.ProjectSpecificSubscription(
+                            subscriber_uuid=subscriber_uuid,
+                            event_type=sub["event_type"],
+                            project_uuid=project_uuid,
+                        )
+                    )
+                else:
+                    subscription_objects.append(
+                        models.ProjectJobSpecificSubscription(
+                            subscriber_uuid=subscriber_uuid,
+                            event_type=sub["event_type"],
+                            project_uuid=project_uuid,
+                            job_uuid=job_uuid,
+                        )
+                    )
+            elif job_uuid is not None:
+                raise ValueError(
+                    "Must specify 'project_uuid' if job_uuid is 'specified'."
+                )
+            else:
+                subscription_objects.append(
+                    models.Subscription(
+                        subscriber_uuid=subscriber_uuid,
+                        event_type=sub["event_type"],
+                    )
+                )
+    return subscription_objects
+
+
+def create_subscriber(subscriptions: List[dict]) -> models.Subscriber:
+    """Creates a subscriber entry in the database, does not commit.
+
+    This is a placeholder for future "real" subscribers.
+    """
+    if not subscriptions:
+        raise ValueError("A subscriber must have at least a subscription.")
+
+    subscriber = models.Subscriber()
+    db.session.add(subscriber)
+    # To avoid FK errors and to force sqlalchemy to generate the
+    # subscriber uuid.
+    db.session.flush()
+    subs = _subscription_specs_to_subscriptions(subscriber.uuid, subscriptions)
+    db.session.bulk_save_objects(subs)
+    return subscriber
+
+
+def get_subscribers_subscribed_to_event(
+    event_type: str,
+    project_uuid: Optional[str] = None,
+    job_uuid: Optional[str] = None,
+) -> List[models.Subscriber]:
+    """Gets all subscribers subscribed to an event.
+
+    When only event_type is passed, only subscriptions that do not
+    specify a given project or job are considered. When project or job
+    uuid are specified this query will consider both subscriptions that
+    don't specify a project/job and those who do.
+
+    Args:
+        event_type: Event type of the subscription.
+        project_uuid: Allows to specify that the event is related to a
+            specific project.
+        job_uuid: Allows to specify that the event is related to a
+            specific job. If specified, project_uuid should be specified
+            as well.
+    Returns:
+        List of subscribers that are subscribed to the given event.
+
+    Raises:
+        ValueError if the job_uuid is specified but project_uuid is not.
+    """
+    notified_subscribers_ids = db.session.query(
+        models.Subscription.subscriber_uuid
+    ).filter(
+        models.Subscription.event_type == event_type,
+        # Don't capture subscriptions that specify job or project.
+        models.Subscription.type == "globally_scoped_subscription",
+    )
+
+    if project_uuid is not None:
+        proj_specific_subs = db.session.query(
+            models.ProjectSpecificSubscription.subscriber_uuid
+        ).filter(
+            models.ProjectJobSpecificSubscription.event_type == event_type,
+            models.ProjectJobSpecificSubscription.project_uuid == project_uuid,
+        )
+        notified_subscribers_ids = notified_subscribers_ids.union(proj_specific_subs)
+
+    if job_uuid is not None:
+        if project_uuid is None:
+            raise ValueError("If job_uuid is defind project_uuid must be as well.")
+        proj_job_specific_subs = db.session.query(
+            models.ProjectJobSpecificSubscription.subscriber_uuid
+        ).filter(
+            models.ProjectJobSpecificSubscription.event_type == event_type,
+            models.ProjectJobSpecificSubscription.project_uuid == project_uuid,
+            models.ProjectJobSpecificSubscription.job_uuid == job_uuid,
+        )
+        notified_subscribers_ids = notified_subscribers_ids.union(
+            proj_job_specific_subs
+        )
+
+    notified_subscribers = (
+        models.Subscriber.query.options(noload(models.Subscriber.subscriptions))
+        .filter(models.Subscriber.uuid.in_(notified_subscribers_ids.subquery()))
+        .all()
+    )
+
+    return notified_subscribers

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1282,6 +1282,13 @@ class Subscriber(BaseModel):
         UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4())
     )
 
+    subscriptions = db.relationship(
+        "Subscription",
+        lazy="select",
+        passive_deletes=True,
+        cascade="all, delete",
+    )
+
 
 class Subscription(BaseModel):
     __tablename__ = "subscriptions"
@@ -1291,14 +1298,18 @@ class Subscription(BaseModel):
     )
 
     subscriber_uuid = db.Column(
-        UUID(as_uuid=False), db.ForeignKey("subscribers.uuid", ondelete="CASCADE")
+        UUID(as_uuid=False),
+        db.ForeignKey("subscribers.uuid", ondelete="CASCADE"),
+        nullable=False,
     )
 
     event_type = db.Column(
-        db.String(50), db.ForeignKey("event_types.name", ondelete="CASCADE")
+        db.String(50),
+        db.ForeignKey("event_types.name", ondelete="CASCADE"),
+        nullable=False,
     )
 
-    type = db.Column(db.String(50))
+    type = db.Column(db.String(50), nullable=False)
 
     __mapper_args__ = {
         "polymorphic_on": "type",

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -833,3 +833,72 @@ update_sidecar_info = Model(
         ),
     },
 )
+
+subscription_spec = Model(
+    "SubscriptionSpec",
+    {
+        "event_type": fields.String(
+            required=True, description="Event type to subscribe to."
+        ),
+        "project_uuid": fields.String(
+            required=False,
+            description="Specifies if the subscription is only for a specific project.",
+        ),
+        "job_uuid": fields.String(
+            required=False,
+            description=(
+                "Specifies if the subscription is only for a "
+                "specific job of a project.",
+            ),
+        ),
+    },
+)
+
+subscriber_spec = Model(
+    "SubscriberSpec",
+    {
+        "subscriptions": fields.List(
+            fields.Nested(subscription_spec),
+            description="Collection of subscriptions, elements should be unique.",
+        ),
+    },
+)
+
+subscription = Model(
+    "Subscription",
+    {
+        "uuid": fields.String(required=True, description="UUID of the subscription."),
+        "subscriber_uuid": fields.String(
+            required=True, description="UUID of the subscriber."
+        ),
+        "event_type": fields.String(
+            required=True, description="Event type subscribed to."
+        ),
+        "type": fields.String(
+            required=True,
+            description=("Type of the subscription (global vs project specific etc.)."),
+        ),
+    },
+)
+
+
+subscriber = Model(
+    "Subscriber",
+    {
+        "uuid": fields.String(required=True, description="UUID of the subscriber."),
+        "subscriptions": fields.List(
+            fields.Nested(subscription),
+            description="Subscriptions of the subscriber.",
+            required=False,
+        ),
+    },
+)
+
+subscribers = Model(
+    "Subscribers",
+    {
+        "subscribers": fields.List(
+            fields.Nested(subscriber), description="List of subscribers."
+        ),
+    },
+)

--- a/services/orchest-api/app/migrations/versions/5acfad9426b4_.py
+++ b/services/orchest-api/app/migrations/versions/5acfad9426b4_.py
@@ -1,0 +1,63 @@
+"""Add Subscriber and Subscription models
+
+Revision ID: 5acfad9426b4
+Revises: 3fbff22943d6
+Create Date: 2022-04-25 13:38:57.188708
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "5acfad9426b4"
+down_revision = "3fbff22943d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "subscribers",
+        sa.Column("uuid", postgresql.UUID(), nullable=False),
+        sa.PrimaryKeyConstraint("uuid", name=op.f("pk_subscribers")),
+    )
+    op.create_table(
+        "subscriptions",
+        sa.Column("uuid", postgresql.UUID(), nullable=False),
+        sa.Column("subscriber_uuid", postgresql.UUID(), nullable=True),
+        sa.Column("event_type", sa.String(length=50), nullable=True),
+        sa.Column("type", sa.String(length=50), nullable=True),
+        sa.Column("project_uuid", sa.String(length=36), nullable=True),
+        sa.Column("job_uuid", sa.String(length=36), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["event_type"],
+            ["event_types.name"],
+            name=op.f("fk_subscriptions_event_type_event_types"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["job_uuid"],
+            ["jobs.uuid"],
+            name=op.f("fk_subscriptions_job_uuid_jobs"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_uuid"],
+            ["projects.uuid"],
+            name=op.f("fk_subscriptions_project_uuid_projects"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["subscriber_uuid"],
+            ["subscribers.uuid"],
+            name=op.f("fk_subscriptions_subscriber_uuid_subscribers"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("uuid", name=op.f("pk_subscriptions")),
+    )
+
+
+def downgrade():
+    op.drop_table("subscriptions")
+    op.drop_table("subscribers")

--- a/services/orchest-api/app/migrations/versions/d0eac6764a55_.py
+++ b/services/orchest-api/app/migrations/versions/d0eac6764a55_.py
@@ -1,0 +1,52 @@
+"""Make subscription subscriber_uuid, event_type, type not nullable.
+
+Revision ID: d0eac6764a55
+Revises: 5acfad9426b4
+Create Date: 2022-04-26 13:48:24.744397
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d0eac6764a55"
+down_revision = "5acfad9426b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "subscriptions",
+        "subscriber_uuid",
+        existing_type=postgresql.UUID(),
+        nullable=False,
+    )
+    op.alter_column(
+        "subscriptions",
+        "event_type",
+        existing_type=sa.VARCHAR(length=50),
+        nullable=False,
+    )
+    op.alter_column(
+        "subscriptions", "type", existing_type=sa.VARCHAR(length=50), nullable=False
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "subscriptions", "type", existing_type=sa.VARCHAR(length=50), nullable=True
+    )
+    op.alter_column(
+        "subscriptions",
+        "event_type",
+        existing_type=sa.VARCHAR(length=50),
+        nullable=True,
+    )
+    op.alter_column(
+        "subscriptions",
+        "subscriber_uuid",
+        existing_type=postgresql.UUID(),
+        nullable=True,
+    )


### PR DESCRIPTION
## Description

This is another changeset towards having notifications in Orchest, this PR adds a subscriber and subscription system in the `orchest-api` which makes use of the existing events and event types.

The PR introduces a new api namespace, `notifications`, and a new module with the same name. The subscriptions of a subscriber can't be altered post-facto, although that's something that can be easily added later.

## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).

