### PR TITLE
Disable opening file when the project has no pipeline

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContextMenu.tsx
@@ -91,7 +91,7 @@ export const FileManagerContextMenu: React.FC<{
 
     if (!pipelineUuid || !pipelineCwd) return;
 
-    const foundStep = Object.values(pipelineJson.steps).find((step) => {
+    const foundStep = Object.values(pipelineJson?.steps || {}).find((step) => {
       const filePath = joinRelativePaths(pipelineCwd, step.file_path);
       return filePath === cleanFilePath(contextMenuCombinedPath);
     });

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -175,6 +175,14 @@ export const FileTree = React.memo(function FileTreeComponent({
 
   const onOpen = React.useCallback(
     (filePath: string) => {
+      if (pipelines.length === 0) {
+        setAlert(
+          "Notice",
+          "In order to open a file in JupyterLab, you need to create a pipeline first."
+        );
+        return;
+      }
+
       if (isWithinDataFolder(filePath)) {
         setAlert(
           "Notice",

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/TreeRow.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/TreeRow.tsx
@@ -94,7 +94,7 @@ export const TreeRow = ({
   handleRename: (oldPath: string, newPath: string) => void;
   setDragFile: (dragFileData: { labelText: string; path: string }) => void;
   root: string;
-  hoveredPath: string;
+  hoveredPath: string | undefined;
   onOpen: (filePath: string) => void;
 }) => {
   const {


### PR DESCRIPTION
## Description

It requires at least a pipeline to open a file in JupyterLab.

Fixes: #957 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
