### PR TITLE
Expand webhook payload content

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -1450,6 +1450,15 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
         )
 
         if runs_to_complete == 0:
+            status = "SUCCESS"
+
+            if (
+                models.NonInteractivePipelineRun.query.filter_by(job_uuid=job_uuid)
+                .filter(models.NonInteractivePipelineRun.status == "FAILURE")
+                .count()
+            ) > 0:
+                status = "FAILURE"
+
             if (
                 models.Job.query.filter_by(uuid=job_uuid)
                 .filter(
@@ -1459,13 +1468,13 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
                     # 2PF.
                     models.Job.status.not_in(["SUCCESS", "ABORTED", "FAILURE"])
                 )
-                .update({"status": "SUCCESS"})
+                .update({"status": status})
                 > 0
             ):
-                # NOTIFICATIONS_TODO: we will probably need to
-                # alter how we define a job SUCCESS status,
-                # might require FE changes as well.
-                events.register_job_succeeded(job.project_uuid, job_uuid)
+                if status == "SUCCESS":
+                    events.register_job_succeeded(job.project_uuid, job_uuid)
+                else:
+                    events.register_job_failed(job.project_uuid, job_uuid)
 
     def _collateral(self):
         pass

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -1358,8 +1358,6 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
         # See if the job is done running (all its runs are done).
         if status_update["status"] in ["SUCCESS", "FAILURE", "ABORTED"]:
 
-            DeleteNonRetainedJobPipelineRuns(self.tpe).transaction(job_uuid)
-
             # Only non recurring jobs terminate to SUCCESS.
             if job.schedule is None:
                 self._update_one_off_job(job_uuid)
@@ -1367,6 +1365,8 @@ class UpdateJobPipelineRun(TwoPhaseFunction):
                 self._update_cron_job_run(
                     job_uuid, pipeline_run_uuid, status_update["status"]
                 )
+
+            DeleteNonRetainedJobPipelineRuns(self.tpe).transaction(job_uuid)
 
         return {"message": "Status was updated successfully"}, 200
 

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -722,6 +722,11 @@ class RunJob(TwoPhaseFunction):
             job.status = "STARTED"
             events.register_job_started(job.project_uuid, job.uuid)
 
+        if job.schedule is not None:
+            events.register_cron_job_run_started(
+                job.project_uuid, job.uuid, job.total_scheduled_executions
+            )
+
         # To be later used by the collateral effect function.
         tasks_to_launch = []
 
@@ -794,11 +799,6 @@ class RunJob(TwoPhaseFunction):
                     )
                 )
             db.session.bulk_save_objects(pipeline_steps)
-
-        if job.schedule is not None:
-            events.register_cron_job_run_started(
-                job.project_uuid, job.uuid, job.total_scheduled_executions
-            )
 
         job.total_scheduled_executions += 1
         # Must run after total_scheduled_executions has been updated.

--- a/services/orchest-api/app/app/apis/namespace_notifications.py
+++ b/services/orchest-api/app/app/apis/namespace_notifications.py
@@ -118,6 +118,9 @@ class SendSubscriberTestPingDelivery(Resource):
         ):
             return {"message": "success"}, 200
         else:
+            if response is not None:
+                logger.info(response.status_code)
+                logger.info(response.text)
             return {"message": "failure"}, 500
 
 

--- a/services/orchest-api/app/app/apis/namespace_notifications.py
+++ b/services/orchest-api/app/app/apis/namespace_notifications.py
@@ -29,7 +29,7 @@ class SubscriberList(Resource):
     @api.doc("get_subscribers")
     @api.response(200, "Success", schema.subscribers)
     def get(self):
-        """Gets all subscribers, without subscriptions."""
+        """Gets all subscribers, doesn't include their subscriptions."""
         subscribers = models.Subscriber.query.options(
             noload(models.Subscriber.subscriptions)
         ).all()
@@ -46,7 +46,7 @@ class SubscriberList(Resource):
 class WebhookList(Resource):
     @api.doc("create_webhook")
     @api.expect(schema.webhook_spec, validate=True)
