### PR TITLE
Remove swr in useFetchEnvironment

### DIFF
--- a/services/orchest-webserver/client/src/environment-edit-view/ContainerImagesRadioGroup.tsx
+++ b/services/orchest-webserver/client/src/environment-edit-view/ContainerImagesRadioGroup.tsx
@@ -108,12 +108,14 @@ export const ContainerImagesRadioGroup = ({
       )
     );
     if (foundDefaultImage) {
-      // Always return a versioned image.
-      // So user uses the latest environment version
-      const defaultImageToSave = `${foundDefaultImage.base_image}:${orchestVersion}`;
-      onChange({ ...foundDefaultImage, base_image: defaultImageToSave });
+      // Always return a un-versioned image, and let BE fill the version.
+      onChange({
+        ...foundDefaultImage,
+        base_image: foundDefaultImage.base_image,
+      });
     }
   };
+
   return (
     <RadioGroup value={value} onChange={(e, value) => onChangeSelection(value)}>
       <Box>
@@ -144,7 +146,7 @@ export const ContainerImagesRadioGroup = ({
             <Grid item sm={6} key={base_image}>
               <ImageOption
                 title={isUnavailable ? "Temporarily unavailable" : base_image}
-                value={`${base_image}:${orchestVersion}`}
+                value={base_image}
                 disabled={isUnavailable || disabled}
                 supportGpu={gpu_support}
               >

--- a/services/orchest-webserver/client/src/environment-edit-view/useCustomImage.tsx
+++ b/services/orchest-webserver/client/src/environment-edit-view/useCustomImage.tsx
@@ -2,7 +2,6 @@ import type { CustomImage, Environment } from "@/types";
 import "codemirror/mode/shell/shell";
 import "codemirror/theme/dracula.css";
 import React from "react";
-import { DEFAULT_BASE_IMAGES } from "./common";
 
 /**
  * according to the fetched environment, extract custom image (if any), and load it into the state `customImage`
@@ -11,6 +10,7 @@ import { DEFAULT_BASE_IMAGES } from "./common";
  */
 export const useCustomImage = (
   environment: Environment | undefined,
+  defaultImageInUse: (CustomImage & { img_src: string }) | undefined,
   orchestVersion: string | undefined
 ) => {
   const [customImage, setCustomImage] = React.useState<CustomImage>();
@@ -21,15 +21,9 @@ export const useCustomImage = (
       // This means that from the BE perspective, `orchest/base-kernel-py` means latest, equivalent to `orchest/base-kernel-py:${current_orchest_version}`.
       // User could still choose to use an older version of the Orchest default image, e.g. `orchest/base-kernel-py:v2022.05.1`.
       // Then this is considered as a custom image, because user choose to specify an image themselves, so do the other non-Orchest images.
-      const isUsingDefaultImage = DEFAULT_BASE_IMAGES.some((image) => {
-        return [
-          `${image.base_image}:${orchestVersion}`,
-          image.base_image,
-        ].includes(environment.base_image);
-      });
-      setCustomImage(!isUsingDefaultImage ? environment : undefined);
+      setCustomImage(!defaultImageInUse ? environment : undefined);
     }
-  }, [environment, customImage]);
+  }, [environment, defaultImageInUse, orchestVersion, customImage]);
 
   return [customImage, setCustomImage] as const;
 };

--- a/services/orchest-webserver/client/src/environment-edit-view/useCustomImage.tsx
+++ b/services/orchest-webserver/client/src/environment-edit-view/useCustomImage.tsx
@@ -1,0 +1,35 @@
+import type { CustomImage, Environment } from "@/types";
+import "codemirror/mode/shell/shell";
+import "codemirror/theme/dracula.css";
+import React from "react";
+import { DEFAULT_BASE_IMAGES } from "./common";
+
+/**
+ * according to the fetched environment, extract custom image (if any), and load it into the state `customImage`
+ * Note that this only occurs when `customImage` is empty; otherwise, when user selects the other default images,
+ * the custom image will disappear
+ */
+export const useCustomImage = (
+  environment: Environment | undefined,
+  orchestVersion: string | undefined
+) => {
+  const [customImage, setCustomImage] = React.useState<CustomImage>();
+
+  React.useEffect(() => {
+    if (environment && !customImage && orchestVersion) {
+      // If user choose orchest/base-kernel-py, BE will fill the latest matching version of the image, e.g. `orchest/base-kernel-py:v2022.05.3`.
+      // This means that from the BE perspective, `orchest/base-kernel-py` means latest, equivalent to `orchest/base-kernel-py:${current_orchest_version}`.
+      // User could still choose to use an older version of the Orchest default image, e.g. `orchest/base-kernel-py:v2022.05.1`.
+      // Then this is considered as a custom image, because user choose to specify an image themselves, so do the other non-Orchest images.
+      const isUsingDefaultImage = DEFAULT_BASE_IMAGES.some((image) => {
+        return [
+          `${image.base_image}:${orchestVersion}`,
+          image.base_image,
+        ].includes(environment.base_image);
+      });
+      setCustomImage(!isUsingDefaultImage ? environment : undefined);
+    }
+  }, [environment, customImage]);
+
+  return [customImage, setCustomImage] as const;
+};

