### PR TITLE
Add  interactive pipeline run events to `orchest-api` (notifications)

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -34,11 +34,21 @@ class Event(Enum):
     ENVIRONMENT_BUILD_STARTED = "environment-build:started"
     HEARTBEAT_TRIGGER = "heartbeat-trigger"
     JOB_DUPLICATED = "job:duplicated"
-    JOB_UPDATED = "job:updated"
     PIPELINE_SAVED = "pipeline:saved"
 
     # Sent by the orchest-api.
     DEBUG_PING = "debug-ping"
+
+    PROJECT_CREATED = "project:created"
+    PROJECT_UPDATED = "project:updated"
+    PROJECT_DELETED = "project:deleted"
+
+    ENVIRONMENT_CREATED = "project:environment:created"
+    ENVIRONMENT_DELETED = "project:environment:deleted"
+
+    PIPELINE_CREATED = "project:pipeline:created"
+    PIPELINE_UPDATED = "project:pipeline:updated"
+    PIPELINE_DELETED = "project:pipeline:deleted"
 
     JUPYTER_IMAGE_BUILD_CREATED = "jupyter:image-build:created"
     JUPYTER_IMAGE_BUILD_STARTED = "jupyter:image-build:started"
@@ -65,6 +75,7 @@ class Event(Enum):
     ONE_OFF_JOB_DELETED = "project:one-off-job:deleted"
     ONE_OFF_JOB_CANCELLED = "project:one-off-job:cancelled"
     ONE_OFF_JOB_FAILED = "project:one-off-job:failed"
+    ONE_OFF_JOB_UPDATED = "project:one-off-job:updated"
     ONE_OFF_JOB_SUCCEEDED = "project:one-off-job:succeeded"
 
     ONE_OFF_JOB_PIPELINE_RUN_CREATED = "project:one-off-job:pipeline-run:created"
@@ -79,6 +90,7 @@ class Event(Enum):
     CRON_JOB_DELETED = "project:cron-job:deleted"
     CRON_JOB_CANCELLED = "project:cron-job:cancelled"
     CRON_JOB_FAILED = "project:cron-job:failed"
+    CRON_JOB_UPDATED = "project:cron-job:updated"
     CRON_JOB_PAUSED = "project:cron-job:paused"
     CRON_JOB_UNPAUSED = "project:cron-job:unpaused"
 
