### PR TITLE
Fix/dont lose settings restart required state on restart

### DIFF
--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -102,7 +102,7 @@ def create_app(
 
         with app.app_context():
             settings = utils.OrchestSettings()
-            settings.save()
+            settings.save(app)
             app.config.update(settings.as_dict())
 
     # Create a background scheduler (in a daemon thread) for every
@@ -121,12 +121,12 @@ def create_app(
                 # Infinite amount of grace time, so that if a task
                 # cannot be instantly executed (e.g. if the webserver is
                 # busy) then it will eventually be.
-                "misfire_grace_time": 2 ** 31,
+                "misfire_grace_time": 2**31,
                 "coalesce": False,
                 # So that the same job can be in the queue an infinite
                 # amount of times, e.g. for concurrent requests issuing
                 # the same tasks.
-                "max_instances": 2 ** 31,
+                "max_instances": 2**31,
             },
         )
 

--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -39,6 +39,7 @@ from app.models import (
     Job,
     JupyterImageBuild,
     NonInteractivePipelineRun,
+    Setting,
 )
 from config import CONFIG_CLASS
 
@@ -315,6 +316,18 @@ def register_teardown_request(app):
         return response
 
     return app
+
+
+def register_orchest_stop():
+    app = create_app(
+        config_class=CONFIG_CLASS, use_db=True, be_scheduler=False, register_api=False
+    )
+    app.logger.info("Orchest is being stopped")
+
+    with app.app_context():
+        app.logger.info("Updating Settings.")
+        Setting.query.update(dict(requires_restart=False))
+        db.session.commit()
 
 
 def cleanup():

--- a/services/orchest-api/app/app/models.py
+++ b/services/orchest-api/app/app/models.py
@@ -64,6 +64,15 @@ class Setting(BaseModel):
     # be able to preserve types while storing 1 setting as 1 record.
     value = db.Column(JSONB, nullable=False)
 
+    # Requires Orchest to be restarted in order to apply the setting.
+    requires_restart = db.Column(
+        db.Boolean(),
+        nullable=False,
+        default=False,
+        # To migrate existing entries.
+        server_default="False",
+    )
+
 
 class SchedulerJob(BaseModel):
     """Latest run of a job assigned to a Scheduler."""

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -388,7 +388,7 @@ class OrchestSettings:
         # Flatten into regular dictionary.
         return dict(self._values)
 
-    def save(self, flask_app=None) -> Optional[List[str]]:
+    def save(self, flask_app) -> List[str]:
         """Saves the state to the database.
 
         Args:
@@ -398,7 +398,6 @@ class OrchestSettings:
                 can be updated at runtime.
 
         Returns:
-            * `None` if no `flask_app` is given.
             * List of changed config options that require an Orchest
               restart to take effect.
             * Empty list otherwise.
@@ -421,9 +420,6 @@ class OrchestSettings:
         ).delete()
 
         db.session.commit()
-
-        if flask_app is None:
-            return
 
         return self._apply_runtime_changes(flask_app, settings_as_dict)
 

--- a/services/orchest-api/app/cleanup.py
+++ b/services/orchest-api/app/cleanup.py
@@ -4,7 +4,8 @@ This is used to ensure that on Orchest start and stop the system
 remains in a consistent state and without dangling resources like pods
 or sessions.
 """
-from app import cleanup
+from app import cleanup, register_orchest_stop
 
 if __name__ == "__main__":
+    register_orchest_stop()
     cleanup()

--- a/services/orchest-api/app/migrations/versions/355762ae407e_.py
+++ b/services/orchest-api/app/migrations/versions/355762ae407e_.py
@@ -1,0 +1,28 @@
+"""Add Setting.requires_restart field
+
+Revision ID: 355762ae407e
+Revises: 063e3d096399
+Create Date: 2022-05-27 10:05:16.967270
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "355762ae407e"
+down_revision = "063e3d096399"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "settings",
+        sa.Column(
+            "requires_restart", sa.Boolean(), server_default="False", nullable=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("settings", "requires_restart")

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
@@ -90,6 +90,8 @@ func (reconciler *OrchestApiReconciler) Uninstall(ctx context.Context, component
 	}
 
 	// Get the cleanup pod
+	// Note: the cleanup logic is also taking care of registering the
+	// fact that Orchest is being stopped, see (register_orchest_stop).
 	pod, err := reconciler.Client().CoreV1().Pods(component.Namespace).Get(ctx, controller.OrchestApiCleanup, metav1.GetOptions{})
 	if err != nil && !kerrors.IsNotFound(err) {
 		return false, err


### PR DESCRIPTION
## Description

Makes it so that the fact that a setting requires a restart is persisted in the database.

Couple of things I am not too happy about:
- using the cleanup pod to register the fact that Orchest is being stopped, although I am not sure if it makes sense to explore more fleshed out solutions, i.e. doesn't seem too much of a priority
- the fact that we are using the flask app config as storage for the user Orchest settings, which seems to be only required because we are passing the flask app to the analytics module (which I am not too happy about either). This isn't something introduced by the PR but it might be a good occasion to discuss the matter and create an issue to solve it in the future

Fixes: #867 

## Checklist

- [X] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
