### PR TITLE
Add environment image builds events to `orchest-api` (notifications)

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -296,6 +296,9 @@ class _Anonymizer:
     @staticmethod
     def environment_image_build_event(event_properties: dict) -> dict:
         derived_properties = _Anonymizer.environment_event(event_properties)
+        event_properties["project"]["environment"]["image_build"].pop(
+            "project_path", None
+        )
         derived_properties["project"]["environment"]["image_build"] = {}
         return derived_properties
 
@@ -313,6 +316,15 @@ class _Anonymizer:
             image_build_derived_props[
                 "uses_orchest_base_image"
             ] = base_image.startswith("orchest/")
+            # Deprecated.
+            derived_properties["uses_orchest_base_image"] = image_build_derived_props[
+                "uses_orchest_base_image"
+            ]
+        if not derived_properties.get("uses_orchest_base_image", False):
+            event_properties["project"]["environment"]["image_build"].pop(
+                base_image, None
+            )
+
         return derived_properties
 
     @staticmethod

--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -30,8 +30,6 @@ class Event(Enum):
 
     # Sent by orchest-webserver. Try to minimize these events, in favour
     # of moving them to the orchest-api.
-    ENVIRONMENT_BUILD_CANCELLED = "environment-build:cancelled"
-    ENVIRONMENT_BUILD_STARTED = "environment-build:started"
     HEARTBEAT_TRIGGER = "heartbeat-trigger"
     JOB_DUPLICATED = "job:duplicated"
     PIPELINE_SAVED = "pipeline:saved"
@@ -45,6 +43,11 @@ class Event(Enum):
 
     ENVIRONMENT_CREATED = "project:environment:created"
     ENVIRONMENT_DELETED = "project:environment:deleted"
+    ENVIRONMENT_IMAGE_BUILD_CREATED = "project:environment:image-build:created"
+    ENVIRONMENT_IMAGE_BUILD_STARTED = "project:environment:image-build:started"
+    ENVIRONMENT_IMAGE_BUILD_CANCELLED = "project:environment:image-build:cancelled"
+    ENVIRONMENT_IMAGE_BUILD_FAILED = "project:environment:image-build:failed"
+    ENVIRONMENT_IMAGE_BUILD_SUCCEEDED = "project:environment:image-build:succeeded"
 
     PIPELINE_CREATED = "project:pipeline:created"
     PIPELINE_UPDATED = "project:pipeline:updated"
@@ -291,6 +294,28 @@ class _Anonymizer:
         return derived_properties
 
     @staticmethod