--- a/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
@@ -1,3 +1,4 @@
+import { Environment } from "@/types";
 import { useFetcher } from "./useFetcher";
 
 export const useFetchEnvironment = (
@@ -6,7 +7,7 @@ export const useFetchEnvironment = (
     | undefined
 ) => {
   const { projectUuid, environmentUuid } = props || {};
-  const { data, setData, error, status, fetchData } = useFetcher(
+  const { data, setData, error, status, fetchData } = useFetcher<Environment>(
     projectUuid && environmentUuid
       ? `/store/environments/${projectUuid}/${environmentUuid}`
       : undefined

--- a/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
@@ -1,61 +1,32 @@
-import { DEFAULT_BASE_IMAGES } from "@/environment-edit-view/common";
-import { CustomImage, Environment } from "@/types";
-import { fetcher, hasValue } from "@orchest/lib-utils";
+import { useAsync } from "@/hooks/useAsync";
+import { Environment } from "@/types";
+import { fetcher } from "@orchest/lib-utils";
 import React from "react";
-import useSWR from "swr";
-import { MutatorCallback } from "swr/dist/types";
 
 export const useFetchEnvironment = (
-  initialEnvironment: Partial<Omit<Environment, "uuid" | "project_uuid">> & {
-    uuid: string | undefined;
-    project_uuid: string | undefined;
-  }
+  props:
+    | { projectUuid: string | undefined; environmentUuid: string | undefined }
+    | undefined
 ) => {
-  const { project_uuid, uuid } = initialEnvironment;
+  const { run, data, setData, error, status } = useAsync<Environment>();
 
-  const isExistingEnvironment = hasValue(project_uuid) && hasValue(uuid);
+  const { projectUuid, environmentUuid } = props || {};
 
-  const { data, error, isValidating, mutate } = useSWR<Environment>(
-    isExistingEnvironment
-      ? `/store/environments/${project_uuid}/${uuid}`
-      : null,
-    fetcher
-  );
-
-  const setEnvironment = React.useCallback(
-    (
-      data?: Environment | Promise<Environment> | MutatorCallback<Environment>
-    ) => mutate(data, false),
-    [mutate]
-  );
-
-  /**
-   * according to the fetched environment, extract custom image (if any), and load it into the state `customImage`
-   * Note that this only occurs when `customImage` is empty; otherwise, when user select other default images, the custom image will disappear
-   */
-  const [customImage, setCustomImage] = React.useState<CustomImage | undefined>(
-    undefined
-  );
+  const sendRequest = React.useCallback(() => {
+    if (!projectUuid || !environmentUuid) return;
+    const url = `/store/environments/${projectUuid}/${environmentUuid}`;
+    return run(fetcher(url));
+  }, [run, projectUuid, environmentUuid]);
 
   React.useEffect(() => {
-    if (data && uuid && !customImage) {
-      setCustomImage(
-        !DEFAULT_BASE_IMAGES.some(
-          (image) => data.base_image === image.base_image
-        )
-          ? data
-          : undefined
-      );
-    }
-  }, [data, uuid, customImage]);
+    sendRequest();
+  }, [sendRequest]);
 
   return {
     environment: data,
+    isFetchingEnvironment: status === "PENDING",
     error,
-    isFetchingEnvironment: isValidating,
-    fetchEnvironment: mutate,
-    setEnvironment,
-    customImage,
-    setCustomImage,
+    fetchEnvironment: sendRequest,
+    setEnvironment: setData,
   };
 };

--- a/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchEnvironment.ts
@@ -1,32 +1,22 @@
-import { useAsync } from "@/hooks/useAsync";
-import { Environment } from "@/types";
-import { fetcher } from "@orchest/lib-utils";
-import React from "react";
+import { useFetcher } from "./useFetcher";
 
 export const useFetchEnvironment = (
   props:
     | { projectUuid: string | undefined; environmentUuid: string | undefined }
     | undefined
 ) => {
-  const { run, data, setData, error, status } = useAsync<Environment>();
-
   const { projectUuid, environmentUuid } = props || {};
-
-  const sendRequest = React.useCallback(() => {
-    if (!projectUuid || !environmentUuid) return;
-    const url = `/store/environments/${projectUuid}/${environmentUuid}`;
-    return run(fetcher(url));
-  }, [run, projectUuid, environmentUuid]);
-
-  React.useEffect(() => {
-    sendRequest();
-  }, [sendRequest]);
+  const { data, setData, error, status, fetchData } = useFetcher(
+    projectUuid && environmentUuid
+      ? `/store/environments/${projectUuid}/${environmentUuid}`
+      : undefined
+  );
 
   return {
     environment: data,
     isFetchingEnvironment: status === "PENDING",
     error,
-    fetchEnvironment: sendRequest,
+    fetchEnvironment: fetchData,
     setEnvironment: setData,
   };
 };


### PR DESCRIPTION
## Description

This is one of the PR's that removes the usage of swr (see #973). This PR also resolves the issue: the latest version of Orchest official base image should be listed as a default option instead of a custom image.