@@ -265,6 +277,31 @@ class _Anonymizer:
     """
 
     @staticmethod
+    def project_event(event_properties: dict) -> dict:
+        derived_properties = {}
+        derived_properties["project"] = _anonymize_project_properties(
+            event_properties["project"]
+        )
+        return derived_properties
+
+    @staticmethod
+    def environment_event(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.project_event(event_properties)
+        derived_properties["project"]["environment"] = {}
+        return derived_properties
+
+    @staticmethod
+    def pipeline_event(event_properties: dict) -> dict:
+        derived_properties = {}
+        derived_properties["project"] = _anonymize_project_properties(
+            event_properties["project"]
+        )
+        derived_properties["project"]["pipeline"] = _anonymize_pipeline_properties(
+            event_properties["project"]["pipeline"]
+        )
+        return derived_properties
+
+    @staticmethod
     def _deprecated_job_created(event_properties: dict) -> dict:
         """To not introduce breaking changes in the analytics schema."""
 
@@ -280,50 +317,27 @@ class _Anonymizer:
         derived_properties = {"job_definition": {}}
         derived_properties["job_definition"] = {
             "parameterized_runs_count": len(job_def.pop("parameters", [])),
+            "env_variables_count": len(job_def.pop("env_variables", {})),
         }
         return derived_properties
 
     @staticmethod
-    def project_one_off_job_created(event_properties: dict) -> dict:
-        derived_properties = {}
-        derived_properties["project"] = _anonymize_project_properties(
-            event_properties["project"]
-        )
-        derived_job_properties = _anonymize_one_off_job_properties(
-            event_properties["job"]
-        )
-        derived_properties["job"] = derived_job_properties
+    def project_one_off_job_created_updated(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.project_one_off_job(event_properties)
         deprecated_derived = _Anonymizer._deprecated_job_created(event_properties)
         derived_properties = {**deprecated_derived, **derived_properties}
         return derived_properties
 
     @staticmethod
-    def project_cron_job_created(event_properties: dict) -> dict:
-        derived_properties = {}
-        derived_properties["project"] = _anonymize_project_properties(
-            event_properties["project"]
-        )
-        derived_job_properties = _anonymize_cron_job_properties(event_properties["job"])
-        derived_properties["job"] = derived_job_properties
+    def project_cron_job_created_updated(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.project_cron_job(event_properties)
         deprecated_derived = _Anonymizer._deprecated_job_created(event_properties)
         derived_properties = {**deprecated_derived, **derived_properties}
-        return derived_job_properties
+        return derived_properties
 
     @staticmethod
     def job_duplicated(event_properties: dict) -> dict:
         return _Anonymizer._deprecated_job_created(event_properties)
-
-    @staticmethod
-    def job_updated(event_properties: dict) -> dict:
-        job_def = event_properties["job_definition"]
-        job_def.pop("strategy_json", None)
-
-        derived_properties = {"job_definition": {}}
-        derived_properties["job_definition"] = {
-            "env_variables_count": len(job_def.pop("env_variables", {})),
-            "parameterized_runs_count": len(job_def.pop("parameters", [])),
-        }
-        return derived_properties
 
     @staticmethod
     def session_started(event_properties: dict) -> dict:
@@ -409,10 +423,15 @@ class _Anonymizer:
 
 
 _ANONYMIZATION_MAPPINGS = {
-    Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created,
-    Event.CRON_JOB_CREATED: _Anonymizer.project_cron_job_created,
+    Event.PROJECT_CREATED: _Anonymizer.project_event,
+    Event.PROJECT_UPDATED: _Anonymizer.project_event,
+    Event.PROJECT_DELETED: _Anonymizer.project_event,
+    Event.ENVIRONMENT_CREATED: _Anonymizer.environment_event,
+    Event.ENVIRONMENT_DELETED: _Anonymizer.environment_event,
+    Event.PIPELINE_CREATED: _Anonymizer.pipeline_event,
+    Event.PIPELINE_UPDATED: _Anonymizer.pipeline_event,
+    Event.PIPELINE_DELETED: _Anonymizer.pipeline_event,
     Event.JOB_DUPLICATED: _Anonymizer.job_duplicated,
-    Event.JOB_UPDATED: _Anonymizer.job_updated,
     Event.SESSION_STARTED: _Anonymizer.session_started,
     Event.INTERACTIVE_PIPELINE_RUN_CREATED: _Anonymizer.interactive_pipeline_run,
     Event.INTERACTIVE_PIPELINE_RUN_STARTED: _Anonymizer.interactive_pipeline_run,
@@ -421,7 +440,8 @@ _ANONYMIZATION_MAPPINGS = {
     Event.INTERACTIVE_PIPELINE_RUN_SUCCEEDED: _Anonymizer.interactive_pipeline_run,
     Event.PIPELINE_SAVED: _Anonymizer.pipeline_saved,
     Event.ENVIRONMENT_BUILD_STARTED: _Anonymizer.environment_build_started,
-    Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created,
+    Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created_updated,
+    Event.ONE_OFF_JOB_UPDATED: _Anonymizer.project_one_off_job_created_updated,
     Event.ONE_OFF_JOB_STARTED: _Anonymizer.project_one_off_job,
     Event.ONE_OFF_JOB_DELETED: _Anonymizer.project_one_off_job,
     Event.ONE_OFF_JOB_CANCELLED: _Anonymizer.project_one_off_job,
@@ -433,7 +453,8 @@ _ANONYMIZATION_MAPPINGS = {
     Event.ONE_OFF_JOB_PIPELINE_RUN_FAILED: _Anonymizer.project_one_off_job,
     Event.ONE_OFF_JOB_PIPELINE_RUN_DELETED: _Anonymizer.project_one_off_job,
     Event.ONE_OFF_JOB_PIPELINE_RUN_SUCCEEDED: _Anonymizer.project_one_off_job,
-    Event.CRON_JOB_CREATED: _Anonymizer.project_cron_job_created,
+    Event.CRON_JOB_CREATED: _Anonymizer.project_cron_job_created_updated,
+    Event.CRON_JOB_UPDATED: _Anonymizer.project_cron_job_created_updated,
     Event.CRON_JOB_STARTED: _Anonymizer.project_cron_job,
     Event.CRON_JOB_DELETED: _Anonymizer.project_cron_job,
     Event.CRON_JOB_CANCELLED: _Anonymizer.project_cron_job,
@@ -454,6 +475,11 @@ _ANONYMIZATION_MAPPINGS = {
 
 def _anonymize_project_properties(project: dict) -> dict:
     project.pop("name", None)
+    return {}
+
+
+def _anonymize_pipeline_properties(pipeline: dict) -> dict:
+    pipeline.pop("name", None)
     return {}
 
 

--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -327,17 +327,21 @@ class _Anonymizer:
 
     @staticmethod
     def session_started(event_properties: dict) -> dict:
-        derived_properties = {"user_services": {}}
+        derived_user_services = {}
         user_services = event_properties["project"]["session"]["user_services"]
         for service_name, service_def in user_services.items():
-            derived_properties["user_services"][
-                service_name
-            ] = _anonymize_service_definition(service_def)
+            derived_user_services[service_name] = _anonymize_service_definition(
+                service_def
+            )
 
         event_properties["project"]["session"].pop("user_services")
 
+        derived_properties = {}
+        derived_properties["project"] = {
+            "session": {"user_services": derived_user_services}
+        }
         # To not break the analytics schema, deprecated.
-        derived_properties["services"] = derived_properties["user_services"]
+        derived_properties["services"] = derived_user_services
 
         return derived_properties
 

--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -487,17 +487,12 @@ def _anonymize_pipeline_run_properties(pipeline_run: dict) -> dict:
     derived_properties["parameters"] = derived_params
     for k, v in pipeline_run.pop("parameters", {}).items():
         if k == "pipeline_parameters":
-            derived_params[f"{k}_count"] = len(v)
+            derived_params[f"{k}_count"] = len(v["parameters"])
         else:
-            step_uuid = k[-36:]
-            derived_params[f"step_{step_uuid}_parameters_count"] = len(v)
+            derived_params[f"{k}_parameters_count"] = len(v["parameters"])
 
-    if "steps" in pipeline_run:
-        pipeline_run["steps"] = [
-            # Only keep the uuid.
-            step[-36:]
-            for step in pipeline_run["steps"]
-        ]
+    for step in pipeline_run.get("steps", []):
+        step.pop("title", None)
 
     if "pipeline_definition" in pipeline_run:
         pipeline_run["pipeline_definition"] = _anonymize_pipeline_definition(

--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -35,8 +35,6 @@ class Event(Enum):
     HEARTBEAT_TRIGGER = "heartbeat-trigger"
     JOB_DUPLICATED = "job:duplicated"
     JOB_UPDATED = "job:updated"
-    PIPELINE_RUN_CANCELLED = "pipeline-run:cancelled"
-    PIPELINE_RUN_STARTED = "pipeline-run:started"
     PIPELINE_SAVED = "pipeline:saved"
 
     # Sent by the orchest-api.
@@ -47,6 +45,20 @@ class Event(Enum):
     JUPYTER_IMAGE_BUILD_CANCELLED = "jupyter:image-build:cancelled"
     JUPYTER_IMAGE_BUILD_FAILED = "jupyter:image-build:failed"
     JUPYTER_IMAGE_BUILD_SUCCEEDED = "jupyter:image-build:succeeded"
+
+    INTERACTIVE_PIPELINE_RUN_CREATED = (
+        "project:pipeline:interactive-pipeline-run:created"
+    )
+    INTERACTIVE_PIPELINE_RUN_STARTED = (
+        "project:pipeline:interactive-pipeline-run:started"
+    )
+    INTERACTIVE_PIPELINE_RUN_CANCELLED = (
+        "project:pipeline:interactive-pipeline-run:cancelled"
+    )
+    INTERACTIVE_PIPELINE_RUN_FAILED = "project:pipeline:interactive-pipeline-run:failed"
+    INTERACTIVE_PIPELINE_RUN_SUCCEEDED = (
+        "project:pipeline:interactive-pipeline-run:succeeded"
+    )
 
     ONE_OFF_JOB_CREATED = "project:one-off-job:created"
     ONE_OFF_JOB_STARTED = "project:one-off-job:started"
@@ -330,7 +342,7 @@ class _Anonymizer:
         return derived_properties
 
     @staticmethod
-    def pipeline_run_started(event_properties: dict) -> dict:
+    def interactive_pipeline_run_created(event_properties: dict) -> dict:
         pdef = event_properties["pipeline_definition"]
         derived_properties = {
             "pipeline_definition": _anonymize_pipeline_definition(pdef),
@@ -384,7 +396,7 @@ _ANONYMIZATION_MAPPINGS = {
     Event.JOB_DUPLICATED: _Anonymizer.job_duplicated,
     Event.JOB_UPDATED: _Anonymizer.job_updated,
     Event.SESSION_STARTED: _Anonymizer.session_started,
-    Event.PIPELINE_RUN_STARTED: _Anonymizer.pipeline_run_started,
+    Event.INTERACTIVE_PIPELINE_RUN_CREATED: _Anonymizer.interactive_pipeline_run_created,  # noqa
     Event.PIPELINE_SAVED: _Anonymizer.pipeline_saved,
     Event.ENVIRONMENT_BUILD_STARTED: _Anonymizer.environment_build_started,
     Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created,

--- a/scripts/migration_manager.sh
+++ b/scripts/migration_manager.sh
@@ -46,7 +46,7 @@ else
 fi
 
 # Get the pod to which command & cp will be issued.
-pod_name=$(kubectl get pods -n orchest -l app.kubernetes.io/name=${SERVICE} \
+pod_name=$(kubectl get pods -n orchest -l ${SERVICE}=${SERVICE} \
     --field-selector=status.phase=Running --no-headers \
     --output=jsonpath={.items..metadata.name})
 

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -253,6 +253,7 @@ class CreateInteractiveRun(TwoPhaseFunction):
             "pipeline_uuid": pipeline.properties["uuid"],
             "project_uuid": project_uuid,
             "status": "PENDING",
+            "pipeline_definition": pipeline.to_dict(),
         }
         db.session.add(models.InteractivePipelineRun(**run))
         # need to flush because otherwise the bulk insertion of pipeline

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -16,7 +16,7 @@ from app import errors as self_errors
 from app import schema
 from app.celery_app import make_celery
 from app.connections import db
-from app.core import environments
+from app.core import environments, events
 from app.core.pipelines import Pipeline, construct_pipeline
 from app.utils import get_proj_pip_env_variables, register_schema, update_status_db
 
@@ -90,11 +90,28 @@ class Run(Resource):
         filter_by = {"uuid": run_uuid}
         status_update = request.get_json()
         try:
-            update_status_db(
+            has_updated = update_status_db(
                 status_update, model=models.PipelineRun, filter_by=filter_by
             )
+            if has_updated:
+                run = models.InteractivePipelineRun.query.filter(
+                    models.InteractivePipelineRun.uuid == run_uuid
+                ).one()
+                if status_update["status"] == "STARTED":
+                    events.register_interactive_pipeline_run_started(
+                        run.project_uuid, run.pipeline_uuid, run_uuid
+                    )
+                elif status_update["status"] == "FAILURE":
+                    events.register_interactive_pipeline_run_failed(
+                        run.project_uuid, run.pipeline_uuid, run_uuid
+                    )
+                elif status_update["status"] == "SUCCESS":
+                    events.register_interactive_pipeline_run_succeeded(
+                        run.project_uuid, run.pipeline_uuid, run_uuid
+                    )
             db.session.commit()
-        except Exception:
+        except Exception as e:
+            current_app.logger.error(e)
             db.session.rollback()
             return {"message": "Failed update operation."}, 500
 
@@ -190,6 +207,13 @@ class AbortPipelineRun(TwoPhaseFunction):
                 status_update, model=models.PipelineRunStep, filter_by=filter_by
             )
 
+        run = models.InteractivePipelineRun.query.filter(
+            models.InteractivePipelineRun.uuid == run_uuid
+        ).one()
+        events.register_interactive_pipeline_run_cancelled(
+            run.project_uuid, run.pipeline_uuid, run_uuid
+        )
+
         self.collateral_kwargs["run_uuid"] = run_uuid if can_abort else None
 
         return can_abort
@@ -264,6 +288,10 @@ class CreateInteractiveRun(TwoPhaseFunction):
             msg = "Please make sure every pipeline step is assigned an environment."
             raise self_errors.PipelineDefinitionNotValid(msg)
 
+        events.register_interactive_pipeline_run_created(
+            project_uuid, pipeline.properties["uuid"], task_id
+        )
+
         self.collateral_kwargs["project_uuid"] = project_uuid
         self.collateral_kwargs["task_id"] = task_id
         self.collateral_kwargs["pipeline"] = pipeline
@@ -323,4 +351,9 @@ class CreateInteractiveRun(TwoPhaseFunction):
         models.PipelineRunStep.query.filter_by(
             run_uuid=self.collateral_kwargs["task_id"]
         ).update({"status": "FAILURE"})
+        events.register_interactive_pipeline_run_failed(
+            self.collateral_kwargs["project_uuid"],
+            self.collateral_kwargs["pipeline"].properties["uuid"],
+            self.collateral_kwargs["task_id"],
+        )
         db.session.commit()

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -457,3 +457,70 @@ def _register_interactive_session_service_succeeded(
     _register_interactive_session_event(
         "project:interactive-session:succeeded", project_uuid, pipeline_uuid
     )
+
+
+def _register_interactive_pipeline_run_event(
+    type: str, project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    ev = models.InteractivePipelineRunEvent(
+        type=type,
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )
+    _register_event(ev)
+
+
+def register_interactive_pipeline_run_created(
+    project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    _register_interactive_pipeline_run_event(
+        "project:pipeline:interactive-pipeline-run:created",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )
+
+
+def register_interactive_pipeline_run_started(
+    project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    _register_interactive_pipeline_run_event(
+        "project:pipeline:interactive-pipeline-run:started",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )
+
+
+def register_interactive_pipeline_run_cancelled(
+    project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    _register_interactive_pipeline_run_event(
+        "project:pipeline:interactive-pipeline-run:cancelled",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )
+
+
+def register_interactive_pipeline_run_failed(
+    project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    _register_interactive_pipeline_run_event(
+        "project:pipeline:interactive-pipeline-run:failed",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )
+
+
+def register_interactive_pipeline_run_succeeded(
+    project_uuid: str, pipeline_uuid: str, pipeline_run_uuid: str
+) -> None:
+    _register_interactive_pipeline_run_event(
+        "project:pipeline:interactive-pipeline-run:succeeded",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        pipeline_run_uuid=pipeline_run_uuid,
+    )

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -5,6 +5,7 @@ accordingly based on any subscribers subscribed to the event type that
 happened.
 """
 from app import models