-    @api.response(200, "Success", schema.webhook_with_secret)
+    @api.response(201, "Success", schema.webhook_with_secret)
     def post(self):
         """Creates a webhook with the given subscriptions.
 

--- a/services/orchest-api/app/app/apis/namespace_notifications.py
+++ b/services/orchest-api/app/app/apis/namespace_notifications.py
@@ -118,7 +118,7 @@ class SendSubscriberTestPingDelivery(Resource):
         ):
             return {"message": "success"}, 200
         else:
-            return {"message": "success"}, 500
+            return {"message": "failure"}, 500
 
 
 @api.route("/subscribers/subscribed-to/<string:event_type>")

--- a/services/orchest-api/app/app/apis/namespace_notifications.py
+++ b/services/orchest-api/app/app/apis/namespace_notifications.py
@@ -94,6 +94,33 @@ class Subscriber(Resource):
         return {"message": ""}, 201
 
 
+@api.route("/subscribers/test-ping-delivery/<string:uuid>")
+class SendSubscriberTestPingDelivery(Resource):
+    @api.doc("subscribers/test-ping-delivery")
+    @api.response(200, "Success")
+    @api.response(500, "Failure")
+    def get(self, uuid: str):
+        """Send a test ping delivery to the subscriber.
+
+        This endpoint allows to send a ping event notifications to the
+        subscriber, so that it's possible to test if a given webhook
+        is working end to end, i.e. the deliveree is reachable.
+
+        The endpoint will return a 200 if the response obtained from the
+        deliveree is to be considered successfull, 500 otherwise.
+
+        """
+        response = webhooks.send_test_ping_delivery(uuid)
+        if (
+            response is not None
+            and response.status_code >= 200
+            and response.status_code <= 299
+        ):
+            return {"message": "success"}, 200
+        else:
+            return {"message": "success"}, 500
+
+
 @api.route("/subscribers/subscribed-to/<string:event_type>")
 class SubscribersSubscribedToEvent(Resource):
     @api.doc("get_subscribers_subscribed_to_event")

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -40,7 +40,12 @@ class ProjectList(Resource):
         project = request.get_json()
 
         if len(project["name"]) > 255:
-            return {}, 400
+            return {
+                "message": (
+                    "The provided project name exceeds the maximum length of 255 "
+                    "characters."
+                )
+            }, 400
 
         project["env_variables"] = project.get("env_variables", {})
         if not _utils.are_environment_variables_valid(project["env_variables"]):

--- a/services/orchest-api/app/app/apis/namespace_projects.py
+++ b/services/orchest-api/app/app/apis/namespace_projects.py
@@ -38,6 +38,10 @@ class ProjectList(Resource):
     def post(self):
         """Create a new project."""
         project = request.get_json()
+
+        if len(project["name"]) > 255:
+            return {}, 400
+
         project["env_variables"] = project.get("env_variables", {})
         if not _utils.are_environment_variables_valid(project["env_variables"]):
             return {"message": ("Invalid environment variables definition.")}, 400
@@ -72,9 +76,14 @@ class Project(Resource):
     def put(self, project_uuid):
         """Update a project."""
         update = request.get_json()
+
+        if len(update["name"]) > 255:
+            return {}, 400
+
         update = models.Project.keep_column_entries(update)
         if not _utils.are_environment_variables_valid(update.get("env_variables", {})):
             return {"message": ("Invalid environment variables definition.")}, 400
+
         if update:
             try:
                 models.Project.query.filter_by(uuid=project_uuid).update(update)

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -37,6 +37,7 @@ def _register_event(ev: models.Event) -> None:
             event=ev.uuid,
             deliveree=sub.uuid,
             status="SCHEDULED",
+            notification_payload=ev.to_notification_payload(),
         )
         db.session.add(delivery)
 

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -130,11 +130,20 @@ def register_cron_job_run_started(
     project_uuid: str, job_uuid: str, run_index: int
 ) -> None:
     """Adds a cron-job run started to the db, doesn't commit."""
+    # Need to get the value now because a cronjob can be edited.
+    job = (
+        db.session.query(models.Job.parameters).filter(
+            models.Job.project_uuid == project_uuid,
+            models.Job.uuid == job_uuid,
+        )
+    ).one()
+
     ev = models.CronJobRunEvent(
         type="project:cron-job:run:started",
         project_uuid=project_uuid,
         job_uuid=job_uuid,
         run_index=run_index,
+        total_pipeline_runs=len(job.parameters),
     )
     _register_event(ev)
 
@@ -143,11 +152,24 @@ def register_cron_job_run_succeeded(
     project_uuid: str, job_uuid: str, run_index: int
 ) -> None:
     """Adds a cron-job run succeeded to the db, doesn't commit."""
