### PR TITLE
Allow deleting steps using the keyboard

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useEventVars.tsx
@@ -39,6 +39,7 @@ export type EventVars = {
     y2: number;
     active: boolean;
   };
+  shouldAutoFocus: boolean;
   error?: string | null;
   timestamp: number | undefined;
   subViewIndex: number;
@@ -393,6 +394,7 @@ export const useEventVars = () => {
             ...updated,
             openedStep: newStep.uuid,
             subViewIndex: 0,
+            shouldAutoFocus: true,
             ...selectSteps([newStep.uuid]),
           });
         }
@@ -424,6 +426,7 @@ export const useEventVars = () => {
           return withTimestamp({
             ...state,
             ...updated,
+            shouldAutoFocus: true,
             ...selectSteps(newSteps.map((s) => s.uuid)),
           });
         }
@@ -449,6 +452,7 @@ export const useEventVars = () => {
             ...state,
             cursorControlledStep: undefined,
             selectedSteps: [],
+            shouldAutoFocus: false,
             stepSelector: {
               x1: selectorOrigin.x,
               x2: selectorOrigin.x,
@@ -485,6 +489,7 @@ export const useEventVars = () => {
 
           return {
             ...state,
+            shouldAutoFocus: false,
             ...selectSteps(uniqueSteps),
           };
         }
@@ -704,6 +709,7 @@ export const useEventVars = () => {
     selectedConnection: null,
     timestamp: undefined,
     subViewIndex: 0,
+    shouldAutoFocus: false,
   });
 
   // this function doesn't trigger update, it simply persists clientX clientY for calculation

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
@@ -135,6 +135,7 @@ const StepDetailsComponent: React.FC<{
             <StepDetailsProperties
               pipelineCwd={pipelineCwd}
               readOnly={isReadOnly}
+              shouldAutoFocus={eventVars.shouldAutoFocus}
               onSave={onSave}
               menuMaxWidth={`${panelWidth - 48}px`}
             />

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
@@ -56,11 +56,13 @@ const KERNEL_OPTIONS = [
 export const StepDetailsProperties = ({
   pipelineCwd,
   readOnly,
+  shouldAutoFocus,
   onSave,
   menuMaxWidth,
 }: {
   pipelineCwd: string | undefined;
   readOnly: boolean;
+  shouldAutoFocus: boolean;
   onSave: (payload: Partial<Step>, uuid: string, replace?: boolean) => void;
   menuMaxWidth?: string;
 }) => {
@@ -299,7 +301,7 @@ export const StepDetailsProperties = ({
     <div className={"detail-subview"}>
       <Stack direction="column" spacing={3}>
         <TextField
-          autoFocus
+          autoFocus={shouldAutoFocus}
           value={step.title}
           onChange={(e) => onChangeTitle(e.target.value)}
           label="Title"


### PR DESCRIPTION
## Description

When user selects a step, the `Title` field is no longer auto focused to allow the delete/backspace keys to delete the step. In the case the step was just added, the `Title` field is focused so the user can start writing normally

Fixes: #556

## Checklist

- [ ] The documentation reflects the changes.
- [ ] The PR branch is set up to merge into `dev` instead of `master`.
- [ ] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [ ] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
- [ ] In case I changed code in the `orchest-cli` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md)
- [ ] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards
      compatibility is maintained.
- [ ] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update
      the corresponding `requirements.txt`.
