### PR TITLE
Fix: allow assigning files in the `/data/` folder to pipeline steps

### DIFF
--- a/lib/javascript/utils/src/typed.ts
+++ b/lib/javascript/utils/src/typed.ts
@@ -21,12 +21,12 @@ export function collapseDoubleDots(path: string) {
    * */
 
   let pathComponents = path.split("/");
-  let newPathComponents = [];
+  let newPathComponents = [] as string[];
   let skipCount = 0;
 
   // traverse in reverse
   for (let x = pathComponents.length - 1; x >= 0; x--) {
-    if (pathComponents[x] == "..") {
+    if (pathComponents[x] === "..") {
       // skip path that follows
       skipCount += 1;
     } else if (skipCount > 0) {

--- a/services/orchest-webserver/app/app/error.py
+++ b/services/orchest-webserver/app/app/error.py
@@ -36,6 +36,15 @@ class OutOfDataDirectoryError(Exception):
     pass
 
 
+class OutOfAllowedDirectoryError(Exception):
+    """
+    Attempting to do an operation outside the allowed directories,
+    i.e. the data directory or a project directory.
+    """
+
+    pass
+
+
 class ProjectDoesNotExist(Exception):
     pass
 

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -765,7 +765,7 @@ def is_valid_pipeline_relative_path(
 
 
 def is_valid_data_path(path: str):
-    return os.path.abspath(os.path.normpath(path)).startswith("/data")
+    return os.path.abspath(os.path.normpath(path)).startswith(_config.USERDIR_DATA)
 
 
 def resolve_absolute_path(abs_path: str) -> Optional[str]:

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -764,8 +764,13 @@ def is_valid_pipeline_relative_path(
     return abs_path.startswith(project_path)
 
 
-def is_valid_data_path(path: str):
-    return os.path.abspath(os.path.normpath(path)).startswith(_config.USERDIR_DATA)
+def is_valid_data_path(path: str, is_absolute=False):
+    if not is_absolute and not path.startswith("/data/"):
+        return False
+    absolute_data_path = path if is_absolute else resolve_absolute_path(path)
+    return os.path.abspath(os.path.normpath(absolute_data_path)).startswith(
+        _config.USERDIR_DATA
+    )
 
 
 def resolve_absolute_path(abs_path: str) -> Optional[str]:

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -844,12 +844,12 @@ def register_views(app, db):
 
             # Normalize relative paths.
             for step in pipeline_json["steps"].values():
-                if not is_valid_pipeline_relative_path(
-                    project_uuid, pipeline_uuid, step["file_path"]
-                ):
-                    raise app_error.OutOfProjectError(
-                        "Step path points outside of the project directory."
-                    )
+                extensions = list(
+                    map(lambda x: f".{x.lower()}", ["ipynb", "py", "R", "sh", "jl"])
+                )
+
+                if not step["file_path"].endswith(tuple(extensions)):
+                    raise ValueError("Unsupported pipeline step file type.")
 
                 if not step["file_path"].startswith("/"):
                     step["file_path"] = normalize_project_relative_path(

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -844,6 +844,18 @@ def register_views(app, db):
 
             # Normalize relative paths.
             for step in pipeline_json["steps"].values():
+
+                is_project_file = is_valid_pipeline_relative_path(
+                    project_uuid, pipeline_uuid, step["file_path"]
+                )
+
+                is_data_file = is_valid_data_path(step["file_path"])
+
+                if not (is_project_file or is_data_file):
+                    raise app_error.OutOfAllowedDirectoryError(
+                        "File is neither in the project, nor in the data directory."
+                    )
+
                 extensions = list(
                     map(lambda x: f".{x.lower()}", ["ipynb", "py", "R", "sh", "jl"])
                 )

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -1010,7 +1010,7 @@ def register_views(app, db):
 
         if path.startswith("/"):
             file_path = resolve_absolute_path(path)
-            if not is_valid_data_path(file_path):
+            if not is_valid_data_path(file_path, True):
                 raise app_error.OutOfDataDirectoryError(
                     "Path points outside of the data directory."
                 )

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelines.ts
@@ -4,6 +4,11 @@ import React from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { MutatorCallback } from "swr/dist/types";
 
+export const fetchPipelines = (projectUuid: string) =>
+  fetcher<{ result: PipelineMetaData[] }>(
+    `/async/pipelines/${projectUuid}`
+  ).then((response) => response.result);
+
 export const useFetchPipelines = ({
   projectUuid,
   shouldFetch = true,
@@ -14,10 +19,7 @@ export const useFetchPipelines = ({
   const { cache } = useSWRConfig();
   const { data, error, isValidating, mutate } = useSWR<PipelineMetaData[]>(
     projectUuid && shouldFetch ? `/async/pipelines/${projectUuid}` : null,
-    (url) =>
-      fetcher<{ result: PipelineMetaData[] }>(url).then(
-        (response) => response.result
-      )
+    () => fetchPipelines(projectUuid as string)
   );
 
   if (error) {

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -15,7 +15,7 @@ import React from "react";
 import { DRAG_CLICK_SENSITIVITY } from "./common";
 import { usePipelineCanvasContext } from "./contexts/PipelineCanvasContext";
 import { usePipelineEditorContext } from "./contexts/PipelineEditorContext";
-import { getFilePathForDragFile } from "./file-manager/common";
+import { getFilePathForRelativeToProject } from "./file-manager/common";
 import { useFileManagerContext } from "./file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "./file-manager/useValidateFilesOnSteps";
 import { useUpdateZIndex } from "./hooks/useZIndexMax";
@@ -237,7 +237,7 @@ const PipelineStepComponent = React.forwardRef<
         type: "ASSIGN_FILE_TO_STEP",
         payload: {
           stepUuid: uuid,
-          filePath: getFilePathForDragFile(dragFile.path, pipelineCwd),
+          filePath: getFilePathForRelativeToProject(dragFile.path, pipelineCwd),
         },
       });
       resetMove();

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -33,7 +33,7 @@ export type PipelineEditorContextType = {
   eventVars: EventVars;
   dispatch: (value: EventVarsAction) => void;
   stepDomRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>;
-  pipelineCanvasRef: React.MutableRefObject<HTMLDivElement | undefined>;
+  pipelineCanvasRef: React.MutableRefObject<HTMLDivElement | null>;
   newConnection: React.MutableRefObject<NewConnection | undefined>;
   keysDown: Set<number | string>;
   trackMouseMovement: (clientX: number, clientY: number) => void;
@@ -94,7 +94,7 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
   // No pipeline found. Editor is frozen and shows "Pipeline not found".
   const disabled = hasValue(pipelines) && pipelines.length === 0;
 
-  const pipelineCanvasRef = React.useRef<HTMLDivElement>();
+  const pipelineCanvasRef = React.useRef<HTMLDivElement | null>(null);
 
   const {
     eventVars,

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -3,6 +3,7 @@ import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { fetchPipelines } from "@/hooks/useFetchPipelines";
 import { siteMap } from "@/Routes";
 import { IOrchestSessionUuid, PipelineMetaData } from "@/types";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -105,7 +106,7 @@ const sendChangePipelineFilePathRequest = (
   });
 };
 
-const doChangeFilePath = ({
+const doChangeFilePath = async ({
   pipelineUuid,
   projectUuid,
   ...params
@@ -117,16 +118,24 @@ const doChangeFilePath = ({
   projectUuid: string;
   pipelineUuid?: string;
 }) => {
-  if (isFileByExtension(["orchest"], params.newPath)) {
+  // sendChangePipelineFilePathRequest can only move a pipeline file within /project-dir:/ folder
+  // to move .orchest file from /project-dir:/ to /data:/, use /async/file-management/rename endpoint, and delete the pipeline from state.pipelines.
+  if (
+    isFileByExtension(["orchest"], params.newPath) &&
+    params.newRoot === "/project-dir" &&
+    pipelineUuid
+  ) {
+    // `pipeline_uuid` is only needed when newRoot is  "/project-dir:/".
     if (!pipelineUuid) throw new Error("pipeline_uuid is required.");
+
     return sendChangePipelineFilePathRequest(
       projectUuid,
       pipelineUuid,
       params.newPath
     );
-  } else {
-    return sendChangeFilePathRequest({ ...params, projectUuid });
   }
+
+  return sendChangeFilePathRequest({ ...params, projectUuid });
 };
 
 export const FileTree = React.memo(function FileTreeComponent({
@@ -346,15 +355,43 @@ export const FileTree = React.memo(function FileTreeComponent({
       const params = getFilePathChangeParams(oldFilePath, newFilePath);
       try {
         await doChangeFilePath({ ...params, projectUuid, pipelineUuid });
+
+        // Moving a pipeline file from /data to /project-dir is equivalent to create new pipeline out of the .orchest file.
+        // Thus, fire a fetch pipelines request to force BE to dicover the .orchest file.
+        // and then update ProjectsContext and reload.
+        const shouldReloadImmediately =
+          isFileByExtension(["orchest"], params.newPath) &&
+          params.newRoot === "/project-dir";
+
+        if (shouldReloadImmediately) {
+          const updatedPipelines = await fetchPipelines(projectUuid);
+          dispatch({ type: "SET_PIPELINES", payload: updatedPipelines });
+          reload();
+          return;
+        }
+
+        // If `.orchest` file is moved into `/data`, the pipeline cannot be opened.
+        const shouldRemovePipeline =
+          isFileByExtension(["orchest"], params.newPath) &&
+          params.newRoot === "/data";
+
         const pipelineFilePath = cleanFilePath(params.newPath);
         dispatch((current) => {
+          const currentPipelines = current.pipelines || [];
+
+          const payload = shouldRemovePipeline
+            ? currentPipelines.filter((pipeline) => {
+                return pipeline.uuid !== pipelineUuid;
+              })
+            : currentPipelines.map((pipeline) => {
+                return pipeline.uuid === pipelineUuid
+                  ? { ...pipeline, path: pipelineFilePath }
+                  : pipeline;
+              });
+
           return {
             type: "SET_PIPELINES",
-            payload: (current.pipelines || []).map((pipeline) => {
-              return pipeline.uuid === pipelineUuid
-                ? { ...pipeline, path: pipelineFilePath }
-                : pipeline;
-            }),
+            payload,
           };
         });
 
@@ -525,10 +562,18 @@ export const FileTree = React.memo(function FileTreeComponent({
             async (resolve) => {
               await Promise.all(
                 deducedPaths.map(([sourcePath, newPath]) => {
+                  // When moving a pipeline file, the pipelineUuid of this file should be used.
+                  const pipelineUuidInPayload = !sourcePath.endsWith(".orchest")
+                    ? pipelineUuid
+                    : pipelines.find(
+                        (pipeline) =>
+                          pipeline.path === cleanFilePath(sourcePath)
+                      )?.uuid;
+
                   return handleChangeFilePath({
                     oldFilePath: sourcePath,
                     newFilePath: newPath,
-                    pipelineUuid,
+                    pipelineUuid: pipelineUuidInPayload,
                     skipReload: true,
                   });
                 })
@@ -550,6 +595,7 @@ export const FileTree = React.memo(function FileTreeComponent({
       setConfirm,
       projectUuid,
       pipelineUuid,
+      pipelines,
       moveFiles,
       handleChangeFilePath,
       reload,

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/__tests__/getRelativePathTo.test.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/__tests__/getRelativePathTo.test.tsx
@@ -2,18 +2,21 @@ import { findFirstDiffIndex, getRelativePathTo } from "../common";
 
 describe("findFirstDiffIndex", () => {
   it("should return the index of the first diff char", () => {
-    expect(findFirstDiffIndex("/a/b/c.py", "/a/d")).toBe(3);
+    expect(findFirstDiffIndex("a/b/c.py".split("/"), "a/d".split("/"))).toBe(1);
   });
 });
 
 describe("getRelativePathTo", () => {
   it("should return the right relative path: case 1", () => {
-    expect(getRelativePathTo("/a/b/c.py", "/a/")).toBe("b/c.py");
+    expect(getRelativePathTo("/a/b/c.py", "/")).toBe("a/b/c.py");
   });
   it("should return the right relative path: case 2", () => {
-    expect(getRelativePathTo("/a/b/c.py", "/a/d/")).toBe("../b/c.py");
+    expect(getRelativePathTo("/a/b/c.py", "/a/")).toBe("b/c.py");
   });
   it("should return the right relative path: case 3", () => {
+    expect(getRelativePathTo("/a/b/c.py", "/a/d/")).toBe("../b/c.py");
+  });
+  it("should return the right relative path: case 4", () => {
     expect(getRelativePathTo("/a/b/c.py", "/a/b/d/e/f/")).toBe("../../../c.py");
   });
 });

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
@@ -353,26 +353,33 @@ export const allowedExtensionsMarkup = ALLOWED_STEP_EXTENSIONS.map(
   }
 );
 
-export const findFirstDiffIndex = (a: string, b: string) => {
+export const findFirstDiffIndex = (arrA: string[], arrB: string[]) => {
   let i = 0;
-  if (a === b) return -1;
-  while (a[i] === b[i]) i++;
+  while (arrA[i] === arrB[i]) i++;
   return i;
 };
 
-export const getRelativePathTo = (filePath: string, targetFolder: string) => {
-  const cleanFilePath = filePath.replace(/^\//, "");
-  const cleanTargetFolder = targetFolder.replace(/^\//, "");
-  const firstDiffIndex = findFirstDiffIndex(cleanFilePath, cleanTargetFolder);
+const getRelativePathComponents = (path: string) =>
+  path.replace(/^\//, "").split("/");
 
-  const upLevels = cleanTargetFolder
-    .substring(firstDiffIndex)
-    .split("/")
-    .filter((value) => value).length;
+export const getRelativePathTo = (filePath: string, targetFolder: string) => {
+  const cleanFilePathComponents = getRelativePathComponents(filePath);
+  const cleanTargetFolderComponents = getRelativePathComponents(targetFolder);
+
+  const firstDiffIndex = findFirstDiffIndex(
+    cleanFilePathComponents,
+    cleanTargetFolderComponents
+  );
+
+  const remainingFilePathComponents = cleanFilePathComponents.slice(
+    firstDiffIndex
+  );
+
+  const upLevels = cleanTargetFolderComponents.length - firstDiffIndex - 1;
 
   const leadingString = "../".repeat(upLevels);
 
-  return `${leadingString}${cleanFilePath.substring(firstDiffIndex)}`;
+  return `${leadingString}${remainingFilePathComponents.join("/")}`;
 };
 
 export const filePathFromHTMLElement = (element: HTMLElement) => {
@@ -394,13 +401,13 @@ export const isWithinDataFolder = (filePath: string) =>
 const getFilePathInDataFolder = (dragFilePath: string) =>
   cleanFilePath(dragFilePath);
 
-export const getFilePathForDragFile = (
-  dragFilePath: string,
+export const getFilePathForRelativeToProject = (
+  absFilePath: string,
   pipelineCwd: string
 ) => {
-  return isWithinDataFolder(dragFilePath)
-    ? getFilePathInDataFolder(dragFilePath)
-    : getRelativePathTo(cleanFilePath(dragFilePath), pipelineCwd);
+  return isWithinDataFolder(absFilePath)
+    ? getFilePathInDataFolder(absFilePath)
+    : getRelativePathTo(cleanFilePath(absFilePath), pipelineCwd);
 };
 
 export const lastSelectedFolderPath = (selectedFiles: string[]) => {

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
@@ -142,7 +142,7 @@ const DEFAULT_STEP_SELECTOR = {
 
 export function removeConnection<
   T extends Pick<EventVars, "steps" | "connections">
->(baseState: T, connectionToDelete: Connection | null): T {
+>(baseState: T, connectionToDelete: Connection | NewConnection | null): T {
   if (!connectionToDelete) return baseState;
 
   const { startNodeUUID, endNodeUUID } = connectionToDelete;
@@ -154,7 +154,7 @@ export function removeConnection<
     );
   });
 
-  const subsequentStep = baseState.steps[endNodeUUID];
+  const subsequentStep = endNodeUUID ? baseState.steps[endNodeUUID] : undefined;
 
   const updatedState = {
     ...baseState,
@@ -162,7 +162,7 @@ export function removeConnection<
     selectedConnection: null,
   };
 
-  if (!subsequentStep) return updatedState;
+  if (!endNodeUUID || !subsequentStep) return updatedState;
 
   // remove it from the incoming_connections of its subsequent nodes
   // we don't have to clean up outgoing_connections
@@ -244,7 +244,7 @@ export const useEventVars = () => {
 
         // ==== user didn't mouseup on a step, abort
 
-        if (!endNodeUUID) {
+        if (!endNodeUUID && newConnection.current) {
           console.error("Failed to make connection. endNodeUUID is undefined.");
           const connectionToRemove = { ...newConnection.current };
           // when deleting connections, it's impossible that user is also creating a new connection
@@ -260,7 +260,7 @@ export const useEventVars = () => {
           startNodeUUID
         );
 
-        if (alreadyExists) {
+        if (alreadyExists && newConnection.current) {
           const error =
             "These steps are already connected. No new connection has been created.";
           const connectionToRemove = { ...newConnection.current };
@@ -275,7 +275,7 @@ export const useEventVars = () => {
           endNodeUUID,
         ]);
 
-        if (connectionCreatesCycle) {
+        if (connectionCreatesCycle && newConnection.current) {
           const error =
             "Connecting this step will create a cycle in your pipeline which is not supported.";
 
@@ -293,7 +293,8 @@ export const useEventVars = () => {
             (connection) => !connection.endNodeUUID
           );
           draft.connections[index].endNodeUUID = endNodeUUID;
-          draft.steps[endNodeUUID].incoming_connections.push(startNodeUUID);
+          if (startNodeUUID)
+            draft.steps[endNodeUUID].incoming_connections.push(startNodeUUID);
         });
       };
 
@@ -374,7 +375,6 @@ export const useEventVars = () => {
             ...state,
             ...updated,
             openedStep: newStep.uuid,
-            openedMultiStep: false,
             ...selectSteps([newStep.uuid]),
           });
         }
@@ -426,7 +426,6 @@ export const useEventVars = () => {
             return {
               ...state,
               openedStep: uuids[0],
-              openedMultiStep: false,
               ...selectSteps(uuids),
             };
           }
@@ -583,7 +582,7 @@ export const useEventVars = () => {
                 ...outgoingConnections,
               ];
             },
-            []
+            [] as Connection[]
           );
           newConnection.current = undefined;
           const updatedState: EventVars = connectionsToDelete.reduce(

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineCanvas.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineCanvas.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export const PipelineCanvas = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement | undefined>
 >(function PipelineStepsHolder({ children, ...props }, ref) {
   return (
     <div

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -13,7 +13,7 @@ import {
 } from "../common";
 import { usePipelineCanvasContext } from "../contexts/PipelineCanvasContext";
 import { usePipelineEditorContext } from "../contexts/PipelineEditorContext";
-import { getFilePathForDragFile } from "../file-manager/common";
+import { getFilePathForRelativeToProject } from "../file-manager/common";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "../file-manager/useValidateFilesOnSteps";
 import { INITIAL_PIPELINE_POSITION } from "../hooks/usePipelineCanvasState";
@@ -218,7 +218,7 @@ export const PipelineViewport = React.forwardRef<
             title: "",
             uuid: uuidv4(),
             incoming_connections: [],
-            file_path: getFilePathForDragFile(filePath, pipelineCwd),
+            file_path: getFilePathForRelativeToProject(filePath, pipelineCwd),
             kernel: {
               name: environment?.language || "python",
               display_name: environment?.name || "Python",
@@ -239,7 +239,6 @@ export const PipelineViewport = React.forwardRef<
   const onDropFiles = React.useCallback(() => {
     // assign a file to a step cannot be handled here because PipelineStep onMouseUp has e.stopPropagation()
     // here we only handle "create a new step".
-    // const targetElement = target as HTMLElement;
     const dropPosition = getOnCanvasPosition({
       x: STEP_WIDTH / 2,
       y: STEP_HEIGHT / 2,

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -81,7 +81,7 @@ export const PipelineViewport = React.forwardRef<
     resetPipelineCanvas,
   } = usePipelineCanvasContext();
 
-  const localRef = React.useRef<HTMLDivElement>(null);
+  const localRef = React.useRef<HTMLDivElement | null>(null);
   const [canvasResizeStyle, resizeCanvas] = React.useState<React.CSSProperties>(
     {}
   );
@@ -206,6 +206,7 @@ export const PipelineViewport = React.forwardRef<
 
   const createStepsWithFiles = React.useCallback(
     (dropPosition: Position) => {
+      if (!pipelineCwd) return;
       const { allowed } = getApplicableStepFiles();
 
       const environment = environments.length > 0 ? environments[0] : null;
@@ -222,7 +223,7 @@ export const PipelineViewport = React.forwardRef<
               name: environment?.language || "python",
               display_name: environment?.name || "Python",
             },
-            environment: environment?.uuid,
+            environment: environment?.uuid || "",
             parameters: {},
             meta_data: {
               position: [dropPosition.x, dropPosition.y],

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
@@ -25,7 +25,7 @@ const isTrachpad = (event: WheelEvent) => {
  * All the gesture events for PipelineEditor should be implemented in this hook.
  */
 export const useGestureOnViewport = (
-  ref: React.MutableRefObject<HTMLDivElement>,
+  ref: React.MutableRefObject<HTMLDivElement | null>,
   pipelineSetHolderOrigin: (newOrigin: [number, number]) => void
 ) => {
   const {

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useKeyboardEventsOnViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useKeyboardEventsOnViewport.tsx
@@ -5,7 +5,7 @@ import { usePipelineEditorContext } from "../contexts/PipelineEditorContext";
 import { CanvasFunctions } from "./PipelineViewport";
 
 export const useKeyboardEventsOnViewport = (
-  canvasFuncRef: React.MutableRefObject<CanvasFunctions>
+  canvasFuncRef: React.MutableRefObject<CanvasFunctions | undefined>
 ) => {
   const { dispatch, keysDown } = usePipelineEditorContext();
   const { setPipelineCanvasState } = usePipelineCanvasContext();
@@ -22,7 +22,7 @@ export const useKeyboardEventsOnViewport = (
         setPipelineCanvasState({ panningState: "ready-to-pan" });
         keysDown.add("Space");
       }
-      if (event.key === "h" && !keysDown.has("h")) {
+      if (canvasFuncRef.current && event.key === "h" && !keysDown.has("h")) {
         canvasFuncRef.current.centerView();
         keysDown.add("h");
       }

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/FilePicker.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/FilePicker.tsx
@@ -77,7 +77,7 @@ type FilePickerProps = {
   cwd: string;
   icon?: React.ReactNode;
   helperText: string;
-  onChangeValue?: (value: FilePickerProps["value"]) => void;
+  onChangeValue: (value: FilePickerProps["value"]) => void;
   tree: FileTree;
   value: string;
   menuMaxWidth?: string;
@@ -139,10 +139,10 @@ const FilePicker: React.FC<FilePickerProps> = ({
     return computeAbsPath({ cwd, value, tree });
   }, [cwd, value, tree]);
 
-  const [absPath, setAbsPath] = React.useState(computedAbsPath);
+  const [absPath, setAbsPath] = React.useState<string>(computedAbsPath);
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>();
-  const menuRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement | null>(null);
   useClickOutside(menuRef, () => setIsDropdownOpen(false));
 
   const isBlurAllowed = React.useRef(true);
@@ -165,7 +165,6 @@ const FilePicker: React.FC<FilePickerProps> = ({
       setAbsPath((oldPath) => {
         // If it's root, it needs to be handled differently.
         // It is either "/project-dir:/", or "/data:/".
-        if (!selectedNode.depth) return selectedNode.path;
 
         return `${oldPath}${selectedNode.name}/`;
       });
@@ -207,9 +206,10 @@ const FilePicker: React.FC<FilePickerProps> = ({
         // Root nodes need to be handled differently.
         // Because `node.name` is used to render UI, we have to check node.path, which ends with ":/".
         // For the rest of the nodes, simply compare node.name.
-        const isRoot = child.depth === 0 && /^\/(.*):\/$/.test(child.path);
+        const isRoot =
+          child.depth === 0 && /^\/(.*):\/$/.test(child.path || "");
         const valueToCompare = isRoot
-          ? child.path.replace(/\//g, "")
+          ? (child.path || "").replace(/\//g, "")
           : child.name;
 
         if (valueToCompare === component) {

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/FilePicker.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/FilePicker.tsx
@@ -11,12 +11,12 @@ import MenuList from "@mui/material/MenuList";
 import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
 import {
-  absoluteToRelativePath,
   ALLOWED_STEP_EXTENSIONS,
   collapseDoubleDots,
   extensionFromFilename,
 } from "@orchest/lib-utils";
 import React from "react";
+import { getFilePathForRelativeToProject } from "../file-manager/common";
 
 const validatePathInTree = (path: string, tree: FileTree) => {
   // path assumed to start with /
@@ -84,14 +84,6 @@ type FilePickerProps = {
   onSelectMenuItem: (node: FileTree) => void;
 };
 
-const visualizePath = (path: string, cwd: string) => {
-  if (path.startsWith("/data:/")) return path.replace(/^\/data\:\//, "/data/");
-  return absoluteToRelativePath(
-    path.replace(/^\/project-dir\:\//, "/"),
-    cwd
-  ).slice(1);
-};
-
 const getFolderPath = (filePath: string) =>
   filePath.split("/").slice(0, -1).join("/") + "/";
 
@@ -105,8 +97,10 @@ const computeAbsPath = ({
     return getFolderPath(value.replace(/^\/data\//, "/data:/"));
   }
 
+  const absCwd = `/project-dir:/${cwd === "/" ? "" : cwd}`;
+
   // The rest is a relative path to pipelineCwd
-  const projectFilePath = collapseDoubleDots(`${cwd}${value}`);
+  const projectFilePath = collapseDoubleDots(`${absCwd}${value}`);
   const isFile = !projectFilePath.endsWith("/");
   const directoryPath = isFile
     ? getFolderPath(projectFilePath)
@@ -114,11 +108,7 @@ const computeAbsPath = ({
 
   // Check if directoryPath exists.
   // If not, use pipelineCwd as fallback.
-  const validDirectoryPath = !validatePathInTree(directoryPath, tree)
-    ? cwd
-    : directoryPath;
-
-  return `/project-dir:${validDirectoryPath}`;
+  return !validatePathInTree(directoryPath, tree) ? absCwd : directoryPath;
 };
 
 const ITEM_HEIGHT = 48;
@@ -159,21 +149,6 @@ const FilePicker: React.FC<FilePickerProps> = ({
     });
   };
 
-  const onSelectListItem = (selectedNode: FileTree) => {
-    onSelectMenuItem(selectedNode);
-    if (selectedNode.type === "directory") {
-      setAbsPath((oldPath) => {
-        // If it's root, it needs to be handled differently.
-        // It is either "/project-dir:/", or "/data:/".
-
-        return `${oldPath}${selectedNode.name}/`;
-      });
-    } else {
-      onChangeValue(visualizePath(`${absPath}${selectedNode.name}`, cwd));
-      setIsDropdownOpen(false);
-    }
-  };
-
   const onFocusTextField = () => {
     setIsDropdownOpen(true);
   };
@@ -191,7 +166,7 @@ const FilePicker: React.FC<FilePickerProps> = ({
     // that was triggered from within the component.
     // state.path is modified when navigating the directory.
     if (absPath !== computedAbsPath) {
-      onChangeValue(visualizePath(absPath, cwd));
+      onChangeValue(getFilePathForRelativeToProject(absPath, cwd));
     }
   }, [absPath]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -231,6 +206,26 @@ const FilePicker: React.FC<FilePickerProps> = ({
       }),
     };
   }, [absPath, tree]);
+
+  const onSelectListItem = (selectedNode: FileTree) => {
+    onSelectMenuItem(selectedNode);
+    if (selectedNode.type === "directory") {
+      setAbsPath((oldPath) => {
+        const selectedNodePath = selectedNode.path || "";
+        // If it's root, it needs to be handled differently.
+        // It is either "/project-dir:/", or "/data:/".
+        if (["/project-dir:/", "/data:/"].includes(selectedNodePath))
+          return selectedNodePath;
+
+        return `${oldPath}${selectedNode.name}/`;
+      });
+    } else {
+      onChangeValue(
+        getFilePathForRelativeToProject(`${absPath}${selectedNode.name}`, cwd)
+      );
+      setIsDropdownOpen(false);
+    }
+  };
 
   return (
     <Box sx={{ position: "relative" }}>

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/ProjectFilePicker.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/ProjectFilePicker.tsx
@@ -23,8 +23,6 @@ const ProjectFilePicker: React.FC<{
     value
   );
 
-  const onChangeFileValue = (value: string) => onChange(value);
-
   const tree = React.useMemo<FileTree>(() => {
     return {
       name: "",
@@ -72,7 +70,7 @@ const ProjectFilePicker: React.FC<{
               ? "File exists in the project directory."
               : "Warning: this file wasn't found in the project directory."
           }
-          onChangeValue={onChangeFileValue}
+          onChangeValue={onChange}
           menuMaxWidth={menuMaxWidth}
           onSelectMenuItem={onSelectMenuItem}
         />

--- a/services/orchest-webserver/client/src/utils/jquery-replacement.ts
+++ b/services/orchest-webserver/client/src/utils/jquery-replacement.ts
@@ -1,4 +1,6 @@
-export function getOffset<T extends HTMLElement>(element: T | undefined) {
+export function getOffset<T extends HTMLElement>(
+  element: T | undefined | null
+) {
   if (!element) return { top: 0, left: 0 };
   const box = element.getBoundingClientRect();
   return {
@@ -7,14 +9,14 @@ export function getOffset<T extends HTMLElement>(element: T | undefined) {
   };
 }
 
-export const getWidth = (element: HTMLElement) => {
+export const getWidth = (element: HTMLElement | undefined | null) => {
   if (!element) return 0;
 
   const style = window.getComputedStyle(element, null);
   return parseFloat(style.width.replace("px", ""));
 };
 
-export const getHeight = (element: HTMLElement) => {
+export const getHeight = (element: HTMLElement | undefined | null) => {
   if (!element) return 0;
 
   const style = window.getComputedStyle(element, null);


### PR DESCRIPTION
## Description

Previously, only the project files can be assigned to pipeline steps. To encourage reusing generic scripts across projects, this PR allows user assign files in the `/data` folder to pipeline steps.

This PR also fixes the following bugs:

- When user uses the dropdown of the file picker to specify the file for pipeline steps, the value is the path should be relative to the pipeline file, instead of the project root.
- When user moves `.orchest` files from `Project files` to `/data`, it should not throw errors and the corresponding pipeline should be removed (i.e. disappear from the sessions panel).
- When user moves `.orchest` files from `/data` to `Project files`, the `.orchest` files should be recognized and added as pipelines (i.e. visible in the sessions panel).

@fruttasecca  Tag you here because there are some minor BE code changes.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.