+    # Retrieve the original value, the cronjob could have been edited.
+    run_started_event = (
+        db.session.query(models.CronJobRunEvent.total_pipeline_runs).filter(
+            models.CronJobRunEvent.type == "project:cron-job:run:started",
+            models.CronJobRunEvent.project_uuid == project_uuid,
+            models.CronJobRunEvent.job_uuid == job_uuid,
+            models.CronJobRunEvent.run_index == run_index,
+        )
+    ).first()
+    total_pipeline_runs = (
+        run_started_event.total_pipeline_runs if run_started_event is not None else None
+    )
     ev = models.CronJobRunEvent(
         type="project:cron-job:run:succeeded",
         project_uuid=project_uuid,
         job_uuid=job_uuid,
         run_index=run_index,
+        total_pipeline_runs=total_pipeline_runs,
     )
     _register_event(ev)
 
@@ -156,11 +178,24 @@ def register_cron_job_run_failed(
     project_uuid: str, job_uuid: str, run_index: int
 ) -> None:
     """Adds a cron-job run failed to the db, doesn't commit."""
+    # Retrieve the original value, the cronjob could have been edited.
+    run_started_event = (
+        db.session.query(models.CronJobRunEvent.total_pipeline_runs).filter(
+            models.CronJobRunEvent.type == "project:cron-job:run:started",
+            models.CronJobRunEvent.project_uuid == project_uuid,
+            models.CronJobRunEvent.job_uuid == job_uuid,
+            models.CronJobRunEvent.run_index == run_index,
+        )
+    ).first()
+    total_pipeline_runs = (
+        run_started_event.total_pipeline_runs if run_started_event is not None else None
+    )
     ev = models.CronJobRunEvent(
         type="project:cron-job:run:failed",
         project_uuid=project_uuid,
         job_uuid=job_uuid,
         run_index=run_index,
+        total_pipeline_runs=total_pipeline_runs,
     )
     _register_event(ev)
 
@@ -188,12 +223,24 @@ def _register_cron_job_run_pipeline_run_event(
         )
         .one()
     ).job_run_index
+    run_started_event = (
+        db.session.query(models.CronJobRunEvent.total_pipeline_runs).filter(
+            models.CronJobRunEvent.type == "project:cron-job:run:started",
+            models.CronJobRunEvent.project_uuid == project_uuid,
+            models.CronJobRunEvent.job_uuid == job_uuid,
+            models.CronJobRunEvent.run_index == run_index,
+        )
+    ).first()
+    total_pipeline_runs = (
+        run_started_event.total_pipeline_runs if run_started_event is not None else None
+    )
     ev = models.CronJobRunPipelineRunEvent(
         type=type,
         project_uuid=project_uuid,
         job_uuid=job_uuid,
         pipeline_run_uuid=pipeline_run_uuid,
         run_index=run_index,
+        total_pipeline_runs=total_pipeline_runs,
     )
     _register_event(ev)
 

