### PR TITLE
Use `order` as the serial number for services

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -141,13 +141,26 @@ def is_service_name_valid(service_name: str) -> bool:
     return bool(re.match(r"^[0-9a-zA-Z\-]{1,36}$", service_name))
 
 
-def is_service_definition_valid(service: Dict[str, Any]) -> bool:
+def is_service_order_valid(
+    service_order: Any, existing_service_orders: list[int]
+) -> bool:
+    # service_order acts as a serial number of a service
+    if isinstance(service_order, int) and service_order not in existing_service_orders:
+        existing_service_orders.append(service_order)
+        return True
+    return False
+
+
+def is_service_definition_valid(
+    service: Dict[str, Any], existing_service_orders: list[int]
+) -> bool:
     return (
         isinstance(service, dict)
         and is_service_name_valid(service["name"])
         and isinstance(service["image"], str)
         and service["image"]
         and isinstance(service["scope"], list)
+        and is_service_order_valid(service.get("order", 0), existing_service_orders)
         and isinstance(service.get("preserve_base_path", False), bool)
         and
         # Allowed scopes.
@@ -181,9 +194,11 @@ def is_service_definition_valid(service: Dict[str, Any]) -> bool:
 
 
 def is_services_definition_valid(services: Dict[str, Dict[str, Any]]) -> bool:
+    existing_service_orders = []
     return isinstance(services, dict) and all(
         [
-            is_service_definition_valid(service) and sname == service["name"]
+            is_service_definition_valid(service, existing_service_orders)
+            and sname == service["name"]
             for sname, service in services.items()
         ]
     )

--- a/orchest-sdk/python/orchest/pipeline.py
+++ b/orchest-sdk/python/orchest/pipeline.py
@@ -37,6 +37,7 @@ class ServiceDefinition(TypedDict):
     scope: List[str]  # interactive, noninteractive
     exposed: bool
     requires_authentication: bool
+    order: int
 
 
 class PipelineDefinition(TypedDict):

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -136,6 +136,13 @@ service = Model(
                 "without authentication requirements."
             ),
         ),
+        "order": fields.Integer(
+            required=False,
+            description=(
+                "Acts as the serial number of a service, "
+                "which should be unique within a pipeline."
+            ),
+        ),
     },
 )
 

--- a/services/orchest-api/app/app/types.py
+++ b/services/orchest-api/app/app/types.py
@@ -43,6 +43,7 @@ class ServiceDefinition(TypedDict):
     ports: Optional[List[int]]
     preserve_base_path: Optional[str]
     scope: List[str]  # interactive, noninteractive
+    order: int
 
 
 class PipelineDefinition(TypedDict):

--- a/services/orchest-webserver/app/app/compat.py
+++ b/services/orchest-webserver/app/app/compat.py
@@ -87,11 +87,16 @@ def _migrate_1_1_0(pipeline: dict) -> None:
         )
 
 
+def _migrate_1_2_0(pipeline: dict) -> None:
+    """Fill the missing order property for services"""
+    _fill_missing_order(pipeline.get("services"))
+
+
 # version: (migration function, version to which it's migrated)
 _version_to_migration_function = {
     "1.0.0": (_migrate_1_0_0, "1.1.0"),
     "1.1.0": (_migrate_1_1_0, "1.2.0"),
-    "1.2.0": (_migrate_1_1_0, "1.2.1"),
+    "1.2.0": (_migrate_1_2_0, "1.2.1"),
 }
 
 # Make sure no forward version is repeated.
@@ -129,7 +134,10 @@ def _sort_service_key_function(
         return 0
 
 
-def _fill_missing_order(services: Dict[str, Dict[str, Any]]) -> None:
+def _fill_missing_order(services: Optional[Dict[str, Dict[str, Any]]]) -> None:
+    if services is None:
+        return
+
     service_list = services.items()
     ordered_dict: Dict[str, int] = {}
 
@@ -156,7 +164,7 @@ def _fill_missing_order(services: Dict[str, Dict[str, Any]]) -> None:
         services[key]["order"] = max_order
 
 
-def migrate_pipeline(pipeline: dict):
+def migrate_pipeline(pipeline: dict) -> None:
     """Migrates a pipeline in place to the latest version."""
 
     if not pipeline.get("version", ""):
@@ -168,5 +176,3 @@ def migrate_pipeline(pipeline: dict):
         ]
         migration_func(pipeline)
         pipeline["version"] = migrate_to_version
-
-    _fill_missing_order(pipeline.get("services"))

