### PR TITLE
Feat/canvas context menu

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/CreateNextStepButton.tsx
@@ -1,7 +1,7 @@
 import { useAppContext } from "@/contexts/AppContext";
 import AddIcon from "@mui/icons-material/Add";
-import { uuidv4 } from "@orchest/lib-utils";
 import React from "react";
+import { createStepAction } from "./action-helpers/eventVarsHelpers";
 import { usePipelineCanvasContext } from "./contexts/PipelineCanvasContext";
 import { usePipelineEditorContext } from "./contexts/PipelineEditorContext";
 import { PipelineActionButton } from "./PipelineActionButton";
@@ -39,30 +39,12 @@ export const CreateNextStepButton = ({
         pipelineOffsetY,
       ] = pipelineCanvasState.pipelineOffset;
 
-      const position = [
-        -pipelineOffsetX + clientWidth / 2 - STEP_WIDTH / 2,
-        -pipelineOffsetY + clientHeight / 2 - STEP_HEIGHT / 2,
-      ] as [number, number];
+      const position = {
+        x: -pipelineOffsetX + clientWidth / 2 - STEP_WIDTH / 2,
+        y: -pipelineOffsetY + clientHeight / 2 - STEP_HEIGHT / 2,
+      };
 
-      dispatch({
-        type: "CREATE_STEP",
-        payload: {
-          title: "",
-          uuid: uuidv4(),
-          incoming_connections: [],
-          file_path: "",
-          kernel: {
-            name: environment?.language || "python",
-            display_name: environment?.name || "Python",
-          },
-          environment: environment?.uuid || "",
-          parameters: {},
-          meta_data: {
-            position,
-            hidden: false,
-          },
-        },
-      });
+      dispatch(createStepAction(environment, position));
     } catch (error) {
       setAlert("Error", `Unable to create a new step. ${error}`);
     }

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -27,7 +27,7 @@ import {
   fetcher,
   hasValue,
 } from "@orchest/lib-utils";
-import React, { useState } from "react";
+import React from "react";
 import { BackToJobButton } from "./BackToJobButton";
 import {
   getNodeCenter,
@@ -395,7 +395,7 @@ export const PipelineEditor = () => {
     setPipelineJson((value) => value, true);
   }, [setPipelineJson]);
 