--- a/services/orchest-api/app/app/core/notifications/utils.py
+++ b/services/orchest-api/app/app/core/notifications/utils.py
@@ -18,7 +18,7 @@ def subscription_specs_to_subscriptions(
             project_uuid = sub.get("project_uuid")
             job_uuid = sub.get("job_uuid")
             if event_type is None:
-                raise ValueError("Missing 'event_type'.")
+                raise ValueError(f"Missing 'event_type' for subscription '{key}'.")
             if project_uuid is not None:
                 if job_uuid is None:
                     subscription_objects.append(

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -62,16 +62,16 @@ def create_webhook(webhook_spec: dict) -> models.Webhook:
 
 def _create_delivery_payload(delivery: models.Delivery) -> dict:
 
-    event = models.Event.query.filter(models.Event.uuid == delivery.event).one()
-    event = event.to_notification_payload()
-
     webhook = (
         models.Webhook.query.options(noload(models.Webhook.subscriptions))
         .filter(models.Webhook.uuid == delivery.deliveree)
         .one()
     )
 
-    payload = {"delivered_for": marshal(webhook, schema.webhook), "event": event}
+    payload = {
+        "delivered_for": marshal(webhook, schema.webhook),
+        "event": delivery.notification_payload,
+    }
     _post_process_payload(payload, webhook)
 
     return payload

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -223,6 +223,10 @@ def deliver(delivery_uuid: str) -> None:
             if response.status_code >= 200 and response.status_code <= 299:
                 logger.info(f"Delivered {delivery_uuid}.")
                 delivery.set_delivered()
+                # Not really useful to set_delivered() atm since it will
+                # get deleted, but we might add some collateral effects
+                # or other logic to set_delivered in the future.
+                db.session.delete(delivery)
             else:
                 raise self_errors.DeliveryFailed(
                     f"Failed to deliver {delivery_uuid}: {response.status_code}."
@@ -232,5 +236,4 @@ def deliver(delivery_uuid: str) -> None:
             delivery.reschedule()
             logger.info(f"Rescheduling {delivery_uuid} at {delivery.scheduled_at}.")
 
-    db.session.delete(delivery)
     db.session.commit()

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -85,6 +85,10 @@ def _post_process_payload(payload: dict, webhook: models.Webhook) -> None:
 
     if webhook.is_slack_webhook():
         payload["text"] = json.dumps(payload, sort_keys=True, indent=1)
+    elif webhook.is_discord_webhook():
+        payload["content"] = json.dumps(payload, sort_keys=True, indent=1)
+        # 2000 max allowed characters.
+        payload["content"] = f'{payload["content"][:1997]}...'
 
 
 def _inject_headers(

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -83,7 +83,7 @@ def _post_process_payload(payload: dict, webhook: models.Webhook) -> None:
     # To keep thing brief.
     payload["delivered_for"].pop("subscriptions", None)
 
-    if webhook.is_slack_webhook():
+    if webhook.is_slack_webhook() or webhook.is_teams_webhook():
         payload["text"] = json.dumps(payload, sort_keys=True, indent=1)
     elif webhook.is_discord_webhook():
         payload["content"] = json.dumps(payload, sort_keys=True, indent=1)

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -232,4 +232,5 @@ def deliver(delivery_uuid: str) -> None:
             delivery.reschedule()
             logger.info(f"Rescheduling {delivery_uuid} at {delivery.scheduled_at}.")
 
+    db.session.delete(delivery)
     db.session.commit()

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -88,7 +88,14 @@ def _post_process_payload(payload: dict, webhook: models.Webhook) -> None:
     elif webhook.is_discord_webhook():
         payload["content"] = json.dumps(payload, sort_keys=True, indent=1)
         # 2000 max allowed characters.
-        payload["content"] = f'{payload["content"][:1997]}...'
+        if len(payload["content"]) > 2000:
+            payload["delivered_for"] = {
+                "uuid": payload["delivered_for"].get("uuid"),
+                "name": payload["delivered_for"].get("name"),
+            }
+            payload["content"] = json.dumps(payload, sort_keys=True, indent=1)
+
+            payload["content"] = f'{payload["content"][:1997]}...'
 
 
 def _inject_headers(

--- a/services/orchest-api/app/app/core/notifications/webhooks.py
+++ b/services/orchest-api/app/app/core/notifications/webhooks.py
@@ -66,13 +66,7 @@ def _create_delivery_payload(delivery: models.Delivery) -> dict:
     webhook = marshal(webhook, schema.webhook)
 
     event = models.Event.query.filter(models.Event.uuid == delivery.event).one()
-    # TODO: make this a method of the Event class and children.
-    if isinstance(event, models.JobEvent):
-        event = marshal(event, schema.job_event)
-    elif isinstance(event, models.ProjectEvent):
-        event = marshal(event, schema.project_event)
-    else:
-        event = marshal(event, schema.event)
+    event = event.to_notification_payload()
 
     payload = {"delivered_for": webhook, "event": event}
     return payload

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1388,7 +1388,7 @@ class CronJobRunEvent(CronJobEvent):
             status = None
         payload["job"]["run"] = {}
         payload["job"]["run"]["status"] = status
-        payload["job"]["run"]["index"] = self.run_index
+        payload["job"]["run"]["number"] = self.run_index
         payload["job"]["run"]["total_runs"] = None
 
         job = Job.query.filter(Job.uuid == self.job_uuid).first()

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1430,7 +1430,7 @@ class CronJobRunPipelineRunEvent(CronJobRunEvent):
 
     def to_notification_payload(self) -> dict:
         payload = super().to_notification_payload()
-        payload["job"]["pipeline_run"] = _prepare_job_pipeline_run_payload(
+        payload["job"]["run"]["pipeline_run"] = _prepare_job_pipeline_run_payload(
             self.job_uuid, self.pipeline_run_uuid
         )
 

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1275,6 +1275,10 @@ def _prepare_job_pipeline_run_payload(job_uuid: str, pipeline_run_uuid: str) -> 
     if pipeline_run is None:
         return payload
 
+    payload["number"] = pipeline_run.pipeline_run_index
+    if job.schedule is not None:
+        payload["number_in_run"] = pipeline_run.job_run_pipeline_run_index
+
     payload["status"] = pipeline_run.status
     payload["parameters"] = _prepare_parameters_payload(
         job.pipeline_definition, pipeline_run.parameters

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1596,7 +1596,19 @@ class Delivery(BaseModel):
     # The event which the delivery is about.
     event = db.Column(
         UUID(as_uuid=False),
-        db.ForeignKey("events.uuid", ondelete="CASCADE"),
+        # Allow deletion of parent entities of an event (like a pipeline
+        # run) while retaining the delivery.
+        db.ForeignKey("events.uuid", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # The information content of the notification. The payload is
+    # created in the same transaction where the event that triggered
+    # this delivery is created, this way we can cover edge cases like
+    # max_retained_pipeline_runs leading to the deletion of failed runs,
+    # which would make it impossible to construct such a payload.
+    notification_payload = db.Column(
+        JSONB,
         nullable=False,
     )
 

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1253,6 +1253,8 @@ def _prepare_parameters_payload(
             parameters_payload[k] = v
         else:
             step_name = pipeline_definition.get("steps").get(k, {}).get("title")
+            if step_name is None:
+                step_name = "untitled"
             parameters_payload[f"step-{step_name}-{k}"] = v
     return parameters_payload
 

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1484,6 +1484,9 @@ class Webhook(Subscriber):
     def is_slack_webhook(self) -> bool:
         return self.url.startswith("https://hooks.slack.com/")
 
+    def is_discord_webhook(self) -> bool:
+        return self.url.startswith("https://discord.com/api/webhooks/")
+
     __mapper_args__ = {
         "polymorphic_identity": "webhook",
     }

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1375,6 +1375,8 @@ class CronJobRunEvent(CronJobEvent):
 
     run_index = db.Column(db.Integer)
 
+    total_pipeline_runs = db.Column(db.Integer)
+
     def to_notification_payload(self) -> dict:
         payload = super().to_notification_payload()
 
@@ -1386,16 +1388,11 @@ class CronJobRunEvent(CronJobEvent):
             status = "FAILURE"
         else:
             status = None
+
         payload["job"]["run"] = {}
         payload["job"]["run"]["status"] = status
         payload["job"]["run"]["number"] = self.run_index
-        payload["job"]["run"]["total_runs"] = None
-
-        job = Job.query.filter(Job.uuid == self.job_uuid).first()
-        if job is None:
-            return payload
-
-        payload["job"]["run"]["total_runs"] = len(job.parameters)
+        payload["job"]["run"]["total_pipeline_runs"] = self.total_pipeline_runs
 
         return payload
 

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1481,6 +1481,9 @@ class Webhook(Subscriber):
 
     content_type = db.Column(db.String(50), nullable=False)
 
+    def is_slack_webhook(self) -> bool:
+        return self.url.startswith("https://hooks.slack.com/")
+
     __mapper_args__ = {
         "polymorphic_identity": "webhook",
     }

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1206,6 +1206,9 @@ class JobEvent(ProjectEvent):
         job_payload["name"] = job.name
         job_payload["status"] = job.status
         job_payload["pipeline_name"] = job.pipeline_name
+        job_payload[
+            "url_path"
+        ] = f"/job?project_uuid={job.project_uuid}&job_uuid={job.uuid}"
 
         return payload
 
@@ -1284,6 +1287,10 @@ def _prepare_job_pipeline_run_payload(job_uuid: str, pipeline_run_uuid: str) -> 
     payload["status"] = pipeline_run.status
     payload["parameters"] = _prepare_parameters_payload(
         job.pipeline_definition, pipeline_run.parameters
+    )
+    payload["url_path"] = (
+        f"/job-run?project_uuid={job.project_uuid}&pipeline_uuid={job.pipeline_uuid}&"
+        f"job_uuid={job.uuid}&run_uuid={pipeline_run.uuid}"
     )
 
     if pipeline_run.status == "FAILURE":

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1510,6 +1510,9 @@ class Webhook(Subscriber):
     def is_discord_webhook(self) -> bool:
         return self.url.startswith("https://discord.com/api/webhooks/")
 
+    def is_teams_webhook(self) -> bool:
+        return "webhook.office.com" in self.url
+
     __mapper_args__ = {
         "polymorphic_identity": "webhook",
     }

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -969,17 +969,3 @@ event = Model(
         ),
     },
 )
-
-project_event = event.inherit(
-    "ProjectEvent",
-    {
-        "project_uuid": fields.String(required=True, description="UUID of project"),
-    },
-)
-
-job_event = project_event.inherit(
-    "JobEvent",
-    {
-        "job_uuid": fields.String(required=True, description="UUID of job"),
-    },
-)

--- a/services/orchest-api/app/migrations/versions/00ed420c6abf_.py
+++ b/services/orchest-api/app/migrations/versions/00ed420c6abf_.py
@@ -1,0 +1,25 @@
+"""Add CronJobRunEvent.total_pipeline_runs field
+
+Revision ID: 00ed420c6abf
+Revises: 7b9a23ad5946
+Create Date: 2022-04-28 13:38:19.223004
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "00ed420c6abf"
+down_revision = "7b9a23ad5946"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "events", sa.Column("total_pipeline_runs", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("events", "total_pipeline_runs")

--- a/services/orchest-api/app/migrations/versions/7b9a23ad5946_.py
+++ b/services/orchest-api/app/migrations/versions/7b9a23ad5946_.py
@@ -1,0 +1,31 @@
+"""Add Project.name field
+
+Revision ID: 7b9a23ad5946
+Revises: ff549d6b66be
+Create Date: 2022-04-28 11:50:13.304600
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7b9a23ad5946"
+down_revision = "ff549d6b66be"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "projects",
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            server_default=sa.text("'Project'"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("projects", "name")

--- a/services/orchest-api/app/migrations/versions/dfe5c529e6da_.py
+++ b/services/orchest-api/app/migrations/versions/dfe5c529e6da_.py
@@ -1,0 +1,57 @@
+"""Add Delivery.notification_payload, make event FK nullable
+
+Revision ID: dfe5c529e6da
+Revises: 00ed420c6abf
+Create Date: 2022-05-02 11:13:36.074151
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "dfe5c529e6da"
+down_revision = "00ed420c6abf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "deliveries",
+        sa.Column(
+            "notification_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+    )
+    op.alter_column(
+        "deliveries", "event", existing_type=postgresql.UUID(), nullable=True
+    )
+    op.drop_constraint("fk_deliveries_event_events", "deliveries", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("fk_deliveries_event_events"),
+        "deliveries",
+        "events",
+        ["event"],
+        ["uuid"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_deliveries_event_events"), "deliveries", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "fk_deliveries_event_events",
+        "deliveries",
+        "events",
+        ["event"],
+        ["uuid"],
+        ondelete="CASCADE",
+    )
+    op.alter_column(
+        "deliveries", "event", existing_type=postgresql.UUID(), nullable=False
+    )
+    op.drop_column("deliveries", "notification_payload")

--- a/services/orchest-webserver/app/app/core/projects.py
+++ b/services/orchest-webserver/app/app/core/projects.py
@@ -39,6 +39,11 @@ class CreateProject(TwoPhaseFunction):
         Returns:
             UUID of the newly initialized project.
         """
+        if len(project_path) > 255:
+            raise error.InvalidProjectName(
+                "Project name can't be longer than 255 characters."
+            )
+
         # The collateral effect will later make use of this.
         project_uuid = str(uuid.uuid4())
         new_project = Project(
@@ -131,7 +136,7 @@ class CreateProject(TwoPhaseFunction):
 
         resp = requests.post(
             f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/projects/',
-            json={"uuid": project_uuid},
+            json={"uuid": project_uuid, "name": project_path},
         )
         if resp.status_code != 201:
             raise Exception("Orchest-api project creation failed.")
@@ -208,6 +213,10 @@ class RenameProject(TwoPhaseFunction):
     """
 
     def _transaction(self, project_uuid: str, new_name: str):
+        if len(new_name) > 255:
+            raise error.InvalidProjectName(
+                "Project name can't be longer than 255 characters."
+            )
 
         project = (
             Project.query.with_for_update()
@@ -259,6 +268,16 @@ class RenameProject(TwoPhaseFunction):
 
         Project.query.filter_by(uuid=project_uuid).update({"status": "READY"})
         db.session.commit()
+
+        resp = requests.put(
+            (
+                f'http://{current_app.config["ORCHEST_API_ADDRESS"]}/api/projects'
+                f"/{project_uuid}"
+            ),
+            json={"name": new_name},
+        )
+        if resp.status_code != 200:
+            raise Exception("Orchest-api project name change failed.")
 
     def _revert(self):
         # Move it back if necessary. This avoids the project being

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -555,6 +555,11 @@ def register_views(app, db):
             with TwoPhaseExecutor(db.session) as tpe:
                 project_uuid = CreateProject(tpe).transaction(request.json["name"])
                 return jsonify({"project_uuid": project_uuid})
+        except error.InvalidProjectName as e:
+            return (
+                jsonify({"message": str(e)}),
+                400,
+            )
         except Exception as e:
 
             # The sql integrity error message can be quite ugly.

--- a/services/orchest-webserver/client/src/job-view/JobStatus.tsx
+++ b/services/orchest-webserver/client/src/job-view/JobStatus.tsx
@@ -71,7 +71,8 @@ const statusTitleMapping: Partial<Record<RenderedJobStatus, string>> = {
 export const JobStatus: React.FC<
   { totalCount?: number } & Pick<Job, "status" | "pipeline_run_status_counts">
 > = ({ status, totalCount, pipeline_run_status_counts: count }) => {
-  const isJobDone = status === "SUCCESS" || status === "ABORTED";
+  const isJobDone =
+    status === "SUCCESS" || status === "ABORTED" || status === "FAILURE";
   const totalPendingCount = getSummedCount(count, ["PENDING", "STARTED"]);
   const totalFailureCount = getSummedCount(count, ["ABORTED", "FAILURE"]);
   const totalSuccessCount = getSummedCount(count, ["SUCCESS"]);

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -191,6 +191,7 @@ export type JobStatus =
   | "PAUSED"
   | "SUCCESS"
   | "ABORTED"
+  | "FAILURE"
   | "DRAFT";
 
 export type PipelineRun = {


### PR DESCRIPTION
## Description

Part of of the notifications feature. Expands the content of webhook payloads, generally speaking, a payload event will carry the following information if applicable:
- project name and uuid
- job name, pipeline_name, uuid, next_scheduled_time, schedule, status (different properties based on cron-job vs one-off-job)
- cron-job run: run number, status, total number of runs
- job pipeline run: uuid, status, parameters, failed steps if any

Example payload:
```
 {
   "delivered_for": {
     "content_type": "application/json",
    "name": "string",
     "subscriptions": [
       {
         "event_type": "project:one-off-job:created",
         "job_uuid": null,
         "project_uuid": null,
         "subscriber_uuid": "d2dafc8b-fb5e-4c74-af3f-1d02643f3dad",
         "uuid": "b111fd12-6535-4237-b090-da56f27c9db7"
       },
       {
         "event_type": "project:cron-job:run:started",
         "job_uuid": null,
         "project_uuid": null,
         "subscriber_uuid": "d2dafc8b-fb5e-4c74-af3f-1d02643f3dad",
         "uuid": "b111fd12-6535-4237-b090-da56f27c9db6"
       }
     ],
     "type": "webhook",
     "url": "<redacted>",
     "uuid": "d2dafc8b-fb5e-4c74-af3f-1d02643f3dad",
     "verify_ssl": true
   },
   "event": {
     "job": {
       "name": "aa",
       "next_scheduled_time": "2022-04-28 12:55:00+00:00",
       "pipeline_name": "california-housing",
       "run": {
         "number": 83,
         "status": "STARTED",
         "total_pipeline_runs": 1
       },
       "schedule": "* * * * *",
       "status": "STARTED",
       "uuid": "c27e4daa-96ff-4fa8-8cf0-cedb92675b36"
     },
     "project": {
       "name": "Project",
       "uuid": "d4e49111-ce8d-4872-af3e-77e9431bd16e"
     },
     "timestamp": "2022-04-28 12:54:02.163011+00:00",
     "type": "project:cron-job:run:started",
     "uuid": "aac930ab-afc0-4346-8219-c0b4fd2a5ea4"
   }
 }

```

## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).

