### PR TITLE
Remove swr in useCheckUpdate

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -13,6 +13,7 @@ import { OnboardingDialog } from "./components/Layout/OnboardingDialog";
 import { AppDrawer } from "./components/MainDrawer";
 import { SystemDialog } from "./components/SystemDialog";
 import { useAppContext } from "./contexts/AppContext";
+import { AppInnerContextProvider } from "./contexts/AppInnerContext";
 import Jupyter from "./jupyter/Jupyter";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -101,31 +102,33 @@ const App = () => {
         }
       }}
     >
-      <Box sx={{ display: "flex", flex: 1, overflow: "hidden" }}>
-        <HeaderBar toggleDrawer={toggleDrawer} isDrawerOpen={isDrawerOpen} />
-        <AppDrawer isOpen={isDrawerOpen} />
-        <Box
-          component="main"
-          sx={{
-            flex: 1,
-            overflow: "hidden",
-            position: "relative",
-            minHeight: 0,
-            display: "flex",
-            flexDirection: "column",
-          }}
-          id="main-content"
-          data-test-id="app"
-        >
-          <Routes />
-          <div ref={jupyterRef} className="persistent-view jupyter hidden" />
+      <AppInnerContextProvider>
+        <Box sx={{ display: "flex", flex: 1, overflow: "hidden" }}>
+          <HeaderBar toggleDrawer={toggleDrawer} isDrawerOpen={isDrawerOpen} />
+          <AppDrawer isOpen={isDrawerOpen} />
+          <Box
+            component="main"
+            sx={{
+              flex: 1,
+              overflow: "hidden",
+              position: "relative",
+              minHeight: 0,
+              display: "flex",
+              flexDirection: "column",
+            }}
+            id="main-content"
+            data-test-id="app"
+          >
+            <Routes />
+            <div ref={jupyterRef} className="persistent-view jupyter hidden" />
+          </Box>
         </Box>