--- a/services/orchest-webserver/app/app/compat.py
+++ b/services/orchest-webserver/app/app/compat.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 """Provides a simple migration layer for pipeline jsons.
 
@@ -91,6 +91,7 @@ def _migrate_1_1_0(pipeline: dict) -> None:
 _version_to_migration_function = {
     "1.0.0": (_migrate_1_0_0, "1.1.0"),
     "1.1.0": (_migrate_1_1_0, "1.2.0"),
+    "1.2.0": (_migrate_1_1_0, "1.2.1"),
 }
 
 # Make sure no forward version is repeated.
@@ -103,17 +104,17 @@ __migration_functions = set(
 assert len(_version_to_migration_function) == len(__migration_functions)
 
 
-def ensure_unique_order(sorted_service_list: Tuple[str, Dict[str, Any]]):
-    anchor = -1
-    for key, service in sorted_service_list:
-        service_order = service.get("order", -1)
-        if service_order == -1:
+def ensure_unique_order(sorted_service_list: List[Tuple[str, Dict[str, Any]]]):
+    max_order: int = -1
+    for (key, service) in sorted_service_list:
+        service_order = service.get("order")
+        if service_order is None:
             continue
-        if anchor == service_order:
+        if max_order == service_order:
             service["order"] = service_order + 1
-        anchor = service["order"]
+        max_order = service["order"]
 
-    return (sorted_service_list, anchor)
+    return (sorted_service_list, max_order)
 
 
 def sort_service_key_function(service: Dict[str, Any], ordered_dict: Dict[str, int]):

--- a/services/orchest-webserver/app/app/core/pipelines.py
+++ b/services/orchest-webserver/app/app/core/pipelines.py
@@ -8,7 +8,7 @@ import requests
 from flask.globals import current_app
 
 from _orchest.internals.two_phase_executor import TwoPhaseFunction
-from app import error
+from app import compat, error
 from app.connections import db
 from app.models import Pipeline
 from app.utils import (
@@ -331,6 +331,8 @@ class MovePipeline(TwoPhaseFunction):
         if rel_path != ".":
             with open(old_path, "r") as json_file:
                 pipeline_def = json.load(json_file)
+                # Ensures that pipeline_def applies the right schema
+                compat.migrate_pipeline(pipeline_def)
                 self.collateral_kwargs["pipeline_def_backup"] = copy.deepcopy(
                     pipeline_def
                 )

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -841,7 +841,7 @@ def register_views(app, db):
             # Normalize relative paths.
             for step in pipeline_json["steps"].values():
                 # No need to check if step file_path is within the
-                # project folder. Ohterwise, user cannot save anything
+                # project folder. Otherwise, user cannot save anything
                 # before they got all file paths correct.
                 if not step["file_path"].startswith("/"):
                     step["file_path"] = normalize_project_relative_path(

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -840,18 +840,9 @@ def register_views(app, db):
 
             # Normalize relative paths.
             for step in pipeline_json["steps"].values():
-
-                is_project_file = is_valid_pipeline_relative_path(
-                    project_uuid, pipeline_uuid, step["file_path"]
-                )
-
-                is_data_file = is_valid_data_path(step["file_path"])
-
-                if not (is_project_file or is_data_file):
-                    raise app_error.OutOfAllowedDirectoryError(
-                        "File is neither in the project, nor in the data directory."
-                    )
-
+                # No need to check if step file_path is within the
+                # project folder. Ohterwise, user cannot save anything
+                # before they got all file paths correct.
                 if not step["file_path"].startswith("/"):
                     step["file_path"] = normalize_project_relative_path(
                         step["file_path"]

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -339,22 +339,27 @@ const convertConfirm: PromptMessageConverter<Confirm> = ({
   };
 };
 
-const useFetchSystemConfig = () => {
+const useFetchSystemConfig = (shouldStart: boolean) => {
   const { data, run } = useAsync<OrchestServerConfig>();
   React.useEffect(() => {
-    run(fetcher("/async/server-config"));
-  }, [run]);
+    if (shouldStart) run(fetcher("/async/server-config"));
+  }, [run, shouldStart]);
   return (data || {}) as {
     config?: OrchestConfig;
     user_config?: OrchestUserConfig;
   };
 };
 
-export const AppContextProvider: React.FC = ({ children }) => {
+// `shouldStart` is only useful when running tests.
+// Use it to control the side effects within AppContext when mocking.
+export const AppContextProvider: React.FC<{ shouldStart?: boolean }> = ({
+  children,
+  shouldStart = true,
+}) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage("drawer", true);
 
-  const { config, user_config } = useFetchSystemConfig();
+  const { config, user_config } = useFetchSystemConfig(shouldStart);
 
   /**
    * =========================== side effects
@@ -433,7 +438,7 @@ export const AppContextProvider: React.FC = ({ children }) => {
         setIsDrawerOpen,
       }}
     >
-      {config && user_config ? children : null}
+      {children}
     </Context.Provider>
   );
 };

--- a/services/orchest-webserver/client/src/hooks/useFetchJob.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchJob.ts
@@ -17,12 +17,14 @@ export const useFetchJob = ({
 }) => {
   const { setAlert } = useAppContext();
 
+  const cacheKey = jobUuid
+    ? `/catch/api-proxy/api/jobs/${jobUuid}${
+        runStatuses ? "?aggregate_run_statuses=true" : ""
+      }`
+    : "";
+
   const { data: job, mutate, error, isValidating } = useSWR<Job>(
-    jobUuid
-      ? `/catch/api-proxy/api/jobs/${jobUuid}${
-          runStatuses ? "?aggregate_run_statuses=true" : ""
-        }`
-      : null,
+    cacheKey || null,
     fetcher
   );
 

--- a/services/orchest-webserver/client/src/hooks/useFetchJob.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchJob.ts
@@ -10,10 +10,12 @@ export const useFetchJob = ({
   jobUuid,
   runStatuses,
   clearCacheOnUnmount,
+  revalidateOnFocus = true,
 }: {
   jobUuid?: string;
   runStatuses?: boolean;
   clearCacheOnUnmount?: boolean;
+  revalidateOnFocus?: boolean;
 }) => {
   const { setAlert } = useAppContext();
 
@@ -25,7 +27,8 @@ export const useFetchJob = ({
 
   const { data: job, mutate, error, isValidating } = useSWR<Job>(
     cacheKey || null,
-    fetcher
+    fetcher,
+    { revalidateOnFocus }
   );
 
   const setJob = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useFetchPipeline.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipeline.ts
@@ -20,10 +20,14 @@ export const fetchPipeline = (
 
 export const useFetchPipeline = (props: FetchPipelineProps | null) => {
   const { projectUuid, pipelineUuid, clearCacheOnUnmount } = props || {};
-  const { data, error, isValidating, mutate } = useSWR<Pipeline | undefined>(
+
+  const cacheKey =
     projectUuid && pipelineUuid
       ? `/async/pipelines/${projectUuid}/${pipelineUuid}`
-      : null,
+      : "";
+
+  const { data, error, isValidating, mutate } = useSWR<Pipeline | undefined>(
+    cacheKey || null,
     () => fetchPipeline(projectUuid, pipelineUuid)
   );
 

--- a/services/orchest-webserver/client/src/hooks/useFetchPipeline.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipeline.ts
@@ -8,6 +8,7 @@ type FetchPipelineProps = {
   projectUuid: string | undefined;
   pipelineUuid: string | undefined;
   clearCacheOnUnmount?: boolean;
+  revalidateOnFocus?: boolean;
 };
 
 export const fetchPipeline = (
@@ -19,7 +20,12 @@ export const fetchPipeline = (
     : undefined;
 
 export const useFetchPipeline = (props: FetchPipelineProps | null) => {
-  const { projectUuid, pipelineUuid, clearCacheOnUnmount } = props || {};
+  const {
+    projectUuid,
+    pipelineUuid,
+    clearCacheOnUnmount,
+    revalidateOnFocus = true,
+  } = props || {};
 
   const cacheKey =
     projectUuid && pipelineUuid
@@ -28,7 +34,8 @@ export const useFetchPipeline = (props: FetchPipelineProps | null) => {
 
   const { data, error, isValidating, mutate } = useSWR<Pipeline | undefined>(
     cacheKey || null,
-    () => fetchPipeline(projectUuid, pipelineUuid)
+    () => fetchPipeline(projectUuid, pipelineUuid),
+    { revalidateOnFocus }
   );
 
   const setPipeline = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
@@ -11,6 +11,7 @@ type FetchPipelineJsonProps = {
   pipelineUuid: string | undefined;
   projectUuid: string | undefined;
   clearCacheOnUnmount?: boolean;
+  revalidateOnFocus?: boolean;
 };
 
 export const fetchPipelineJson = (
@@ -80,8 +81,14 @@ export const useFetchPipelineJson = (
   props: FetchPipelineJsonProps | undefined
 ) => {
   const { cache } = useSWRConfig();
-  const { pipelineUuid, projectUuid, jobUuid, runUuid, clearCacheOnUnmount } =
-    props || {};
+  const {
+    pipelineUuid,
+    projectUuid,
+    jobUuid,
+    runUuid,
+    clearCacheOnUnmount,
+    revalidateOnFocus = true,
+  } = props || {};
 
   const cacheKey = getPipelineJSONEndpoint({
     pipelineUuid,
@@ -92,13 +99,16 @@ export const useFetchPipelineJson = (
 
   const { data, error, isValidating, mutate } = useSWR<
     PipelineJson | undefined
-  >(cacheKey || null, () =>
-    fetchPipelineJson({
-      pipelineUuid,
-      projectUuid,
-      jobUuid,
-      runUuid,
-    })
+  >(
+    cacheKey || null,
+    () =>
+      fetchPipelineJson({
+        pipelineUuid,
+        projectUuid,
+        jobUuid,
+        runUuid,
+      }),
+    { revalidateOnFocus }
   );
 
   const setPipelineJson = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
@@ -56,6 +56,11 @@ export const fetchPipelineJson = (
       pipelineObj.services = {};
     }
 
+    // Previously `order` was managed via localstorage, meaning that `order` could be incorrect.
+    // Currently, `order` has become mandatory, which should be guaranteed by BE.
+    // To prevent user provides a JSON file with services with wrong order value,
+    // we keep the precautions here, and ensure that FE uses and saves the right data.
+
     const sortedServices = Object.entries(pipelineObj.services).sort((a, b) => {
       if (!hasValue(a[1].order) && !hasValue(b[1].order))
         return a[1].name.localeCompare(b[1].name); // If both services have no order value, sort them by name.

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
@@ -56,21 +56,29 @@ export const fetchPipelineJson = (
       pipelineObj.services = {};
     }
 
-    let maxOrder = 0;
     const sortedServices = Object.entries(pipelineObj.services).sort((a, b) => {
       if (!hasValue(a[1].order) && !hasValue(b[1].order))
         return a[1].name.localeCompare(b[1].name); // If both services have no order value, sort them by name.
-      if (!hasValue(a[1].order)) return -1;
+      if (!hasValue(a[1].order)) return -1; // move all undefined item to the tail.
       if (!hasValue(b[1].order)) return 1;
-      maxOrder = Math.max(maxOrder, a[1].order, b[1].order);
       return a[1].order - b[1].order;
     });
-    // Add `order` if it's undefined
+    // Ensure that order value is unique, and assign a valid value to `order` if it's undefined
+    let maxOrder = -1;
     for (let sorted of sortedServices) {
-      if (!hasValue(pipelineObj.services[sorted[0]].order)) {
-        pipelineObj.services[sorted[0]].order = maxOrder + 1;
-        maxOrder += 1;
+      const targetServiceOrder = pipelineObj.services[sorted[0]].order;
+      if (hasValue(targetServiceOrder)) {
+        const orderValue =
+          maxOrder === targetServiceOrder // Order value is duplicated.
+            ? targetServiceOrder + 1
+            : targetServiceOrder;
+        pipelineObj.services[sorted[0]].order = orderValue;
+        maxOrder = orderValue;
+        continue;
       }
+
+      pipelineObj.services[sorted[0]].order = maxOrder + 1;
+      maxOrder += 1;
     }
 
     return pipelineObj;

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineRun.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineRun.ts
@@ -8,6 +8,7 @@ type FetchPipelineRunProps = {
   jobUuid: string | undefined;
   runUuid: string | undefined;
   clearCacheOnUnmount?: boolean;
+  revalidateOnFocus?: boolean;
 };
 
 export const fetchPipelineRun = (
@@ -19,14 +20,16 @@ export const fetchPipelineRun = (
     : undefined;
 
 export const useFetchPipelineRun = (props: FetchPipelineRunProps | null) => {
-  const { jobUuid, runUuid, clearCacheOnUnmount } = props || {};
+  const { jobUuid, runUuid, clearCacheOnUnmount, revalidateOnFocus = true } =
+    props || {};
 
   const cacheKey =
     jobUuid && runUuid ? `/catch/api-proxy/api/jobs/${jobUuid}/${runUuid}` : "";
 
   const { data, error, isValidating, mutate } = useSWR<PipelineRun | undefined>(
     cacheKey || null,
-    () => fetchPipelineRun(jobUuid, runUuid)
+    () => fetchPipelineRun(jobUuid, runUuid),
+    { revalidateOnFocus }
   );
 
   const setPipelineRun = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineRun.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineRun.ts
@@ -20,10 +20,12 @@ export const fetchPipelineRun = (
 
 export const useFetchPipelineRun = (props: FetchPipelineRunProps | null) => {
   const { jobUuid, runUuid, clearCacheOnUnmount } = props || {};
+
+  const cacheKey =
+    jobUuid && runUuid ? `/catch/api-proxy/api/jobs/${jobUuid}/${runUuid}` : "";
+
   const { data, error, isValidating, mutate } = useSWR<PipelineRun | undefined>(
-    jobUuid && runUuid
-      ? `/catch/api-proxy/api/jobs/${jobUuid}/${runUuid}`
-      : null,
+    cacheKey || null,
     () => fetchPipelineRun(jobUuid, runUuid)
   );
 

--- a/services/orchest-webserver/client/src/hooks/useFetchProject.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchProject.ts
@@ -12,11 +12,13 @@ export function useFetchProject<T = Project>({
   projectUuid?: string;
   selector?: (project: Project) => T;
 }) {
+  const cacheKey = projectUuid ? `/async/projects/${projectUuid}` : "";
   const { data, error, isValidating, mutate } = useSWR<T>(
-    projectUuid ? `/async/projects/${projectUuid}` : null,
+    cacheKey || null,
     (url: string) =>
       fetchProject(url, true).then((response) => selector(response))
   );
+
   return {
     data,
     error,

--- a/services/orchest-webserver/client/src/hooks/useFetchProject.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchProject.ts
@@ -8,15 +8,18 @@ export const fetchProject = (projectUuid: string, isFullPath = false) =>
 export function useFetchProject<T = Project>({
   projectUuid,
   selector = (p) => (p as unknown) as T,
+  revalidateOnFocus = true,
 }: {
   projectUuid?: string;
   selector?: (project: Project) => T;
+  revalidateOnFocus?: boolean;
 }) {
   const cacheKey = projectUuid ? `/async/projects/${projectUuid}` : "";
   const { data, error, isValidating, mutate } = useSWR<T>(
     cacheKey || null,
     (url: string) =>
-      fetchProject(url, true).then((response) => selector(response))
+      fetchProject(url, true).then((response) => selector(response)),
+    { revalidateOnFocus }
   );
 
   return {

--- a/services/orchest-webserver/client/src/hooks/useFocusBrowserTab.ts
+++ b/services/orchest-webserver/client/src/hooks/useFocusBrowserTab.ts
@@ -1,0 +1,97 @@
+import React from "react";
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+
+type Hidden = "hidden" | "msHidden" | "mozHidden" | "webkitHidden" | "oHidden";
+type VisibilityState =
+  | "visibilityState"
+  | "msVisibilityState"
+  | "mozVisibilityState"
+  | "webkitVisibilityState"
+  | "oVisibilityState";
+
+type VisibilityChange =
+  | "visibilitychange"
+  | "msvisibilitychange"
+  | "mozVisibilitychange"
+  | "webkitvisibilitychange"
+  | "oVisibilitychange";
+
+const hasWindow = typeof window !== "undefined";
+
+const browserPrefix = ["moz", "ms", "o", "webkit"];
+const getPrefix = () => {
+  if (!hasWindow) return null;
+  if (typeof document.hidden !== "undefined") return null;
+
+  const prefix = browserPrefix.find((prefix) => {
+    const testPrefix = prefix + "Hidden";
+    return testPrefix in document;
+  });
+
+  return prefix || null;
+};
+
+const prefixProperty = <T extends string>(
+  prefix: string | null,
+  property: T
+) => {
+  const capitalized = (str: string) =>
+    str.charAt(0).toUpperCase() + str.slice(1);
+  return prefix ? (`${prefix}${capitalized(property)}` as T) : (property as T);
+};
+
+const prefix = getPrefix();
+const hidden = prefixProperty<Hidden>(prefix, "hidden");
+const visibilityState = prefixProperty<VisibilityState>(
+  prefix,
+  "visibilityState"
+);
+const visibilityChange = prefixProperty<VisibilityChange>(
+  prefix,
+  "visibilitychange"
+);
+
+const generateHandleVisibilityChange = (
+  callback: (value: boolean) => void
+) => () => {
+  if (document[hidden]) {
+    callback(false);
+  } else {
+    callback(true);
+  }
+};
+
+export const useFocusBrowserTab = () => {
+  const handleVisibilityChangeRef = React.useRef<() => void>();
+  const [isFocused, setIsFocused] = React.useState(
+    hasWindow && document[visibilityState] === "visible"
+  );
+  if (!handleVisibilityChangeRef.current) {
+    handleVisibilityChangeRef.current = generateHandleVisibilityChange(
+      setIsFocused
+    );
+  }
+  React.useEffect(() => {
+    if (
+      hasWindow &&
+      document[hidden] !== undefined &&
+      !!handleVisibilityChangeRef.current
+    ) {
+      document.addEventListener(
+        visibilityChange,
+        handleVisibilityChangeRef.current,
+        false
+      );
+    }
+    return () => {
+      if (hasWindow && !!handleVisibilityChangeRef.current) {
+        document.removeEventListener(
+          visibilityChange,
+          handleVisibilityChangeRef.current
+        );
+      }
+    };
+  }, []);
+  return isFocused;
+};

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -436,14 +436,13 @@ const PipelineSettingsView: React.FC = () => {
   );
 
   const prettifyInputParameters = () => {
-    setInputParameters((current) => {
-      try {
-        if (!current) return current;
-        return JSON.stringify(JSON.parse(current));
-      } catch (error) {
-        return current;
-      }
-    });
+    let newValue: string | undefined;
+    try {
+      const parsedValue = JSON.stringify(JSON.parse(inputParameters));
+      newValue = parsedValue !== inputParameters ? parsedValue : undefined;
+    } catch (error) {}
+
+    if (newValue) setInputParameters(newValue);
   };
 
   const inputParametersError = React.useMemo(() => {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -48,7 +48,7 @@ import {
   IconLightBulbOutline,
   Link,
 } from "@orchest/design-system";
-import { fetcher, hasValue, HEADER, uuidv4 } from "@orchest/lib-utils";
+import { fetcher, hasValue, HEADER } from "@orchest/lib-utils";
 import "codemirror/mode/javascript/javascript";
 import React from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
@@ -180,10 +180,11 @@ const PipelineSettingsView: React.FC = () => {
   // If the component has loaded, attach the resize listener
   useOverflowListener(hasLoaded);
 
+  // Service['order'] acts as the serial number of a service
   const onChangeService = React.useCallback(
-    (uuid: string, service: Service) => {
+    (order: string, service: Service) => {
       setServices((current) => {
-        return { ...current, [uuid]: service };
+        return { ...current, [order]: service };
       });
 
       setServicesChanged(true);
@@ -407,23 +408,23 @@ const PipelineSettingsView: React.FC = () => {
       }
     });
 
-    return sortedServices.map(([uuid, service]) => {
+    return sortedServices.map(([order, service]) => {
       return {
-        uuid,
+        uuid: order,
         name: service.name,
         scope: service.scope
           .map((scopeAsString) => scopeMap[scopeAsString])
           .join(", "),
         exposed: service.exposed ? "Yes" : "No",
         authenticationRequired: service.requires_authentication ? "Yes" : "No",
-        remove: uuid,
+        remove: order,
         details: (
           <ServiceForm
-            key={uuid}
+            key={order}
             service={service}
             services={services}
             disabled={isReadOnly}
-            updateService={(updated) => onChangeService(uuid, updated)}
+            updateService={(updated) => onChangeService(order, updated)}
           />
         ),
       };
@@ -658,11 +659,14 @@ const PipelineSettingsView: React.FC = () => {
                   {!isReadOnly && (
                     <ServiceTemplatesDialog
                       onSelection={(template) => {
+                        const newOrder =
+                          parseInt(serviceRows.slice(-1)[0]?.uuid || "0") + 1;
                         const newService = instantiateNewService(
                           allServiceNames,
-                          template
+                          template,
+                          newOrder
                         );
-                        onChangeService(uuidv4(), newService);
+                        onChangeService(newOrder.toString(), newService);
                       }}
                     >
                       {(openServiceTemplatesDialog) => (

--- a/services/orchest-webserver/client/src/pipeline-settings-view/__tests__/useFetchPipelineSettings.test.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/__tests__/useFetchPipelineSettings.test.tsx
@@ -9,35 +9,59 @@ import * as React from "react";
 import { SWRConfig } from "swr";
 import { useFetchPipelineSettings } from "../useFetchPipelineSettings";
 
-describe("useFetchPipelineSettings", () => {
-  const wrapper = ({ children }) => {
-    return (
-      <SWRConfig value={{ revalidateOnMount: true }}>
-        <AppContextProvider>
-          <ProjectsContextProvider>{children}</ProjectsContextProvider>;
-        </AppContextProvider>
-      </SWRConfig>
-    );
-  };
+const wrapper = ({ children = null, shouldStart }) => {
+  return (
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <AppContextProvider shouldStart={shouldStart}>
+        <ProjectsContextProvider>{children}</ProjectsContextProvider>;
+      </AppContextProvider>
+    </SWRConfig>
+  );
+};
 
-  const useTestHook = (props: {
-    projectUuid: string | undefined;
-    pipelineUuid: string | undefined;
-    jobUuid: string | undefined;
-    runUuid: string | undefined;
-  }) => {
-    const {
-      state: { hasUnsavedChanges },
-    } = useAppContext();
-    const values = useFetchPipelineSettings(props);
-    return { ...values, hasUnsavedChanges };
-  };
+const useTestHook = (props: {
+  projectUuid: string | undefined;
+  pipelineUuid: string | undefined;
+  jobUuid: string | undefined;
+  runUuid: string | undefined;
+  isBrowserTabFocused: boolean;
+}) => {
+  const {
+    state: { hasUnsavedChanges },
+  } = useAppContext();
+  const values = useFetchPipelineSettings(props);
+  return { ...values, hasUnsavedChanges };
+};
+
+describe("useFetchPipelineSettings", () => {
+  const { result, waitForNextUpdate, rerender, unmount } = renderHook<
+    {
+      children?: null;
+      shouldStart: boolean;
+      projectUuid: string | undefined;
+      pipelineUuid: string | undefined;
+      jobUuid: string | undefined;
+      runUuid: string | undefined;
+      isBrowserTabFocused: boolean;
+    },
+    ReturnType<typeof useFetchPipelineSettings> & { hasUnsavedChanges: boolean }
+  >(({ children, ...props }) => useTestHook(props), {
+    wrapper,
+    initialProps: {
+      shouldStart: false,
+      projectUuid: undefined,
+      pipelineUuid: undefined,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: false,
+    },
+  });
 
   beforeEach(async () => {
     mockProjects.reset();
   });
 
-  it("should fetch and update pipeline settings for a non-read-only pipeline", async () => {
+  it("should fetch pipeline settings", async () => {
     const mockProjectUuid = chance.guid();
     const mockPipelineUuid = chance.guid();
 
@@ -46,16 +70,14 @@ describe("useFetchPipelineSettings", () => {
       .get(mockProjectUuid)
       .pipelines.get(mockPipelineUuid);
 
-    const { result, waitForNextUpdate } = renderHook(
-      () =>
-        useTestHook({
-          projectUuid: mockProjectUuid,
-          pipelineUuid: mockPipelineUuid,
-          jobUuid: undefined,
-          runUuid: undefined,
-        }),
-      { wrapper }
-    );
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: true,
+    });
 
     await waitForNextUpdate();
 
@@ -80,51 +102,132 @@ describe("useFetchPipelineSettings", () => {
     );
 
     expect(result.current.hasUnsavedChanges).toEqual(false);
+  });
+
+  it(`should refresh pipeline settings if 
+      - the pipeline is not read-only
+      - regaining browser tab focus 
+      - no unsaved changes`, async () => {
+    const mockProjectUuid = chance.guid();
+    const mockPipelineUuid = chance.guid();
+
+    mockProjects.get(mockProjectUuid).project;
+    const pipeline = mockProjects
+      .get(mockProjectUuid)
+      .pipelines.get(mockPipelineUuid);
+
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: true,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.pipelineName).toEqual(pipeline.metadata.name);
+    expect(result.current.pipelinePath).toEqual(pipeline.metadata.path);
+    expect(result.current.hasUnsavedChanges).toEqual(false);
+
+    // Lose browser tab focus.
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: false,
+    });
 
     // Mutate the Mock API data
-
     mockProjects.set(mockProjectUuid, (projectData) => {
-      const targetPipeline = projectData.pipelines.set(
-        mockPipelineUuid,
-        (currentPipeline) => {
-          const newPipelineName = "New Pipeline Name";
-          const newPipelinePath = "new-pipeline-name.orchest";
-          return {
-            ...currentPipeline,
-            metadata: {
-              ...currentPipeline.metadata,
-              name: newPipelineName,
-              path: newPipelinePath,
-            },
-            pipeline: { ...currentPipeline.pipeline, path: newPipelinePath },
-            definition: {
-              ...currentPipeline.definition,
-              name: newPipelineName,
-            },
-          };
-        }
-      );
+      projectData.pipelines.set(mockPipelineUuid, (currentPipeline) => {
+        const newPipelineName = "New Pipeline Name";
+        const newPipelinePath = "new-pipeline-name.orchest";
+        return {
+          ...currentPipeline,
+          metadata: {
+            ...currentPipeline.metadata,
+            name: newPipelineName,
+            path: newPipelinePath,
+          },
+          pipeline: { ...currentPipeline.pipeline, path: newPipelinePath },
+          definition: {
+            ...currentPipeline.definition,
+            name: newPipelineName,
+          },
+        };
+      });
 
       return projectData;
     });
 
     server.resetHandlers();
 
-    // Simulate the scenario that SWR revalidates when browser tab regain focus when there's no unsaved changes.
-    // This happens when user visits Pipeline Settings (value cached) and
-    // then update the setting in other places, e.g. PipelineEditor
-    // new values, instead of the cached values, should be filled in PipelineSettings.
+    expect(result.current.hasUnsavedChanges).toEqual(false);
 
-    act(() => {
-      // SWRConfig.revalidateOnMount not working as expected
-      // manually refetch here.
-      result.current.refetch();
+    // Regain browser tab focus.
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: true,
     });
 
     await waitForNextUpdate();
 
     expect(result.current.pipelineName).toEqual("New Pipeline Name");
     expect(result.current.pipelinePath).toEqual("new-pipeline-name.orchest");
+    expect(result.current.hasUnsavedChanges).toEqual(false);
+  });
+
+  it("should persist unsaved changes when browser tab regain focus.", async () => {
+    const mockProjectUuid = chance.guid();
+    const mockPipelineUuid = chance.guid();
+
+    mockProjects.get(mockProjectUuid).project;
+    mockProjects.get(mockProjectUuid).pipelines.get(mockPipelineUuid);
+
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: true,
+    });
+
+    await waitForNextUpdate();
+
+    // Mutate the Mock API data
+    mockProjects.set(mockProjectUuid, (projectData) => {
+      projectData.pipelines.set(mockPipelineUuid, (currentPipeline) => {
+        const newPipelineName = "New Pipeline Name";
+        const newPipelinePath = "new-pipeline-name.orchest";
+        return {
+          ...currentPipeline,
+          metadata: {
+            ...currentPipeline.metadata,
+            name: newPipelineName,
+            path: newPipelinePath,
+          },
+          pipeline: { ...currentPipeline.pipeline, path: newPipelinePath },
+          definition: {
+            ...currentPipeline.definition,
+            name: newPipelineName,
+          },
+        };
+      });
+
+      return projectData;
+    });
+
+    server.resetHandlers();
+
     expect(result.current.hasUnsavedChanges).toEqual(false);
 
     // Update states manually
@@ -140,13 +243,26 @@ describe("useFetchPipelineSettings", () => {
     );
     expect(result.current.hasUnsavedChanges).toEqual(true);
 
-    // If states are updated and then refetch data, the states should stay.
-
-    act(() => {
-      result.current.refetch();
+    // Lose browser tab focus.
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: false,
     });
 
-    await waitForNextUpdate();
+    // Regain browser tab focus.
+    // The unsaved changes should stay.
+    rerender({
+      shouldStart: true,
+      projectUuid: mockProjectUuid,
+      pipelineUuid: mockPipelineUuid,
+      jobUuid: undefined,
+      runUuid: undefined,
+      isBrowserTabFocused: true,
+    });
 
     expect(result.current.pipelineName).toEqual("Another New Pipeline Name");
     expect(result.current.pipelinePath).toEqual(

--- a/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
@@ -5,8 +5,9 @@ import cloneDeep from "lodash.clonedeep";
 
 export const instantiateNewService = (
   allNames: Set<string>,
-  service: ServiceTemplate["config"]
-) => {
+  service: ServiceTemplate["config"],
+  order: number
+): Service => {
   let clonedService = cloneDeep(service);
 
   let count = 0;
@@ -19,7 +20,7 @@ export const instantiateNewService = (
     }
     count += 1;
   }
-  return clonedService;
+  return { ...clonedService, order };
 };
 
 export function parseJsonString<T = Json>(str: string | undefined) {
@@ -59,7 +60,6 @@ export const generatePipelineJsonForSaving = ({
 }): PipelineJson => {
   const parameters = parseJsonString<Json>(inputParameters);
 
-  // Remove order property from services
   return cleanPipelineJson({
     ...pipelineJson,
     name: pipelineName || "",

--- a/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/common.ts
@@ -3,17 +3,6 @@ import type { Json, PipelineJson, PipelineSettings, Service } from "@/types";
 import { hasValue } from "@orchest/lib-utils";
 import cloneDeep from "lodash.clonedeep";
 
-export const getOrderValue = () => {
-  const lsKey = "_monotonic_getOrderValue";
-  // returns monotinically increasing digit
-  if (!window.localStorage.getItem(lsKey)) {
-    window.localStorage.setItem(lsKey, "0");
-  }
-  let value = parseInt(window.localStorage.getItem(lsKey) || "null") + 1;
-  window.localStorage.setItem(lsKey, value + "");
-  return value;
-};
-
 export const instantiateNewService = (
   allNames: Set<string>,
   service: ServiceTemplate["config"]
@@ -47,7 +36,6 @@ export const cleanPipelineJson = (pipelineJson: PipelineJson): PipelineJson => {
   let pipelineCopy = cloneDeep(pipelineJson);
   for (let uuid in pipelineCopy.services) {
     const serviceName = pipelineCopy.services[uuid].name;
-    delete pipelineCopy.services[uuid].order;
     pipelineCopy.services[serviceName] = {
       ...pipelineCopy.services[uuid],
     };

--- a/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineSettings.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineSettings.ts
@@ -128,7 +128,7 @@ export const useFetchPipelineSettings = ({
     // use temporary uuid for easier FE manipulation, will be cleaned up when saving
     initialValue: pipelineJson?.services
       ? (Object.values(pipelineJson?.services).reduce((all, curr) => {
-          return { ...all, [uuidv4()]: curr };
+          return { ...all, [curr.order]: curr };
         }, {}) as Record<string, Service>)
       : undefined,
     hash,

--- a/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineSettings.ts
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/useFetchPipelineSettings.ts
@@ -18,11 +18,13 @@ export const useFetchPipelineSettings = ({
   pipelineUuid,
   jobUuid,
   runUuid,
+  isBrowserTabFocused,
 }: {
   projectUuid: string | undefined;
   pipelineUuid: string | undefined;
   jobUuid: string | undefined;
   runUuid: string | undefined;
+  isBrowserTabFocused: boolean;
 }) => {
   const {
     state: { hasUnsavedChanges },
@@ -33,8 +35,10 @@ export const useFetchPipelineSettings = ({
    * hooks for fetching data for initialization
    */
 
-  const { job } = useFetchJob({ jobUuid });
-  const { pipelineRun } = useFetchPipelineRun(
+  const { job, fetchJob } = useFetchJob({
+    jobUuid,
+  });
+  const { pipelineRun, fetchPipelineRun } = useFetchPipelineRun(
     jobUuid && runUuid ? { jobUuid, runUuid } : null
   );
 
@@ -62,12 +66,6 @@ export const useFetchPipelineSettings = ({
     selector: (project) => envVariablesDictToArray(project.env_variables),
   });
 
-  const refetch = React.useCallback(() => {
-    fetchPipelineJson();
-    fetchPipeline();
-    fetchProject();
-  }, [fetchPipelineJson, fetchPipeline, fetchProject]);
-
   /**
    * hooks for persisting local mutations without changing the initial data
    */
@@ -80,29 +78,50 @@ export const useFetchPipelineSettings = ({
   // ? Question: why not clear the cache?
   // Beacuse `SWR` cache is not scoped. If we clear cashe here, it might break all the other components using the same fetch hook.
 
-  const [updateHash, setUpdateHash] = React.useState(uuidv4());
+  const [hash, updateHash] = React.useReducer(() => uuidv4(), uuidv4());
+
+  const refetch = React.useCallback(() => {
+    return Promise.allSettled([
+      fetchPipelineJson(),
+      fetchPipeline(),
+      fetchProject(),
+      fetchPipelineRun(),
+      fetchJob(),
+    ]);
+  }, [
+    fetchPipelineJson,
+    fetchPipeline,
+    fetchProject,
+    fetchPipelineRun,
+    fetchJob,
+  ]);
+
+  const reinitialize = React.useCallback(async () => {
+    await refetch();
+    updateHash();
+  }, [refetch, updateHash]);
 
   React.useEffect(() => {
-    // Only update if there is no change.
+    // Only reinitialize if there is no change.
     // Otherwise, user would lose all of their progress when switching browser tabs.
-    if (!hasUnsavedChanges) setUpdateHash(uuidv4());
-  }, [hasUnsavedChanges, job, pipeline, pipelineJson, pipelineRun]);
+    if (isBrowserTabFocused && !hasUnsavedChanges) reinitialize();
+  }, [hasUnsavedChanges, isBrowserTabFocused, reinitialize]);
 
   const [inputParameters = "{}", setInputParameters] = usePipelineProperty({
     initialValue: pipelineJson?.parameters
       ? JSON.stringify(pipelineJson.parameters || {})
       : undefined,
-    updateHash,
+    hash,
   });
 
   const [pipelineName, setPipelineName] = usePipelineProperty({
     initialValue: job?.pipeline_name || pipelineJson?.name,
-    updateHash,
+    hash,
   });
   const [pipelinePath, setPipelinePath] = usePipelineProperty({
     initialValue:
       job?.pipeline_run_spec.run_config.pipeline_path || pipeline?.path,
-    updateHash,
+    hash,
   });
 
   const [services = {}, setServices] = usePipelineProperty({
@@ -112,12 +131,12 @@ export const useFetchPipelineSettings = ({
           return { ...all, [uuidv4()]: curr };
         }, {}) as Record<string, Service>)
       : undefined,
-    updateHash,
+    hash,
   });
 
   const [settings = {}, setSettings] = usePipelineProperty({
     initialValue: pipelineJson?.settings,
-    updateHash,
+    hash,
   });
 
   const { envVariables, setEnvVariables } = usePipelineEnvVariables(
@@ -159,6 +178,5 @@ export const useFetchPipelineSettings = ({
     setPipelineJson,
     inputParameters,
     setInputParameters,
-    refetch,
   };
 };

--- a/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineEnvVariables.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineEnvVariables.tsx
@@ -11,7 +11,9 @@ export const usePipelineEnvVariables = (
   const { setAsSaved } = useAppContext();
 
   // Environment variables are fetched either from 1) pipeline 2) pipeline run
-  const [envVariables, _setEnvVariables] = React.useState<EnvVarPair[]>([]);
+  const [envVariables, _setEnvVariables] = React.useState<
+    EnvVarPair[] | undefined
+  >([]);
 
   const fetchedEnvVariables = React.useMemo(() => {
     if (pipeline || pipelineRun) {
@@ -32,7 +34,7 @@ export const usePipelineEnvVariables = (
   }, [fetchedEnvVariables]);
 
   const setEnvVariables = React.useCallback(
-    (data: React.SetStateAction<EnvVarPair[]>) => {
+    (data: React.SetStateAction<EnvVarPair[] | undefined>) => {
       _setEnvVariables(data);
       setAsSaved(false);
     },

--- a/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineProperty.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/usePipelineProperty.tsx
@@ -6,10 +6,10 @@ import React from "react";
  */
 export function usePipelineProperty<T>({
   initialValue,
-  updateHash,
+  hash,
 }: {
   initialValue: T | undefined;
-  updateHash: string;
+  hash: string;
 }) {
   const { setAsSaved } = useAppContext();
 
@@ -21,11 +21,11 @@ export function usePipelineProperty<T>({
 
   // Only re-initialize the value if hash is changed
   React.useEffect(() => {
-    if (initialValue && localHash.current !== updateHash) {
-      localHash.current = updateHash;
+    if (initialValue && localHash.current !== hash) {
+      localHash.current = hash;
       _setPipelineProperty(initialValue);
     }
-  }, [initialValue, updateHash, _setPipelineProperty]);
+  }, [initialValue, hash, _setPipelineProperty]);
 
   const setPipelineProperty = React.useCallback(
     (value: React.SetStateAction<T | undefined>) => {

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
@@ -34,8 +34,8 @@ export type FileManagerContextType = {
   fileTreeDepth: React.MutableRefObject<number>;
 };
 
-export const FileManagerContext = React.createContext<FileManagerContextType | null>(
-  null
+export const FileManagerContext = React.createContext<FileManagerContextType>(
+  {} as FileManagerContextType
 );
 
 export const useFileManagerContext = () => React.useContext(FileManagerContext);

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
@@ -21,10 +21,10 @@ export type FilePathChange = {
 export type FileManagerContextType = {
   selectedFiles: string[];
   setSelectedFiles: React.Dispatch<React.SetStateAction<string[]>>;
-  dragFile: DragFile;
+  dragFile: DragFile | undefined;
   setDragFile: React.Dispatch<React.SetStateAction<DragFile | undefined>>;
-  hoveredPath: string;
-  setHoveredPath: React.Dispatch<React.SetStateAction<string>>;
+  hoveredPath: string | undefined;
+  setHoveredPath: React.Dispatch<React.SetStateAction<string | undefined>>;
   isDragging: boolean;
   setIsDragging: React.Dispatch<React.SetStateAction<boolean>>;
   resetMove: () => void;
@@ -34,7 +34,7 @@ export type FileManagerContextType = {
   fileTreeDepth: React.MutableRefObject<number>;
 };
 
-export const FileManagerContext = React.createContext<FileManagerContextType>(
+export const FileManagerContext = React.createContext<FileManagerContextType | null>(
   null
 );
 
@@ -60,10 +60,8 @@ export const FileManagerContextProvider: React.FC = ({ children }) => {
   const [dragFile, setDragFile] = React.useState<{
     labelText: string;
     path: string;
-  }>(undefined);
-  const [hoveredPath, setHoveredPath] = React.useState<string | undefined>(
-    undefined
-  );
+  }>();
+  const [hoveredPath, setHoveredPath] = React.useState<string>();
   const [isDragging, setIsDragging] = React.useState(false);
 
   const [fileTrees, setFileTrees] = React.useState<FileTrees>({});
@@ -80,6 +78,7 @@ export const FileManagerContextProvider: React.FC = ({ children }) => {
 
   const fetchFileTrees = React.useCallback(
     async (depth?: number) => {
+      if (!projectUuid) return;
       if (depth) {
         fileTreeDepth.current = Math.max(fileTreeDepth.current, depth);
       }

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -329,7 +329,7 @@ export type Service = {
   env_variables_inherit?: any[];
   exposed: boolean;
   requires_authentication?: boolean;
-  order?: number;
+  order: number;
 };
 
 export type FileTree = {

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -483,7 +483,7 @@ export function tryUntilTrue(action, retries, delay, interval?) {
 
 // Will return undefined if the envVariables are ill defined.
 export function envVariablesArrayToDict(
-  envVariables: EnvVarPair[]
+  envVariables: EnvVarPair[] = []
 ):
   | { status: "resolved"; value: Record<string, unknown> }
   | { status: "rejected"; error: string } {


### PR DESCRIPTION
## Description

Currently services use user-defined `name` as the key for BE, and with this design, FE generates a FE-only property: `order` to ensure the consistency of the UI. This PR (re-)uses this property as the serial number of service.

This PR also fixes an unable-to-save issue in Pipeline Settings, and added more test cases.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
