### PR TITLE
Disable updates for last pre-controller version

### DIFF
--- a/services/orchest-ctl/app/orchest/_core.py
+++ b/services/orchest-ctl/app/orchest/_core.py
@@ -729,7 +729,14 @@ def _update() -> None:
     a user through the CLI. This code will change the state of the
     deployment of Orchest. It assumes Orchest has been stopped.
     """
-    utils.echo("Updating...")
+    utils.echo(
+        "Orchest has gone through a breaking change to introduce a native kubernetes "
+        "operator for managing Orchest. You are on the latest pre-operator version "
+        "and cannot automatically update further. Head to the docs at "
+        "https://docs.orchest.io/en/stable/getting_started/installation.html for "
+        "instructions on how to move to this newer version of Orchest."
+    )
+    return
 
     # Check if Orchest is actually stopped.
     depls = k8sw.get_orchest_deployments()

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -71,11 +71,11 @@ export const useCheckUpdate = () => {
       "Breaking changes in the next version",
       <>
         <Typography variant="body2">
-          {`There is a new version of Orchest that contains infrastructure breaking changes. Updating to the new version via GUI is not supported.`}
+          {`There is a new version of Orchest that contains infrastructure breaking changes. Directly updating to the new version is unfortunately not possible.`}
         </Typography>
         <Typography variant="body2" sx={{ marginTop: 4 }}>
-          {`Please check out the following tutorial to update to the newer version: `}
-          <a href="https://github.com/orchest/orchest/to-be-defined">
+          {`Please refer to the installation guide to re-install Orchest with the new version `}
+          <a href="https://docs.orchest.io/en/stable/getting_started/installation.html ">
             the tutorial
           </a>
           .

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -74,11 +74,15 @@ export const useCheckUpdate = () => {
           {`There is a new version of Orchest that contains infrastructure breaking changes. Directly updating to the new version is unfortunately not possible.`}
         </Typography>
         <Typography variant="body2" sx={{ marginTop: 4 }}>
-          {`Please refer to the installation guide to re-install Orchest with the new version `}
-          <a href="https://docs.orchest.io/en/stable/getting_started/installation.html ">
-            the tutorial
+          {`Please refer to `}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://docs.orchest.io/en/stable/getting_started/installation.html "
+          >
+            the installation guide
           </a>
-          .
+          {` to re-install Orchest with the new version.`}
         </Typography>
       </>,
       (resolve) => {

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -8,6 +8,7 @@ import Typography from "@mui/material/Typography";
 import { fetcher } from "@orchest/lib-utils";
 import React from "react";
 import useSWRImmutable from "swr/immutable";
+import { useCancelablePromise } from "./useCancelablePromise";
 
 const isVersionLTE = (oldVersion: string, newVersion: string) => {
   const [oldYear, oldMonth, oldPatch] = oldVersion.split(".");
@@ -33,24 +34,37 @@ const shouldPromptOrchestUpdate = (
   return skipVersion !== latestVersion;
 };
 
+const fetchOrchestVersion = () =>
+  fetcher<OrchestVersion>("/async/version").then(
+    (response) => response.version
+  );
+
+const fetchLatestVersion = () =>
+  fetcher<UpdateInfo>("/async/orchest-update-info").then(
+    (response) => response.latest_version
+  );
+
 // To limit the number of api calls and make sure only one prompt is shown,
 // it is best to place this hook in top-level components (i.e. the ones
 // defined in the routingConfig.tsx).
 export const useCheckUpdate = () => {
-  const [skipVersion, setSkipVersion] = useLocalStorage("skip_version", null);
+  const [skipVersion, setSkipVersion] = useLocalStorage<string | null>(
+    "skip_version",
+    null
+  );
 
   // Only make requests every hour, because the latest Orchest version gets
   // fetched once per hour. Use `useSWRImmutable` to disable all kinds of
   // automatic revalidation; just serve from cache and refresh cache
   // once per hour.
-  const { data: orchestVersion } = useSWRImmutable<OrchestVersion>(
+  const { data: orchestVersion } = useSWRImmutable(
     "/async/version",
-    fetcher,
+    fetchOrchestVersion,
     { refreshInterval: 3600000 }
   );
-  const { data: updateInfo } = useSWRImmutable<UpdateInfo>(
+  const { data: latestVersion } = useSWRImmutable(
     "/async/orchest-update-info",
-    fetcher,
+    fetchLatestVersion,
     { refreshInterval: 3600000 }
   );
 
@@ -58,16 +72,17 @@ export const useCheckUpdate = () => {
   const { navigateTo } = useCustomRoute();
 
   const promptUpdate = React.useCallback(
-    (currentVersion: string, latestVersion: string) => {
+    (localVersion: string, versionToUpdate: string) => {
       setConfirm(
         "Update available",
         <>
           <Typography variant="body2">
-            Orchest can be updated from <Code>{currentVersion}</Code> to{" "}
-            <Code>{latestVersion}</Code> . Would you like to update now?
+            {`Orchest can be updated from `}
+            <Code>{localVersion}</Code> to <Code>{versionToUpdate}</Code> .
+            Would you like to update now?
           </Typography>
           <Typography variant="body2" sx={{ marginTop: 4 }}>
-            Check out the{" "}
+            {`Check out the `}
             <a href="https://github.com/orchest/orchest/releases/latest">
               release notes
             </a>
@@ -81,7 +96,7 @@ export const useCheckUpdate = () => {
             return true;
           },
           onCancel: async (resolve) => {
-            setSkipVersion(updateInfo.latest_version);
+            setSkipVersion(versionToUpdate);
             resolve(false);
             return false;
           },
@@ -90,26 +105,25 @@ export const useCheckUpdate = () => {
         }
       );
     },
-    [setConfirm, setSkipVersion, updateInfo?.latest_version, navigateTo]
+    [setConfirm, setSkipVersion, navigateTo]
   );
 
   const handlePrompt = React.useCallback(
     (
-      orchestVersion: OrchestVersion,
-      updateInfo: UpdateInfo,
+      localVersion: OrchestVersion["version"],
+      versionToUpdate: UpdateInfo["latest_version"],
       skipVersion: string | null,
       shouldPromptNoUpdate: boolean
     ) => {
-      const currentVersion = orchestVersion.version;
-      const latestVersion = updateInfo.latest_version;
+      if (!localVersion || !versionToUpdate) return;
 
       const shouldPromptUpdate = shouldPromptOrchestUpdate(
-        currentVersion,
-        latestVersion,
+        localVersion,
+        versionToUpdate,
         skipVersion
       );
       if (shouldPromptUpdate) {
-        promptUpdate(currentVersion, latestVersion);
+        promptUpdate(localVersion, versionToUpdate);
       } else if (shouldPromptNoUpdate) {
         setConfirm(
           "No update available",
@@ -120,27 +134,28 @@ export const useCheckUpdate = () => {
     [setConfirm, promptUpdate]
   );
 
-  const checkUpdateNow = async () => {
+  const { makeCancelable } = useCancelablePromise();
+
+  const checkUpdateNow = React.useCallback(async () => {
     // Use fetcher directly instead of mutate function from the SWR
     // calls to prevent updating the values which would trigger the
     // useEffect and thereby prompting the user twice. In addition,
     // we want to be able to tell the user that no update is available
     // if this function is invoked.
-    const [fetchedOrchestVersion, fetchedUpdateInfo] = await Promise.all([
-      fetcher<OrchestVersion>("/async/version"),
-      fetcher<UpdateInfo>("/async/orchest-update-info"),
-    ]);
+    const [fetchedOrchestVersion, fetchedLatestVersion] = await makeCancelable(
+      Promise.all([fetchOrchestVersion(), fetchLatestVersion()])
+    );
 
-    if (fetchedOrchestVersion && fetchedUpdateInfo) {
-      handlePrompt(fetchedOrchestVersion, fetchedUpdateInfo, null, true);
+    if (fetchedOrchestVersion && fetchedLatestVersion) {
+      handlePrompt(fetchedOrchestVersion, fetchedLatestVersion, null, true);
     }
-  };
+  }, [handlePrompt, makeCancelable]);
 
   React.useEffect(() => {
-    if (orchestVersion && updateInfo) {
-      handlePrompt(orchestVersion, updateInfo, skipVersion, false);
+    if (orchestVersion && latestVersion) {
+      handlePrompt(orchestVersion, latestVersion, skipVersion, false);
     }
-  }, [orchestVersion, updateInfo, skipVersion, handlePrompt]);
+  }, [orchestVersion, latestVersion, skipVersion, handlePrompt]);
 
   return checkUpdateNow;
 };

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -410,5 +410,5 @@ export type UpdateInfo = {
 };
 
 export type OrchestVersion = {
-  version: string | null;
+  version: string | null | undefined;
 };


### PR DESCRIPTION
## Description

This PR:
- [x] adds a GUI alert that tells users about the breaking change and points them to the doc
- [X] disables CLI updates and GUI updates (the GUI won't actually allow to get to the update view through buttons, you have to know which path to look for, nevertheless it's safer to disable)

Once this PR is merged and `dev` is merged back into the controller branch the FE changes will have to be reverted, no BE changes are required since only `orchest-ctl` was modified, which won' be part of Orchest post controller release.