-      </Box>
-      <Prompt when={hasUnsavedChanges} message="hasUnsavedChanges" />
-      <SystemDialog />
-      <BuildPendingDialog />
-      <OnboardingDialog />
-      <CommandPalette />
+        <Prompt when={hasUnsavedChanges} message="hasUnsavedChanges" />
+        <SystemDialog />
+        <BuildPendingDialog />
+        <OnboardingDialog />
+        <CommandPalette />
+      </AppInnerContextProvider>
     </Router>
   );
 };

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -357,7 +357,11 @@ export const AppContextProvider: React.FC<{ shouldStart?: boolean }> = ({
   shouldStart = true,
 }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
-  const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage("drawer", true);
+
+  const [isDrawerOpen, setIsDrawerOpen] = useLocalStorage<boolean>(
+    "drawer",
+    true
+  );
 
   const { config, user_config } = useFetchSystemConfig(shouldStart);
 

--- a/services/orchest-webserver/client/src/contexts/AppInnerContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppInnerContext.tsx
@@ -1,0 +1,28 @@
+import { useCheckUpdate } from "@/hooks/useCheckUpdate";
+import React from "react";
+
+export type AppInnerContextType = {
+  orchestVersion: string | null | undefined;
+  checkUpdate: () => Promise<void>;
+};
+
+export const AppInnerContext = React.createContext<AppInnerContextType>(
+  {} as AppInnerContextType
+);
+
+export const useAppInnerContext = () => React.useContext(AppInnerContext);
+
+export const AppInnerContextProvider: React.FC = ({ children }) => {
+  const { checkUpdate, orchestVersion } = useCheckUpdate();
+
+  return (
+    <AppInnerContext.Provider
+      value={{
+        checkUpdate,
+        orchestVersion,
+      }}
+    >
+      {children}
+    </AppInnerContext.Provider>
+  );
+};

--- a/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
+++ b/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
@@ -88,6 +88,7 @@ export type NavigateParams = {
 // better make use of useLocationQuery and useLocationState
 const useCustomRoute = () => {
   const history = useHistory();
+  const location = useLocation();
 
   const [isReadOnly, prevPathname] = useLocationState<
     [boolean, string, boolean]
@@ -169,6 +170,7 @@ const useCustomRoute = () => {
     runUuid,
     filePath,
     initialTab,
+    location,
     prevPathname,
   };
 };

--- a/services/orchest-webserver/client/src/hooks/useFetcher.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetcher.ts
@@ -7,11 +7,13 @@ import { useHasChanged } from "./useHasChanged";
 export function useFetcher<FetchedValue, Data = FetchedValue>(
   url: string | undefined,
   params?: RequestInit & {
+    disableFetchOnMount?: boolean;
     revalidateOnFocus?: boolean;
     transform?: (data: FetchedValue) => Data;
   }
 ) {
   const {
+    disableFetchOnMount = false,
     revalidateOnFocus = false,
     transform = (fetchedValue: FetchedValue) =>
       (fetchedValue as unknown) as Data,
@@ -46,7 +48,7 @@ export function useFetcher<FetchedValue, Data = FetchedValue>(
     );
   }, [run, url]);
 
-  const hasFetchedOnMount = React.useRef(false);
+  const hasFetchedOnMount = React.useRef(disableFetchOnMount);
 
   React.useEffect(() => {
     if (!hasFetchedOnMount.current || shouldRefetch) {

--- a/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ProjectsView.tsx
@@ -9,7 +9,6 @@ import { defaultOverlaySx, DropZone } from "@/components/DropZone";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
-import { useCheckUpdate } from "@/hooks/useCheckUpdate";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useImportUrl } from "@/hooks/useImportUrl";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -58,8 +57,6 @@ const ProjectsView: React.FC = () => {
   const [isShowingCreateModal, setIsShowingCreateModal] = React.useState(false);
 
   const [isImportDialogOpen, setIsImportDialogOpen] = React.useState(false);
-
-  useCheckUpdate();
 
   const columns: DataTableColumn<ProjectRow>[] = React.useMemo(() => {
     const openSettings = (projectUuid: string) => (e: React.MouseEvent) => {

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export type RouteName =
   | "projects"
   | "examples"
@@ -30,7 +28,6 @@ export type RouteName =
 export type RouteData = {
   path: string;
   root?: string;
-  component: React.FunctionComponent;
   order: number;
 };
 

--- a/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
@@ -2,7 +2,7 @@ import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
-import { useCheckUpdate } from "@/hooks/useCheckUpdate";
+import { useCheckUpdate, useOrchestVersion } from "@/hooks/useCheckUpdate";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
@@ -25,7 +25,6 @@ import { Controlled as CodeMirror } from "react-codemirror2";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useOrchestStatus } from "./hooks/useOrchestStatus";
 import { useOrchestUserConfig } from "./hooks/useOrchestUserConfig";
-import { useOrchestVersion } from "./hooks/useOrchestVersion";
 
 // TODO: remove this when Orchest supports changing disk size.
 const shouldShowHostInfo = false;

--- a/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
@@ -2,7 +2,7 @@ import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/Layout";
 import { useAppContext } from "@/contexts/AppContext";
-import { useCheckUpdate, useOrchestVersion } from "@/hooks/useCheckUpdate";
+import { useAppInnerContext } from "@/contexts/AppInnerContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
@@ -39,13 +39,12 @@ const SettingsView: React.FC = () => {
     config: orchestConfig,
   } = useAppContext();
 
-  const checkUpdate = useCheckUpdate();
+  const { orchestVersion, checkUpdate } = useAppInnerContext();
 
   useSendAnalyticEvent("view load", { name: siteMap.settings.path });
 
   const [status, setStatus] = useOrchestStatus();
 
-  const version = useOrchestVersion();
   const hostInfo = useHostInfo(shouldShowHostInfo);
 
   const {
@@ -177,8 +176,8 @@ const SettingsView: React.FC = () => {
             <p>Version information.</p>
           </div>
           <div className="column">
-            {version ? (
-              <p>{version}</p>
+            {orchestVersion ? (
+              <p>{orchestVersion}</p>
             ) : (
               <LinearProgress className="push-down" />
             )}

--- a/services/orchest-webserver/client/src/settings-view/hooks/useOrchestVersion.tsx
+++ b/services/orchest-webserver/client/src/settings-view/hooks/useOrchestVersion.tsx
@@ -1,9 +1,0 @@
-import { fetcher } from "@orchest/lib-utils";
-import useSWR from "swr";
-
-export const useOrchestVersion = () => {
-  const { data } = useSWR("/async/version", (url) =>
-    fetcher<{ version: string }>(url).then((response) => response.version)
-  );
-  return data;
-};

--- a/services/orchest-webserver/client/src/views/HelpView.tsx
+++ b/services/orchest-webserver/client/src/views/HelpView.tsx
@@ -2,7 +2,6 @@ import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/Layout";
 import { useOnboardingDialog } from "@/components/Layout/OnboardingDialog";
 import { useAppContext } from "@/contexts/AppContext";
-import { useCheckUpdate } from "@/hooks/useCheckUpdate";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
@@ -50,8 +49,6 @@ const HelpView: React.FC = () => {
 
   useSendAnalyticEvent("view load", { name: siteMap.help.path });
   const { setIsOnboardingDialogOpen } = useOnboardingDialog();
-
-  useCheckUpdate();
 
   const {
     ORCHEST_WEB_URLS: { readthedocs, website, slack, github },


### PR DESCRIPTION
## Description

This is one of the PR's that removes the usage of swr (see #973).

Edit:
This ends up a rather-big refactoring. `useCheckUpdate` was moved to a new context `AppInnerContext`. The reason is that if `useCheckUpdate` lives inside a view, the polling is most likely won't be useful (user needs to stay in the same view for one hour to actually trigger the next check). To meet the requirement of the actual use case, we need to move `useCheckUpdate` to an app-wide context.

However, the existing `AppContext` cannot be used for this is that `useCheckUpdate` needs to detect route changes, so it needs to be wrapped as any child of `<Route />`, but `AppContext` must be a parent of `<Route /`>. So we run into a circular dependency.

Therefore, `AppInnerContext` was created. It's an app-wide context that has access to `react-router` context.

Ideally, I would rename `AppConext` to `GlobalContext`, and `AppInnderContext` to `AppContext`. But I think we could change it later in a separate PR.