+from app import types as app_types
 from app import utils
 from app import utils as app_utils
 from app.connections import db
@@ -20,7 +21,6 @@ def _register_event(ev: models.Event) -> None:
     db.session.flush()
 
     db.session.add(ev)
-    _logger.info(ev)
 
     project_uuid = None
     job_uuid = None
@@ -32,6 +32,7 @@ def _register_event(ev: models.Event) -> None:
 
     # So that the event.uuid is generated and visible as a FK.
     db.session.flush()
+    _logger.info(ev)
 
     subscribers = notifications.get_subscribers_subscribed_to_event(
         ev.type, project_uuid=project_uuid, job_uuid=job_uuid
@@ -129,6 +130,39 @@ def register_job_failed(project_uuid: str, job_uuid: str) -> None:
         _register_one_off_job_event(
             "project:one-off-job:failed", project_uuid, job_uuid
         )
+
+
+def register_job_updated(
+    was_cron_job: bool, project_uuid: str, job_uuid: str, update: app_types.EntityUpdate
+) -> None:
+    """Adds a job update event to the db, does not commit.
+
+    Args:
+        was_cron_job: Necessary because an update might make a non
+            cron-job into a cron-job, and we are interested in the
+            status of the job pre-change. I.e. adding a schedule and
+            thus making a one off job into a cronjob should lead to a
+            OneOffJobUpdateEvent, not a CronJobUpdateEvent.
+        project_uuid:
+        job_uuid:
+        update:
+    """
+    if was_cron_job:
+        ev = models.CronJobUpdateEvent(
+            type="project:cron-job:updated",
+            project_uuid=project_uuid,
+            job_uuid=job_uuid,
+            update=update,
+        )
+        _register_event(ev)
+    else:
+        ev = models.OneOffJobUpdateEvent(
+            type="project:one-off-job:updated",
+            project_uuid=project_uuid,
+            job_uuid=job_uuid,
+            update=update,
+        )
+        _register_event(ev)
 
 
 def register_job_succeeded(project_uuid: str, job_uuid: str) -> None:
@@ -524,3 +558,76 @@ def register_interactive_pipeline_run_succeeded(
         pipeline_uuid=pipeline_uuid,
         pipeline_run_uuid=pipeline_run_uuid,
     )
+
+
+def _register_project_event(type: str, project_uuid: str) -> None:
+    ev = models.ProjectEvent(
+        type=type,
+        project_uuid=project_uuid,
+    )
+    _register_event(ev)
+
+
+def register_project_created_event(project_uuid: str):
+    _register_project_event("project:created", project_uuid)
+
+
+def register_project_deleted_event(project_uuid: str):
+    _register_project_event("project:deleted", project_uuid)
+
+
+def _register_environment_event(
+    type: str, project_uuid: str, environment_uuid: str
+) -> None:
+    ev = models.EnvironmentEvent(
+        type=type, project_uuid=project_uuid, environment_uuid=environment_uuid
+    )
+    _register_event(ev)
+
+
+def register_environment_created_event(project_uuid: str, environment_uuid: str):
+    _register_environment_event(
+        "project:environment:created", project_uuid, environment_uuid
+    )
+
+
+def register_environment_deleted_event(project_uuid: str, environment_uuid: str):
+    _register_environment_event(
+        "project:environment:deleted", project_uuid, environment_uuid
+    )
+
+
+def register_project_updated_event(project_uuid: str, update: app_types.EntityUpdate):
+    ev = models.ProjectUpdateEvent(
+        type="project:updated", project_uuid=project_uuid, update=update
+    )
+    _register_event(ev)
+
+
+def _register_pipeline_event(type: str, project_uuid: str, pipeline_uuid: str) -> None:
+    ev = models.PipelineEvent(
+        type=type,
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+    )
+    _register_event(ev)
+
+
+def register_pipeline_created_event(project_uuid: str, pipeline_uuid: str):
+    _register_pipeline_event("project:pipeline:created", project_uuid, pipeline_uuid)
+
+
+def register_pipeline_deleted_event(project_uuid: str, pipeline_uuid: str):
+    _register_pipeline_event("project:pipeline:deleted", project_uuid, pipeline_uuid)
+
+
+def register_pipeline_updated_event(
+    project_uuid: str, pipeline_uuid: str, update: app_types.EntityUpdate
+):
+    ev = models.PipelineUpdateEvent(
+        type="project:pipeline:updated",
+        project_uuid=project_uuid,
+        pipeline_uuid=pipeline_uuid,
+        update=update,
+    )
+    _register_event(ev)

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1077,6 +1077,7 @@ class EventType(BaseModel):
     - services/orchest-api/app/migrations/versions/92dcc9963a9c_.py
     - services/orchest-api/app/migrations/versions/ad0b4cda3e50_.py
     - services/orchest-api/app/migrations/versions/849b7b154ef6_.py
+    - services/orchest-api/app/migrations/versions/637920f5715f_.py
 
     To add more types, add an empty revision with
     `bash scripts/migration_manager.sh orchest-api revision`, then
@@ -1086,7 +1087,7 @@ class EventType(BaseModel):
 
     __tablename__ = "event_types"
 
-    name = db.Column(db.String(50), primary_key=True)
+    name = db.Column(db.String(100), primary_key=True)
 
     def __repr__(self):
         return f"<EventType: {self.name}>"
@@ -1108,7 +1109,9 @@ class Event(BaseModel):
     )
 
     type = db.Column(
-        db.String(50), db.ForeignKey("event_types.name", ondelete="CASCADE"), index=True
+        db.String(100),
+        db.ForeignKey("event_types.name", ondelete="CASCADE"),
+        index=True,
     )
 
     timestamp = db.Column(
@@ -1675,7 +1678,7 @@ class Subscription(BaseModel):
     )
 
     event_type = db.Column(
-        db.String(50),
+        db.String(100),
         db.ForeignKey("event_types.name", ondelete="CASCADE"),
         nullable=False,
     )

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -867,6 +867,13 @@ class InteractivePipelineRun(PipelineRun):
         cascade="all, delete",
     )
 
