### PR TITLE
Fix useAsync setData causing indefinite re-rendering bug

### DIFF
--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -6,6 +6,7 @@ import {
   OrchestConfig,
   OrchestServerConfig,
   OrchestUserConfig,
+  ReducerActionWithCallback,
 } from "@/types";
 import { fetcher } from "@orchest/lib-utils";
 import React from "react";
@@ -118,9 +119,7 @@ type Action =
       payload: boolean;
     };
 
-type ActionCallback = (previousState: AppContextState) => Action;
-
-type AppContextAction = Action | ActionCallback;
+type AppContextAction = ReducerActionWithCallback<AppContextState, Action>;
 
 export type AlertDispatcher = (
   title: string,

--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -1,4 +1,8 @@
-import type { PipelineMetaData, Project } from "@/types";
+import type {
+  PipelineMetaData,
+  Project,
+  ReducerActionWithCallback,
+} from "@/types";
 import React from "react";
 
 const ProjectsContext = React.createContext<IProjectsContext>(
@@ -53,8 +57,10 @@ type Action =
       payload: { uuid: string } & Partial<PipelineMetaData>;
     };
 
-type ActionCallback = (currentState: IProjectsContextState) => Action;
-export type ProjectsContextAction = Action | ActionCallback;
+export type ProjectsContextAction = ReducerActionWithCallback<
+  IProjectsContextState,
+  Action
+>;
 
 export interface IProjectsContext {
   state: IProjectsContextState;

--- a/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
@@ -1,7 +1,11 @@
 import { BUILD_IMAGE_SOLUTION_VIEW } from "@/components/BuildPendingDialog";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
-import type { IOrchestSession, IOrchestSessionUuid } from "@/types";
+import type {
+  IOrchestSession,
+  IOrchestSessionUuid,
+  ReducerActionWithCallback,
+} from "@/types";
 import { checkGate } from "@/utils/webserver-utils";
 import { fetcher, hasValue, HEADER } from "@orchest/lib-utils";
 import pascalcase from "pascalcase";
@@ -92,9 +96,10 @@ type Action =
     }
   | { type: "SET_IS_KILLING_ALL_SESSIONS"; payload: boolean };
 
-type ActionCallback = (previousState: SessionsContextState) => Action;
-
-type SessionsContextAction = Action | ActionCallback;
+type SessionsContextAction = ReducerActionWithCallback<
+  SessionsContextState,
+  Action
+>;
 
 type ToggleSessionFunction = (
   payload: IOrchestSessionUuid & {

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
@@ -5,6 +5,7 @@ import type {
   NewConnection,
   Offset,
   PipelineStepState,
+  ReducerActionWithCallback,
   Step,
   StepsDict,
 } from "@/types";
@@ -135,9 +136,9 @@ type Action =
       payload: number;
     };
 
-type ActionCallback = (previousState: EventVars) => Action | void;
-
-export type EventVarsAction = Action | ActionCallback | undefined;
+export type EventVarsAction =
+  | ReducerActionWithCallback<EventVars, Action>
+  | undefined;
 
 const DEFAULT_SCALE_FACTOR = 1;
 

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -33,6 +33,12 @@ type CommonColorScales =
   | "A400"
   | "A700";
 
+export type ExtractStringLiteralType<T, U extends T> = U;
+
+export type ReducerActionWithCallback<ReducerState, ActionType> =
+  | ActionType
+  | ((previousState: ReducerState) => ActionType);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PartialRecord<K extends keyof any, T> = {
   [P in K]?: T;


### PR DESCRIPTION
## Description

setData in useAsync depends on `data`, which will cause indefinite re-rendering if the consumer put `setData` and `data` in the deps of React.useEffect.

This PR fixes it by remove `data` from the deps of `setData`.
The type ReducerActionWithCallback is to simplify typing of this pattern.

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