-  const contextMenuState = useState(false);
+  const isContextMenuOpenState = React.useState(false);
 
   const autoLayoutPipeline = () => {
     const spacingFactor = 0.7;
@@ -654,7 +654,7 @@ export const PipelineEditor = () => {
           canvasFuncRef={canvasFuncRef}
           executeRun={executeRun}
           autoLayoutPipeline={autoLayoutPipeline}
-          contextMenuState={contextMenuState}
+          isContextMenuOpenState={isContextMenuOpenState}
         >
           {connections.map((connection) => {
             if (!connection) return null;
@@ -778,7 +778,7 @@ export const PipelineEditor = () => {
                 interactiveConnections={interactiveConnections}
                 onDoubleClick={onDoubleClickStep}
                 getPosition={getPosition}
-                contextMenuState={contextMenuState}
+                isContextMenuOpenState={isContextMenuOpenState}
               >
                 <ConnectionDot
                   incoming

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -27,7 +27,7 @@ import {
   fetcher,
   hasValue,
 } from "@orchest/lib-utils";
-import React from "react";
+import React, { useState } from "react";
 import { BackToJobButton } from "./BackToJobButton";
 import {
   getNodeCenter,
@@ -395,6 +395,8 @@ export const PipelineEditor = () => {
     setPipelineJson((value) => value, true);
   }, [setPipelineJson]);
 
+  const contextMenuState = useState(false);
+
   const autoLayoutPipeline = () => {
     const spacingFactor = 0.7;
     const gridMargin = 20;
@@ -650,6 +652,9 @@ export const PipelineEditor = () => {
         <PipelineViewport
           ref={pipelineViewportRef}
           canvasFuncRef={canvasFuncRef}
+          executeRun={executeRun}
+          autoLayoutPipeline={autoLayoutPipeline}
+          contextMenuState={contextMenuState}
         >
           {connections.map((connection) => {
             if (!connection) return null;
@@ -760,6 +765,9 @@ export const PipelineEditor = () => {
               <PipelineStep
                 key={`${step.uuid}-${hash.current}`}
                 data={step}
+                executeRun={executeRun}
+                onOpenFilePreviewView={onOpenFilePreviewView}
+                onOpenNotebook={onOpenNotebook}
                 selected={selected}
                 savePositions={savePositions}
                 movedToTop={movedToTop}
@@ -770,6 +778,7 @@ export const PipelineEditor = () => {
                 interactiveConnections={interactiveConnections}
                 onDoubleClick={onDoubleClickStep}
                 getPosition={getPosition}
+                contextMenuState={contextMenuState}
               >
                 <ConnectionDot
                   incoming

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -491,8 +491,11 @@ const PipelineStepComponent = React.forwardRef<
     {
       type: "item",
       title: "Open in JupyterLab",
-      action: (e: React.MouseEvent, _itemId?: string) => {
-        onOpenNotebook(e);
+      action: (e: React.MouseEvent, itemId?: string) => {
+        if (itemId) {
+          dispatch({ type: "SET_OPENED_STEP", payload: itemId });
+          onOpenNotebook(e);
+        }
       },
     },
     {

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -18,6 +18,9 @@ import { usePipelineEditorContext } from "./contexts/PipelineEditorContext";
 import { getFilePathForRelativeToProject } from "./file-manager/common";
 import { useFileManagerContext } from "./file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "./file-manager/useValidateFilesOnSteps";
+import { MenuItem, useContextMenu } from "./hooks/useContextMenu";
+import { useEventVars } from "./hooks/useEventVars";
+import { RunStepsType } from "./hooks/useInteractiveRuns";
 import { useUpdateZIndex } from "./hooks/useZIndexMax";
 import { InteractiveConnection } from "./pipeline-connection/InteractiveConnection";
 
@@ -115,18 +118,25 @@ const PipelineStepComponent = React.forwardRef<
   {
     data: PipelineStepState;
     selected: boolean;
+    executeRun: (uuids: string[], type: RunStepsType) => Promise<void>;
+    onOpenNotebook: (e: React.MouseEvent) => void;
+    onOpenFilePreviewView: (e: React.MouseEvent, uuid: string) => void;
     movedToTop: boolean;
     isStartNodeOfNewConnection: boolean;
     savePositions: () => void;
     onDoubleClick: (stepUUID: string) => void;
     interactiveConnections: Connection[];
     getPosition: (node: HTMLElement | undefined | null) => Position | null;
+    contextMenuState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
     children: React.ReactNode;
   }
 >(function PipelineStep(
   {
     data,
     selected,
+    executeRun,
+    onOpenNotebook,
+    onOpenFilePreviewView,
     movedToTop,
     isStartNodeOfNewConnection,
     savePositions,
@@ -134,6 +144,7 @@ const PipelineStepComponent = React.forwardRef<
     // the cursor-controlled step also renders all the interactive connections, to ensure the precision of the positions
     interactiveConnections,
     getPosition,
+    contextMenuState,
     children, // expose children, so that children doesn't re-render when step is being dragged
   },
   ref
@@ -275,8 +286,8 @@ const PipelineStepComponent = React.forwardRef<
 
   const onMouseDown = React.useCallback(
     (e: React.MouseEvent) => {
-      // user is panning the canvas
-      if (keysDown.has("Space")) return;
+      // user is panning the canvas or context menu is open
+      if (keysDown.has("Space") || contextMenuState[0]) return;
 
       e.stopPropagation();
       e.preventDefault();
@@ -288,12 +299,18 @@ const PipelineStepComponent = React.forwardRef<
     [forceUpdate, keysDown]
   );
 
+  const [contextMenu, setContextMenu] = React.useState<{
+    mouseX: number;
+    mouseY: number;
+  } | null>(null);
+
   const onClick = async (e: React.MouseEvent) => {
-    // user is panning the canvas
-    if (keysDown.has("Space")) return;
+    // user is panning the canvas or context menu is open
+    if (keysDown.has("Space") || contextMenuState[0]) return;
 
     e.stopPropagation();
     e.preventDefault();
+
     if (e.detail === 1) {
       // even user is actually dragging, React still sees it as a click
       // maybe because cursor remains on the same position over the DOM
@@ -437,6 +454,78 @@ const PipelineStepComponent = React.forwardRef<
     setIsHovering(false);
   };
 
+  const menuItems = [
+    {
+      type: "item",
+      title: "Duplicate",
+      action: (e: React.MouseEvent, itemId: string) => {
+        dispatch({ type: "DUPLICATE_STEPS", payload: [itemId] });
+      },
+    },
+    {
+      type: "item",
+      title: "Delete",
+      action: (e: React.MouseEvent, itemId: string) => {
+        dispatch({ type: "REMOVE_STEPS", payload: [itemId] });
+      },
+    },
+    {
+      type: "item",
+      title: "Properties",
+      action: (e: React.MouseEvent, itemId: string) => {
+        dispatch({ type: "SELECT_SUB_VIEW", payload: 0 });
+      },
+    },
+    {
+      type: "item",
+      title: "Open in JupyterLab",
+      action: (e: React.MouseEvent, itemId: string) => {
+        onOpenNotebook(e);
+      },
+    },
+    {
+      type: "item",
+      title: "Open in File Viewer",
+      action: (e: React.MouseEvent, itemId: string) => {
+        onOpenFilePreviewView(e, itemId);
+      },
+    },
+    {
+      type: "separator",
+    },
+    {
+      type: "item",
+      title: "Run this step",
+      action: (e: React.MouseEvent, itemId: string) => {
+        console.log(itemId);
+        executeRun([itemId], "selection");
+      },
+    },
+    {
+      type: "item",
+      title: "Run incoming",
+      action: (e: React.MouseEvent, itemId: string) => {
+        executeRun([itemId], "incoming");
+      },
+    },
+    {
+      type: "item",
+      title: "Run incoming and this step",
+      action: (e: React.MouseEvent, itemId: string) => {
+        executeRun([itemId], "incoming");
+        executeRun([itemId], "selection");
+      },
+    },
+  ] as MenuItem[];
+
+  const { eventVars } = useEventVars();
+
+  const { handleContextMenu, menu } = useContextMenu(
+    menuItems,
+    contextMenuState,
+    uuid
+  );
+
   return (
     <>
       <Box
@@ -452,18 +541,16 @@ const PipelineStepComponent = React.forwardRef<
           isStartNodeOfNewConnection && "creating-connection"
         )}
         style={{ transform, zIndex }}
+        onContextMenu={handleContextMenu}
         onMouseDown={onMouseDown}
         onMouseUp={onMouseUp}
         onMouseOver={onMouseOverContainer}
         onMouseOut={onMouseOutContainer}
-        onContextMenu={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-        }}
         onClick={onClick}
       >
         {children}
       </Box>
+      {menu}
       {isCursorControlled && // the cursor-controlled step also renders all the interactive connections
         interactiveConnections.map((connection) => {
           if (!connection) return null;

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -301,6 +301,17 @@ const PipelineStepComponent = React.forwardRef<
     [forceUpdate, keysDown, isContextMenuOpenState]
   );
 
+  const onContextMenu = async (e: React.MouseEvent) => {
+    const ctrlKeyPressed = e.ctrlKey || e.metaKey;
+    if (!selected) {
+      dispatch({
+        type: "SELECT_STEPS",
+        payload: { uuids: [uuid], inclusive: ctrlKeyPressed },
+      });
+    }
+    handleContextMenu(e);
+  };
+
   const onClick = async (e: React.MouseEvent) => {
     // user is panning the canvas or context menu is open
     if (keysDown.has("Space") || isContextMenuOpenState[0]) return;
@@ -547,7 +558,7 @@ const PipelineStepComponent = React.forwardRef<
           isStartNodeOfNewConnection && "creating-connection"
         )}
         style={{ transform, zIndex }}
-        onContextMenu={handleContextMenu}
+        onContextMenu={onContextMenu}
         onMouseDown={onMouseDown}
         onMouseUp={onMouseUp}
         onMouseOver={onMouseOverContainer}

--- a/services/orchest-webserver/client/src/pipeline-view/action-helpers/eventVarsHelpers.ts
+++ b/services/orchest-webserver/client/src/pipeline-view/action-helpers/eventVarsHelpers.ts
@@ -1,0 +1,29 @@
+import { Environment, Position } from "@/types";
+import { uuidv4 } from "@orchest/lib-utils";
+import { Action } from "../hooks/useEventVars";
+
+export const createStepAction = (
+  environment: Environment | null,
+  position: Position,
+  filePath = ""
+): Action => {
+  return {
+    type: "CREATE_STEP",
+    payload: {
+      title: "",
+      uuid: uuidv4(),
+      incoming_connections: [],
+      file_path: filePath,
+      kernel: {
+        name: environment?.language || "python",
+        display_name: environment?.name || "Python",
+      },
+      environment: environment?.uuid || "",
+      parameters: {},
+      meta_data: {
+        position: [position.x, position.y],
+        hidden: false,
+      },
+    },
+  };
+};

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
@@ -1,0 +1,90 @@
+import Divider from "@mui/material/Divider";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import React from "react";
+
+type MenuItemAction = {
+  type: "item";
+  title: string;
+  action: (e: React.MouseEvent, item?: string) => void;
+};
+
+type MenuItemSeparator = {
+  type: "separator";
+};
+
+export type MenuItem = MenuItemAction | MenuItemSeparator;
+
+export function useContextMenu(
+  items: MenuItem[],
+  contextMenuState: [boolean, React.Dispatch<React.SetStateAction<boolean>>],
+  itemId?: string
+) {
+  const [contextMenu, setContextMenu] = React.useState<{
+    mouseX: number;
+    mouseY: number;
+  } | null>(null);
+
+  const [contextMenuIsOpen, setContextMenuIsOpen] = contextMenuState;
+
+  const handleClicked = (e: React.MouseEvent, item: MenuItemAction) => {
+    if (contextMenu === null) {
+      return;
+    }
+
+    item.action(e, itemId);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setContextMenu(null);
+    setContextMenuIsOpen(false);
+  };
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (contextMenuIsOpen) {
+      return;
+    }
+
+    setContextMenu(
+      contextMenu === null
+        ? {
+            mouseX: event.clientX,
+            mouseY: event.clientY,
+          }
+        : null
+    );
+
+    setContextMenuIsOpen(contextMenu === null);
+  };
+
+  const menu = (
+    <Menu
+      open={contextMenu !== null}
+      onClose={handleClose}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        contextMenu !== null
+          ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+          : undefined
+      }
+    >
+      {items.map((i) => {
+        switch (i.type) {
+          case "item":
+            return (
+              <MenuItem onClick={(e) => handleClicked(e, i)}>
+                {i.title}
+              </MenuItem>
+            );
+          case "separator":
+            return <Divider />;
+        }
+      })}
+    </Menu>
+  );
+
+  return { handleContextMenu, menu };
+}

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
@@ -6,6 +6,7 @@ import React from "react";
 type MenuItemAction = {
   type: "item";
   title: string;
+  disabled?: boolean;
   action: (e: React.MouseEvent, itemId?: string) => void;
 };
 
@@ -75,7 +76,10 @@ export function useContextMenu(
         switch (i.type) {
           case "item":
             return (
-              <MenuItem onClick={(e) => handleClicked(e, i)}>
+              <MenuItem
+                onClick={(e) => handleClicked(e, i)}
+                disabled={i.disabled}
+              >
                 {i.title}
               </MenuItem>
             );

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
@@ -6,7 +6,7 @@ import React from "react";
 type MenuItemAction = {
   type: "item";
   title: string;
-  action: (e: React.MouseEvent, item?: string) => void;
+  action: (e: React.MouseEvent, itemId?: string) => void;
 };
 
 type MenuItemSeparator = {

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
@@ -9,7 +9,7 @@ import type {
   StepsDict,
 } from "@/types";
 import { getOuterHeight, getOuterWidth } from "@/utils/jquery-replacement";
-import { hasValue, intersectRect } from "@orchest/lib-utils";
+import { hasValue, intersectRect, uuidv4 } from "@orchest/lib-utils";
 import produce from "immer";
 import merge from "lodash.merge";
 import React from "react";
@@ -43,7 +43,7 @@ export type EventVars = {
   subViewIndex: number;
 };
 
-type Action =
+export type Action =
   | {
       type: "SET_STEPS";
       payload: StepsDict;
@@ -51,6 +51,10 @@ type Action =
   | {
       type: "CREATE_STEP";
       payload: PipelineStepState;
+    }
+  | {
+      type: "DUPLICATE_STEPS";
+      payload: string[];
     }
   | {
       type: "ASSIGN_FILE_TO_STEP";
@@ -382,6 +386,34 @@ export const useEventVars = () => {
             openedStep: newStep.uuid,
             subViewIndex: 0,
             ...selectSteps([newStep.uuid]),
+          });
+        }
+
+        case "DUPLICATE_STEPS": {
+          const newSteps = action.payload.map((step) => {
+            let newStep = {
+              ...state.steps[step],
+              uuid: uuidv4(),
+              meta_data: {
+                ...state.steps[step].meta_data,
+                position: getNewStepPosition(
+                  state.steps[step].meta_data.position
+                ),
+              },
+            };
+
+            return newStep;
+          });
+          const updated = produce(state, (draft) => {
+            newSteps.forEach((step) => {
+              draft.steps[step.uuid] = step;
+            });
+          });
+
+          return withTimestamp({
+            ...state,
+            ...updated,
+            ...selectSteps(newSteps.map((s) => s.uuid)),
           });
         }
 

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
@@ -394,6 +394,9 @@ export const useEventVars = () => {
             let newStep = {
               ...state.steps[step],
               uuid: uuidv4(),
+              file_path: state.steps[step].file_path.endsWith(".ipynb")
+                ? ""
+                : state.steps[step].file_path,
               meta_data: {
                 ...state.steps[step].meta_data,
                 position: getNewStepPosition(

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -291,6 +291,7 @@ export const PipelineViewport = React.forwardRef<
     {
       type: "item",
       title: "Run selected steps",
+      disabled: eventVars.selectedSteps.length === 0,
       action: () => {
         executeRun(eventVars.selectedSteps, "selection");
       },


### PR DESCRIPTION
## Description

Adds context menu to pipeline editor for common actions for both steps and general canvas.

Menu flicker on Safari only is a MUI bug, is addressed here https://github.com/mui/material-ui/issues/31849 and should be fixed in the next/a future version of MUI.

Fixes: #589 

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [x] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
- [x] I haven't introduced breaking changes that would disrupt existing jobs.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile`
      to update the corresponding `requirements.txt`.
