### PR TITLE
Fix pipeline auto-saving when deleting steps

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -344,7 +344,6 @@ export const PipelineEditor = () => {
           dispatch({ type: "SET_OPENED_STEP", payload: undefined });
           removeSteps([...eventVars.selectedSteps]);
           setIsDeletingSteps(false);
-          saveSteps(eventVars.steps);
           resolve(true);
           return true;
         },
@@ -355,33 +354,22 @@ export const PipelineEditor = () => {
         },
       });
     }
-  }, [
-    dispatch,
-    eventVars.selectedSteps,
-    eventVars.steps,
-    removeSteps,
-    saveSteps,
-    setConfirm,
-  ]);
+  }, [dispatch, eventVars.selectedSteps, removeSteps, setConfirm]);
 
   const onDetailsDelete = React.useCallback(() => {
+    setIsDeletingSteps(true);
     setConfirm("Warning", deleteStepMessage, async (resolve) => {
       if (!eventVars.openedStep) {
+        setIsDeletingSteps(false);
         resolve(false);
         return false;
       }
       removeSteps([eventVars.openedStep]);
-      saveSteps(eventVars.steps);
+      setIsDeletingSteps(false);
       resolve(true);
       return true;
     });
-  }, [
-    eventVars.openedStep,
-    eventVars.steps,
-    removeSteps,
-    saveSteps,
-    setConfirm,
-  ]);
+  }, [eventVars.openedStep, removeSteps, setConfirm]);
 
   const onOpenNotebook = React.useCallback(
     (e: React.MouseEvent) => {


### PR DESCRIPTION
## Description

This PR removes an unnecessary  request when delete steps. The second request might overwrite the changes of the first request. Although I couldn't constantly reproduce issue #1020, this bug might be the most probable cause to it.

Fixes: #1020

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [x] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
- [x] In case I changed code in the `orchest-cli` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md)
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards
      compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update
      the corresponding `requirements.txt`.