+    pipeline_definition = db.Column(
+        JSONB,
+        nullable=False,
+        # To migrate old entries.
+        server_default="{}",
+    )
+
 
 class ClientHeartbeat(BaseModel):
     """Clients heartbeat for idle checking."""

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -57,6 +57,7 @@ project = Model(
 project_update = Model(
     "ProjectUpdate",
     {
+        "name": fields.String(required=False, description="Name of the project"),
         "env_variables": fields.Raw(
             required=False, description="Environment variables of the project"
         ),

--- a/services/orchest-api/app/app/types.py
+++ b/services/orchest-api/app/app/types.py
@@ -90,3 +90,27 @@ class InteractiveSessionConfig(SessionConfig):
 class NonInteractiveSessionConfig(SessionConfig):
     # Env variables defined for the job.
     user_env_variables: Dict[str, str]
+
+
+# Used for some event payloads. The "str" mixing makes it json
+# serializable.
+class ChangeType(str, Enum):
+    CREATED = "CREATED"
+    UPDATED = "UPDATED"
+    DELETED = "DELETED"
+
+
+class Change(TypedDict):
+    type: ChangeType
+    # What has changed, i.e. an env var, a given job property, etc.
+    changed_object: str
+    # Set them to None or don't include them at all if not applicable or
+    # if you don't want to expose their value. Values should not contain
+    # any sensitive data, they will be exposed to both notifications and
+    # analytics.
+    old_value: Optional[str]
+    new_value: Optional[str]
+
+
+class EntityUpdate(TypedDict):
+    changes: List[Change]

--- a/services/orchest-api/app/migrations/versions/19ce7297c194_.py
+++ b/services/orchest-api/app/migrations/versions/19ce7297c194_.py
@@ -1,0 +1,46 @@
+"""Add EnvironmentEvent model and related event_types
+
+Revision ID: 19ce7297c194
+Revises: a4b1f48ddab5
+Create Date: 2022-05-18 08:24:35.071687
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "19ce7297c194"
+down_revision = "a4b1f48ddab5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:environment:created'),
+        ('project:environment:deleted')
+        ;
+        """
+    )
+    op.add_column(
+        "events", sa.Column("environment_uuid", sa.String(length=36), nullable=True)
+    )
+    op.create_foreign_key(
+        op.f("fk_events_project_uuid_environment_uuid_environments"),
+        "events",
+        "environments",
+        ["project_uuid", "environment_uuid"],
+        ["project_uuid", "uuid"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_events_project_uuid_environment_uuid_environments"),
+        "events",
+        type_="foreignkey",
+    )
+    op.drop_column("events", "environment_uuid")

--- a/services/orchest-api/app/migrations/versions/23def7128481_.py
+++ b/services/orchest-api/app/migrations/versions/23def7128481_.py
@@ -1,0 +1,32 @@
+"""Add InteractivePipelineRun.pipeline_definition field
+
+Revision ID: 23def7128481
+Revises: 637920f5715f
+Create Date: 2022-05-16 11:40:02.148006
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "23def7128481"
+down_revision = "637920f5715f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pipeline_runs",
+        sa.Column(
+            "pipeline_definition",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="{}",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("pipeline_runs", "pipeline_definition")

--- a/services/orchest-api/app/migrations/versions/268b3e08cb46_.py
+++ b/services/orchest-api/app/migrations/versions/268b3e08cb46_.py
@@ -1,0 +1,34 @@
+"""empty message
+
+Revision ID: 268b3e08cb46
+Revises: 2b573339900f
+Create Date: 2022-05-17 10:46:41.928452
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "268b3e08cb46"
+down_revision = "2b573339900f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint(
+        "fk_events_project_uuid_pipeline_uuid_interactive_sessions",
+        "events",
+        type_="foreignkey",
+    )
+
+
+def downgrade():
+    op.create_foreign_key(
+        "fk_events_project_uuid_pipeline_uuid_interactive_sessions",
+        "events",
+        "interactive_sessions",
+        ["project_uuid", "pipeline_uuid"],
+        ["project_uuid", "pipeline_uuid"],
+        ondelete="CASCADE",
+    )

--- a/services/orchest-api/app/migrations/versions/2b573339900f_.py
+++ b/services/orchest-api/app/migrations/versions/2b573339900f_.py
@@ -1,0 +1,39 @@
+"""Add ProjectUpdateEvent, PipelineUpdateEvent models, event_types
+
+Revision ID: 2b573339900f
+Revises: 23def7128481
+Create Date: 2022-05-17 08:59:51.787022
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2b573339900f"
+down_revision = "23def7128481"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:created'),
+        ('project:updated'),
+        ('project:deleted'),
+        ('project:pipeline:created'),
+        ('project:pipeline:updated'),
+        ('project:pipeline:deleted')
+        ;
+        """
+    )
+    op.add_column(
+        "events",
+        sa.Column("update", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("events", "update")

--- a/services/orchest-api/app/migrations/versions/637920f5715f_.py
+++ b/services/orchest-api/app/migrations/versions/637920f5715f_.py
@@ -1,0 +1,52 @@
+"""Add PipelineEvent, InteractivePipelineRunEvent model and event types
+
+Revision ID: 637920f5715f
+Revises: 849b7b154ef6
+Create Date: 2022-05-16 09:25:56.549523
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "637920f5715f"
+down_revision = "849b7b154ef6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        alter table event_types alter column name type character varying(100);
+        alter table events alter column type type character varying(100);
+        alter table subscriptions alter column event_type type character varying(100);
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:pipeline:interactive-pipeline-run:created'),
+        ('project:pipeline:interactive-pipeline-run:started'),
+        ('project:pipeline:interactive-pipeline-run:cancelled'),
+        ('project:pipeline:interactive-pipeline-run:failed'),
+        ('project:pipeline:interactive-pipeline-run:succeeded')
+        ;
+        """
+    )
+    op.create_foreign_key(
+        op.f("fk_events_project_uuid_pipeline_uuid_pipelines"),
+        "events",
+        "pipelines",
+        ["project_uuid", "pipeline_uuid"],
+        ["project_uuid", "uuid"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_events_project_uuid_pipeline_uuid_pipelines"),
+        "events",
+        type_="foreignkey",
+    )

--- a/services/orchest-api/app/migrations/versions/a4b1f48ddab5.py
+++ b/services/orchest-api/app/migrations/versions/a4b1f48ddab5.py
@@ -1,0 +1,31 @@
+"""Add OneOffJobUpdateEvent, CronJobUpdateEvent and related event_types
+
+Revision ID: a4b1f48ddab5
+Revises: a863be01327d
+Create Date: 2022-05-17 12:47:18.027113
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a4b1f48ddab5"
+down_revision = "a863be01327d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:cron-job:updated'),
+        ('project:one-off-job:updated')
+        ;
+        """
+    )
+    pass
+
+
+def downgrade():
+    pass

--- a/services/orchest-api/app/migrations/versions/a863be01327d_.py
+++ b/services/orchest-api/app/migrations/versions/a863be01327d_.py
@@ -1,0 +1,31 @@
+"""Add Pipeline.name field
+
+Revision ID: a863be01327d
+Revises: 268b3e08cb46
+Create Date: 2022-05-17 11:03:15.153821
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a863be01327d"
+down_revision = "268b3e08cb46"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pipelines",
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            server_default=sa.text("'Pipeline'"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("pipelines", "name")

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -694,6 +694,9 @@ def pipeline_set_notebook_kernels(pipeline_json, pipeline_directory, project_uui
 def check_pipeline_correctness(pipeline_json):
     invalid_entries = {}
 
+    if len(pipeline_json["name"]) > 255:
+        invalid_entries["name"] = "invalid_value"
+
     mem_size = pipeline_json["settings"].get("data_passing_memory_size")
     if mem_size is None:
         invalid_entries["data_passing_memory_size"] = "missing"

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -432,17 +432,6 @@ def register_orchest_api_views(app, db):
                 json=json_obj,
             )
 
-            analytics.send_event(
-                app,
-                analytics.Event.PIPELINE_RUN_STARTED,
-                {
-                    "run_uuid": resp.json().get("uuid"),
-                    "run_type": "interactive",
-                    "pipeline_definition": json_obj["pipeline_definition"],
-                    "step_uuids_to_execute": json_obj["uuids"],
-                },
-            )
-
             return resp.content, resp.status_code, resp.headers.items()
 
         elif request.method == "GET":
@@ -477,11 +466,6 @@ def register_orchest_api_views(app, db):
                 + "/api/runs/%s" % run_uuid,
             )
 
-            analytics.send_event(
-                app,
-                analytics.Event.PIPELINE_RUN_CANCELLED,
-                {"run_uuid": run_uuid, "run_type": "interactive"},
-            )
             return resp.content, resp.status_code, resp.headers.items()
 
     @app.route("/catch/api-proxy/api/jobs/<job_uuid>", methods=["DELETE"])

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -507,11 +507,6 @@ def register_orchest_api_views(app, db):
             json=request.json,
         )
 
-        analytics.send_event(
-            app,
-            analytics.Event.JOB_UPDATED,
-            {"job_uuid": job_uuid, "job_definition": request.json},
-        )
         return resp.content, resp.status_code, resp.headers.items()
 
     @app.route("/catch/api-proxy/api/jobs/<job_uuid>/<run_uuid>", methods=["GET"])


### PR DESCRIPTION
## Description

Adds support for interactive pipeline run events in the `orchest-api`, these events can now be subscribed to and are now part of the analytics module.

## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
