### PR TITLE
Fix failed to rename files in File Manager

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -147,7 +147,7 @@ export const FileTree = React.memo(function FileTreeComponent({
   const { projectUuid, pipelineUuid, navigateTo } = useCustomRoute();
   const { getSession, toggleSession } = useSessionsContext();
   const {
-    state: { pipelines = [] },
+    state: { pipelines = [], pipeline },
     dispatch,
   } = useProjectsContext();
 
@@ -386,10 +386,10 @@ export const FileTree = React.memo(function FileTreeComponent({
         oldFilePath,
       ]);
 
-      if (!isSafeToProceed) return;
+      if (!isSafeToProceed || !pipeline) return;
 
-      const filePathRelativeToProjectDir = cleanFilePath(oldFilePath);
-      const foundPipeline = pipelineDics[filePathRelativeToProjectDir];
+      const projectFilePathRelativeToProjectDir = cleanFilePath(pipeline.path);
+      const foundPipeline = pipelineDics[projectFilePathRelativeToProjectDir];
 
       await handleChangeFilePath({
         oldFilePath,
@@ -407,6 +407,7 @@ export const FileTree = React.memo(function FileTreeComponent({
     },
     [
       dispatch,
+      pipeline,
       pipelineUuid,
       pipelineDics,
       handleChangeFilePath,


### PR DESCRIPTION
## Description

Fix failed to rename files in File Manager in Pipeline Editor.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.

