### PR TITLE
Only redirect if current projectUuid is invalid

### DIFF
--- a/services/orchest-webserver/client/src/components/ProjectSelector.tsx
+++ b/services/orchest-webserver/client/src/components/ProjectSelector.tsx
@@ -133,12 +133,20 @@ export const ProjectSelector = () => {
         ? projectUuidFromRoute
         : state.projects[0]?.uuid;
 
-      if (newProjectUuid) {
+      // If state.projectUuid is no loaded, the page is being loaded for the first time.
+      // When newProjectUuid !== projectUuidFromRoute, user provides an invalid projectUuid.
+      if (!state.projectUuid || newProjectUuid !== projectUuidFromRoute) {
         dispatch({ type: "SET_PROJECT", payload: newProjectUuid });
         onChangeProject(newProjectUuid);
       }
     }
-  }, [matchWithinProjectPaths, dispatch, state.hasLoadedProjects]);
+  }, [
+    matchWithinProjectPaths,
+    dispatch,
+    state.hasLoadedProjects,
+    state.projectUuid,
+    setAlert,
+  ]);
 
   if (
     !matchWithinProjectPaths ||

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -247,7 +247,6 @@ export const withinProjectPaths = getOrderedRoutes().reduce<
     projectRootPaths.includes(curr.path) ||
     projectRootPaths.includes(curr.root || "") ||
     curr.path === "/project"
-    // projectsPaths.includes(curr.path)
   ) {
     return [
       ...all,


### PR DESCRIPTION
## Description

A bug was introduced when implemented #892, ProjectSelector attempts to sync `state.projectUuid` and `project_uuid` in the query args. This is to ensure that redirect user to a proper view when the given query args are no longer valid. For example, if user intends to visit /environment with an invalid environment_uuid, ProjectSelector will redirect user to /environments, so user can start from there. 

The bug is that this redirection occurs at all times, so it forces a redirection to /environments regardless.
 
This PR fixes this issue: only redirect if either condition is met:
1. state.projectUuid is undefined: user is landing on the app. 
2. current query arg `project_uuid` is different from the calculated project_uuid. So it won't trigger chaining redirections.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.

