### PR TITLE
Add environment created/delete events to `orchest-api` (notifications)

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -43,6 +43,9 @@ class Event(Enum):
     PROJECT_UPDATED = "project:updated"
     PROJECT_DELETED = "project:deleted"
 
+    ENVIRONMENT_CREATED = "project:environment:created"
+    ENVIRONMENT_DELETED = "project:environment:deleted"
+
     PIPELINE_CREATED = "project:pipeline:created"
     PIPELINE_UPDATED = "project:pipeline:updated"
     PIPELINE_DELETED = "project:pipeline:deleted"
@@ -282,6 +285,12 @@ class _Anonymizer:
         return derived_properties
 
     @staticmethod
+    def environment_event(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.project_event(event_properties)
+        derived_properties["project"]["environment"] = {}
+        return derived_properties
+
+    @staticmethod
     def pipeline_event(event_properties: dict) -> dict:
         derived_properties = {}
         derived_properties["project"] = _anonymize_project_properties(
@@ -417,6 +426,8 @@ _ANONYMIZATION_MAPPINGS = {
     Event.PROJECT_CREATED: _Anonymizer.project_event,
     Event.PROJECT_UPDATED: _Anonymizer.project_event,
     Event.PROJECT_DELETED: _Anonymizer.project_event,
+    Event.ENVIRONMENT_CREATED: _Anonymizer.environment_event,
+    Event.ENVIRONMENT_DELETED: _Anonymizer.environment_event,
     Event.PIPELINE_CREATED: _Anonymizer.pipeline_event,
     Event.PIPELINE_UPDATED: _Anonymizer.pipeline_event,
     Event.PIPELINE_DELETED: _Anonymizer.pipeline_event,

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -576,6 +576,27 @@ def register_project_deleted_event(project_uuid: str):
     _register_project_event("project:deleted", project_uuid)
 
 
+def _register_environment_event(
+    type: str, project_uuid: str, environment_uuid: str
+) -> None:
+    ev = models.EnvironmentEvent(
+        type=type, project_uuid=project_uuid, environment_uuid=environment_uuid
+    )
+    _register_event(ev)
+
+
+def register_environment_created_event(project_uuid: str, environment_uuid: str):
+    _register_environment_event(
+        "project:environment:created", project_uuid, environment_uuid
+    )
+
+
+def register_environment_deleted_event(project_uuid: str, environment_uuid: str):
+    _register_environment_event(
+        "project:environment:deleted", project_uuid, environment_uuid
+    )
+
+
 def register_project_updated_event(project_uuid: str, update: app_types.EntityUpdate):
     ev = models.ProjectUpdateEvent(
         type="project:updated", project_uuid=project_uuid, update=update

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1181,6 +1181,7 @@ class Event(BaseModel):
                 (type.startswith("project:pipeline:updated"), "pipeline_update_event"),
                 (type.startswith("project:pipeline:"), "pipeline_event"),
                 (type.startswith("project:updated"), "project_update_event"),
+                (type.startswith("project:environment:"), "environment_event"),
                 (type.startswith("project:"), "project_event"),
             ],
             else_="event",
@@ -1408,6 +1409,28 @@ class InteractiveSessionEvent(ProjectEvent):
 ForeignKeyConstraint(
     [InteractiveSessionEvent.project_uuid, InteractiveSessionEvent.pipeline_uuid],
     [Pipeline.project_uuid, Pipeline.uuid],
+    ondelete="CASCADE",
+)
+
+
+class EnvironmentEvent(ProjectEvent):
+
+    # Single table inheritance.
+    __tablename__ = None
+
+    __mapper_args__ = {"polymorphic_identity": "environment_event"}
+
+    environment_uuid = db.Column(db.String(36))
+
+    def to_notification_payload(self) -> dict:
+        payload = super().to_notification_payload()
+        payload["project"]["environment"] = {"uuid": self.uuid}
+        return payload
+
+
+ForeignKeyConstraint(
+    [EnvironmentEvent.project_uuid, EnvironmentEvent.environment_uuid],
+    [Environment.project_uuid, Environment.uuid],
     ondelete="CASCADE",
 )
 

--- a/services/orchest-api/app/migrations/versions/19ce7297c194_.py
+++ b/services/orchest-api/app/migrations/versions/19ce7297c194_.py
@@ -1,0 +1,46 @@
+"""Add EnvironmentEvent model and related event_types
+
+Revision ID: 19ce7297c194
+Revises: a4b1f48ddab5
+Create Date: 2022-05-18 08:24:35.071687
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "19ce7297c194"
+down_revision = "a4b1f48ddab5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:environment:created'),
+        ('project:environment:deleted')
+        ;
+        """
+    )
+    op.add_column(
+        "events", sa.Column("environment_uuid", sa.String(length=36), nullable=True)
+    )
+    op.create_foreign_key(
+        op.f("fk_events_project_uuid_environment_uuid_environments"),
+        "events",
+        "environments",
+        ["project_uuid", "environment_uuid"],
+        ["project_uuid", "uuid"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f("fk_events_project_uuid_environment_uuid_environments"),
+        "events",
+        type_="foreignkey",
+    )
+    op.drop_column("events", "environment_uuid")


### PR DESCRIPTION
## Description

Part of the larger effort to add more events to the `orchest-api` and analytics.


## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).