+    def environment_image_build_event(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.environment_event(event_properties)
+        derived_properties["project"]["environment"]["image_build"] = {}
+        return derived_properties
+
+    @staticmethod
+    def environment_image_build_created_event(event_properties: dict) -> dict:
+        derived_properties = _Anonymizer.environment_image_build_event(event_properties)
+        image_build_derived_props = derived_properties["project"]["environment"][
+            "image_build"
+        ]
+
+        base_image = event_properties["project"]["environment"]["image_build"].get(
+            "base_image"
+        )
+        if isinstance(base_image, str):
+            image_build_derived_props[
+                "uses_orchest_base_image"
+            ] = base_image.startswith("orchest/")
+        return derived_properties
+
+    @staticmethod
     def pipeline_event(event_properties: dict) -> dict:
         derived_properties = {}
         derived_properties["project"] = _anonymize_project_properties(
@@ -390,16 +415,6 @@ class _Anonymizer:
         return derived_properties
 
     @staticmethod
-    def environment_build_started(event_properties: dict) -> dict:
-        base_image = event_properties.pop("base_image", None)
-        derived_properties = {}
-        if isinstance(base_image, str):
-            derived_properties["uses_orchest_base_image"] = base_image.startswith(
-                "orchest/"
-            )
-        return derived_properties
-
-    @staticmethod
     def project_one_off_job(event_properties: dict) -> dict:
         derived_properties = {}
         derived_properties["project"] = _anonymize_project_properties(
@@ -428,6 +443,11 @@ _ANONYMIZATION_MAPPINGS = {
     Event.PROJECT_DELETED: _Anonymizer.project_event,
     Event.ENVIRONMENT_CREATED: _Anonymizer.environment_event,
     Event.ENVIRONMENT_DELETED: _Anonymizer.environment_event,
+    Event.ENVIRONMENT_IMAGE_BUILD_CREATED: _Anonymizer.environment_image_build_created_event,  # noqa
+    Event.ENVIRONMENT_IMAGE_BUILD_STARTED: _Anonymizer.environment_image_build_event,
+    Event.ENVIRONMENT_IMAGE_BUILD_FAILED: _Anonymizer.environment_image_build_event,
+    Event.ENVIRONMENT_IMAGE_BUILD_CANCELLED: _Anonymizer.environment_image_build_event,
+    Event.ENVIRONMENT_IMAGE_BUILD_SUCCEEDED: _Anonymizer.environment_image_build_event,
     Event.PIPELINE_CREATED: _Anonymizer.pipeline_event,
     Event.PIPELINE_UPDATED: _Anonymizer.pipeline_event,
     Event.PIPELINE_DELETED: _Anonymizer.pipeline_event,
@@ -439,7 +459,6 @@ _ANONYMIZATION_MAPPINGS = {
     Event.INTERACTIVE_PIPELINE_RUN_FAILED: _Anonymizer.interactive_pipeline_run,
     Event.INTERACTIVE_PIPELINE_RUN_SUCCEEDED: _Anonymizer.interactive_pipeline_run,
     Event.PIPELINE_SAVED: _Anonymizer.pipeline_saved,
-    Event.ENVIRONMENT_BUILD_STARTED: _Anonymizer.environment_build_started,
     Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created_updated,
     Event.ONE_OFF_JOB_UPDATED: _Anonymizer.project_one_off_job_created_updated,
     Event.ONE_OFF_JOB_STARTED: _Anonymizer.project_one_off_job,

--- a/lib/python/orchest-internals/_orchest/internals/analytics.py
+++ b/lib/python/orchest-internals/_orchest/internals/analytics.py
@@ -375,10 +375,6 @@ class _Anonymizer:
         return derived_properties
 
     @staticmethod
-    def job_duplicated(event_properties: dict) -> dict:
-        return _Anonymizer._deprecated_job_created(event_properties)
-
-    @staticmethod
     def session_started(event_properties: dict) -> dict:
         derived_user_services = {}
         user_services = event_properties["project"]["pipeline"]["session"][
@@ -490,7 +486,6 @@ _ANONYMIZATION_MAPPINGS = {
     Event.INTERACTIVE_PIPELINE_RUN_FAILED: _Anonymizer.interactive_pipeline_run,
     Event.INTERACTIVE_PIPELINE_RUN_STARTED: _Anonymizer.interactive_pipeline_run,
     Event.INTERACTIVE_PIPELINE_RUN_SUCCEEDED: _Anonymizer.interactive_pipeline_run,
-    Event.JOB_DUPLICATED: _Anonymizer.job_duplicated,
     Event.ONE_OFF_JOB_CANCELLED: _Anonymizer.project_one_off_job,
     Event.ONE_OFF_JOB_CREATED: _Anonymizer.project_one_off_job_created_updated,
     Event.ONE_OFF_JOB_DELETED: _Anonymizer.project_one_off_job,

--- a/services/orchest-api/app/app/core/events.py
+++ b/services/orchest-api/app/app/core/events.py
@@ -604,6 +604,73 @@ def register_project_updated_event(project_uuid: str, update: app_types.EntityUp
     _register_event(ev)
 
 
+def _register_environment_image_build_event(
+    type: str, project_uuid: str, environment_uuid: str, image_tag: str
+) -> None:
+    ev = models.EnvironmentImageBuildEvent(
+        type=type,
+        project_uuid=project_uuid,
+        environment_uuid=environment_uuid,
+        image_tag=image_tag,
+    )
+    _register_event(ev)
+
+
+def register_environment_image_build_created_event(
+    project_uuid: str, environment_uuid: str, image_tag: str
+):
+    _register_environment_image_build_event(
+        "project:environment:image-build:created",
+        project_uuid,
+        environment_uuid,
+        image_tag,
+    )
+
+
+def register_environment_image_build_started_event(
+    project_uuid: str, environment_uuid: str, image_tag: str
+):
+    _register_environment_image_build_event(
+        "project:environment:image-build:started",
+        project_uuid,
+        environment_uuid,
+        image_tag,
+    )
+
+
+def register_environment_image_build_cancelled_event(
+    project_uuid: str, environment_uuid: str, image_tag: str
+):
+    _register_environment_image_build_event(
+        "project:environment:image-build:cancelled",
+        project_uuid,
+        environment_uuid,
+        image_tag,
+    )
+
+
+def register_environment_image_build_failed_event(
+    project_uuid: str, environment_uuid: str, image_tag: str
+):
+    _register_environment_image_build_event(
+        "project:environment:image-build:failed",
+        project_uuid,
+        environment_uuid,
+        image_tag,
+    )
+
+
+def register_environment_image_build_succeeded_event(
+    project_uuid: str, environment_uuid: str, image_tag: str
+):
+    _register_environment_image_build_event(
+        "project:environment:image-build:succeeded",
+        project_uuid,
+        environment_uuid,
+        image_tag,
+    )
+
+
 def _register_pipeline_event(type: str, project_uuid: str, pipeline_uuid: str) -> None:
     ev = models.PipelineEvent(
         type=type,

--- a/services/orchest-api/app/app/core/notifications/analytics.py
+++ b/services/orchest-api/app/app/core/notifications/analytics.py
@@ -137,6 +137,19 @@ def _generate_pipeline_created_deleted_payload(event: models.ProjectEvent):
     return payload
 
 
+def _generate_environment_image_build_payload(event: models.ProjectEvent):
+    if not event.type.startswith("project:environment:image-build:"):
+        raise ValueError()
+
+    payload = event.to_notification_payload()
+
+    # Deprecated.
+    payload["project_uuid"] = payload["project"]["uuid"]
+    payload["environment_uuid"] = payload["project"]["environment"]["uuid"]
+    payload["image_tag"] = payload["project"]["environment"]["image_build"]["image_tag"]
+    return payload
+
+
 def generate_payload_for_analytics(event: models.Event) -> dict:
     """Creates an analytics module compatible payload.
 
@@ -157,6 +170,9 @@ def generate_payload_for_analytics(event: models.Event) -> dict:
 
     if event.type in ["project:pipeline:created", "project:pipeline:deleted"]:
         return _generate_pipeline_created_deleted_payload(event)
+
+    if event.type.startswith("project:environment:image-build:"):
+        return _generate_environment_image_build_payload(event)
 
     event_type = analytics_payload["type"]
 

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1093,8 +1093,10 @@ class EventType(BaseModel):
     - services/orchest-api/app/migrations/versions/ad0b4cda3e50_.py
     - services/orchest-api/app/migrations/versions/849b7b154ef6_.py
     - services/orchest-api/app/migrations/versions/637920f5715f_.py
-    - services/orchest-api/app/migrations/versions/637920f5715f_.py
+    - services/orchest-api/app/migrations/versions/2b573339900f_.py
     - services/orchest-api/app/migrations/versions/a4b1f48ddab5.py
+    - services/orchest-api/app/migrations/versions/19ce7297c194_.py
+    - services/orchest-api/app/migrations/versions/0eaf40410361_.py
 
     To add more types, add an empty revision with
     `bash scripts/migration_manager.sh orchest-api revision`, then
@@ -1181,6 +1183,10 @@ class Event(BaseModel):
                 (type.startswith("project:pipeline:updated"), "pipeline_update_event"),
                 (type.startswith("project:pipeline:"), "pipeline_event"),
                 (type.startswith("project:updated"), "project_update_event"),
+                (
+                    type.startswith("project:environment:image-build:"),
+                    "environment_image_build_event",
+                ),
                 (type.startswith("project:environment:"), "environment_event"),
                 (type.startswith("project:"), "project_event"),
             ],
@@ -1420,17 +1426,57 @@ class EnvironmentEvent(ProjectEvent):
 
     __mapper_args__ = {"polymorphic_identity": "environment_event"}
 
-    environment_uuid = db.Column(db.String(36))
+    environment_uuid = db.Column(db.String(36), nullable=True)
 
     def to_notification_payload(self) -> dict:
         payload = super().to_notification_payload()
-        payload["project"]["environment"] = {"uuid": self.uuid}
+        payload["project"]["environment"] = {"uuid": self.environment_uuid}
         return payload
 
 
 ForeignKeyConstraint(
     [EnvironmentEvent.project_uuid, EnvironmentEvent.environment_uuid],
     [Environment.project_uuid, Environment.uuid],
+    ondelete="CASCADE",
+)
+
+
+class EnvironmentImageBuildEvent(EnvironmentEvent):
+
+    # Single table inheritance.
+    __tablename__ = None
+
+    __mapper_args__ = {"polymorphic_identity": "environment_image_build_event"}
+
+    image_tag = db.Column(db.Integer, nullable=True)
+
+    def to_notification_payload(self) -> dict:
+        payload = super().to_notification_payload()
+        build = EnvironmentImageBuild.query.filter(
+            EnvironmentImageBuild.project_uuid == self.project_uuid,
+            EnvironmentImageBuild.environment_uuid == self.environment_uuid,
+            EnvironmentImageBuild.image_tag == self.image_tag,
+        ).first()
+        if build is not None:
+            build = build.as_dict()
+            for k, v in build.items():
+                if isinstance(v, datetime.datetime):
+                    build[k] = str(v)
+            payload["project"]["environment"]["image_build"] = build
+        return payload
+
+
+ForeignKeyConstraint(
+    [
+        EnvironmentImageBuildEvent.project_uuid,
+        EnvironmentImageBuildEvent.environment_uuid,
+        EnvironmentImageBuildEvent.image_tag,
+    ],
+    [
+        EnvironmentImageBuild.project_uuid,
+        EnvironmentImageBuild.environment_uuid,
+        EnvironmentImageBuild.image_tag,
+    ],
     ondelete="CASCADE",
 )
 
@@ -1744,7 +1790,9 @@ class JupyterImageBuildEvent(Event):
     __mapper_args__ = {"polymorphic_identity": "jupyter_image_build_event"}
 
     build_uuid = db.Column(
-        db.String(36), db.ForeignKey("jupyter_image_builds.uuid", ondelete="CASCADE")
+        db.String(36),
+        db.ForeignKey("jupyter_image_builds.uuid", ondelete="CASCADE"),
+        nullable=True,
     )
 
     def to_notification_payload(self) -> dict:

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -1430,7 +1430,13 @@ class EnvironmentEvent(ProjectEvent):
 
     def to_notification_payload(self) -> dict:
         payload = super().to_notification_payload()
-        payload["project"]["environment"] = {"uuid": self.environment_uuid}
+        payload["project"]["environment"] = {
+            "uuid": self.environment_uuid,
+            "url_path": (
+                f"/environment?project_uuid={self.project_uuid}&environment_uuid="
+                f"{self.environment_uuid}"
+            ),
+        }
         return payload
 
 

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -667,6 +667,17 @@ def mark_custom_jupyter_images_to_be_removed() -> None:
     images_to_be_removed.update({"marked_for_removal": True})
 
 
+def get_environment_directory_path(project_path: str, environment_uuid: str) -> str:
+    return os.path.join(
+        "/userdir",
+        "projects",
+        project_path,
+        ".orchest",
+        "environments",
+        environment_uuid,
+    )
+
+
 def get_job_dir_path(project_uuid: str, pipeline_uuid: str, job_uuid: str) -> str:
     return os.path.join("/userdir", "jobs", project_uuid, pipeline_uuid, job_uuid)
 

--- a/services/orchest-api/app/migrations/versions/0eaf40410361_.py
+++ b/services/orchest-api/app/migrations/versions/0eaf40410361_.py
@@ -1,0 +1,51 @@
+"""Add EnvironmentImageBuildEvent and related event_types
+
+Revision ID: 0eaf40410361
+Revises: 19ce7297c194
+Create Date: 2022-05-18 11:05:53.335758
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0eaf40410361"
+down_revision = "19ce7297c194"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO event_types (name) values
+        ('project:environment:image-build:created'),
+        ('project:environment:image-build:started'),
+        ('project:environment:image-build:cancelled'),
+        ('project:environment:image-build:failed'),
+        ('project:environment:image-build:succeeded')
+        ;
+        """
+    )
+    op.add_column("events", sa.Column("image_tag", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        op.f(
+            "fk_events_project_uuid_environment_uuid_image_tag_environment_image_builds"
+        ),
+        "events",
+        "environment_image_builds",
+        ["project_uuid", "environment_uuid", "image_tag"],
+        ["project_uuid", "environment_uuid", "image_tag"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        op.f(
+            "fk_events_project_uuid_environment_uuid_image_tag_environment_image_builds"
+        ),
+        "events",
+        type_="foreignkey",
+    )
+    op.drop_column("events", "image_tag")

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -6,7 +6,6 @@ from app import error
 from app.core import jobs
 from app.models import Pipeline, Project
 from app.utils import (
-    get_environment,
     get_environments,
     get_pipeline_json,
     get_project_directory,
@@ -94,15 +93,6 @@ def register_orchest_api_views(app, db):
             % (project_uuid, environment_uuid, image_tag),
         )
 
-        analytics.send_event(
-            app,
-            analytics.Event.ENVIRONMENT_BUILD_CANCELLED,
-            {
-                "project_uuid": project_uuid,
-                "environment_uuid": environment_uuid,
-                "image_tag": image_tag,
-            },
-        )
         return resp.content, resp.status_code, resp.headers.items()
 
     @app.route(
@@ -135,21 +125,6 @@ def register_orchest_api_views(app, db):
             environment_image_build_requests, app.config["ORCHEST_API_ADDRESS"]
         )
 
-        for environment_image_build_request in environment_image_build_requests:
-            environment_uuid = environment_image_build_request["environment_uuid"]
-            project_uuid = environment_image_build_request["project_uuid"]
-            env = get_environment(environment_uuid, project_uuid)
-            analytics.send_event(
-                app,
-                analytics.Event.ENVIRONMENT_BUILD_STARTED,
-                {
-                    "environment_uuid": environment_uuid,
-                    "project_uuid": project_uuid,
-                    "language": env.language,
-                    "gpu_support": env.gpu_support,
-                    "base_image": env.base_image,
-                },
-            )
         return resp.content, resp.status_code, resp.headers.items()
 
     @app.route(


### PR DESCRIPTION
## Description

Part of the larger effort to add more events to the `orchest-api` and analytics.

## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).

