### PR TITLE
Fix UI flickering when polling

### DIFF
--- a/services/orchest-webserver/client/src/components/DataTable.tsx
+++ b/services/orchest-webserver/client/src/components/DataTable.tsx
@@ -500,7 +500,7 @@ export const DataTable = <T extends Record<string, any>>({
 
   const { run, status, error, data, setData } = useAsync<
     DataTableFetcherResponse<T>
-  >({ caching: true });
+  >();
   const fetchData = React.useCallback(async () => {
     if (fetcher) {
       return fetcher({

--- a/services/orchest-webserver/client/src/components/DataTable.tsx
+++ b/services/orchest-webserver/client/src/components/DataTable.tsx
@@ -389,8 +389,9 @@ type DataTableProps<T> = {
     setData: (
       action:
         | DataTableFetcherResponse<T>
+        | undefined
         | ((
-            currentValue: DataTableFetcherResponse<T>
+            currentValue: DataTableFetcherResponse<T> | undefined
           ) => DataTableFetcherResponse<T>)
     ) => void,
     fetchData: () => void
@@ -519,7 +520,7 @@ export const DataTable = <T extends Record<string, any>>({
       if (current === 1) forceUpdate(); // if page is already 1, it won't trigger re-render
       return 1;
     });
-  }, [debouncedSearchTerm]);
+  }, [debouncedSearchTerm, forceUpdate]);
 
   // when user change searchTerm, page, and rowsPerPage, it should re-fetch data, however
   // if we simply subscribe to debouncedSearchTerm, page, and rowsPerPage, an extra request will occur when page !== 1 and searchTerm is changing

--- a/services/orchest-webserver/client/src/hooks/useAsync.ts
+++ b/services/orchest-webserver/client/src/hooks/useAsync.ts
@@ -8,7 +8,7 @@ export type Action<T, E = Error> = {
   type: STATUS;
   data?: T;
   error?: E;
-  caching?: boolean;
+  disableCaching?: boolean;
 };
 
 export type SetStateAction<T> =
@@ -36,7 +36,7 @@ const asyncReducer = <T, E>(
   const action = _action instanceof Function ? _action(state) : _action;
   switch (action.type) {
     case "PENDING": {
-      const payload = action.caching ? state.data : undefined;
+      const payload = action.disableCaching ? undefined : state.data;
       return { status: "PENDING", data: payload, error: undefined };
     }
     case "RESOLVED": {
@@ -57,11 +57,11 @@ const asyncReducer = <T, E>(
 
 type AsyncParams<T> = {
   initialState?: T;
-  caching?: boolean; // if true, data will not be set to null when re-fetching data
+  disableCaching?: boolean; // if true, data will be set to undefined when re-fetching data
 };
 
 const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
-  const { initialState, caching = false } = params || {};
+  const { initialState, disableCaching = false } = params || {};
   const [state, dispatch] = React.useReducer<
     (state: State<T, E>, action: AsyncReducerAction<T, E>) => State<T, E>
   >(asyncReducer, {
@@ -76,7 +76,7 @@ const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
 
   const run = React.useCallback(
     (promise: Promise<T>): Promise<T> => {
-      dispatch({ type: "PENDING", caching });
+      dispatch({ type: "PENDING", disableCaching });
       return makeCancelable(promise).then(
         (data) => {
           dispatch({ type: "RESOLVED", data });
@@ -88,7 +88,7 @@ const useAsync = <T, E = Error>(params?: AsyncParams<T> | undefined) => {
         }
       );
     },
-    [dispatch, caching, makeCancelable]
+    [dispatch, disableCaching, makeCancelable]
   );
 
   const setData: StateDispatcher<T> = React.useCallback(

--- a/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchPipelineJson.ts
@@ -95,10 +95,6 @@ export const fetchPipelineJson = (
   }>(url).then(transformResponse);
 };
 
-// `useSWR` has a unexpected behavior when cache key costantly changes.
-// Sometimes it doesn't refetch, and also doesn't update its data based on the cache key.
-// Using our custom `useAsync` could achieve most things except caching, but it gives more stability.
-
 export const useFetchPipelineJson = (
   props: FetchPipelineJsonProps | undefined
 ) => {
@@ -122,7 +118,6 @@ export const useFetchPipelineJson = (
     PipelineJson
   >(url, {
     transform: transformResponse,
-    caching: true,
     revalidateOnFocus,
   });
 

--- a/services/orchest-webserver/client/src/hooks/useFetcher.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetcher.ts
@@ -10,7 +10,7 @@ export function useFetcher<FetchedValue, Data = FetchedValue>(
     disableFetchOnMount?: boolean;
     revalidateOnFocus?: boolean;
     transform?: (data: FetchedValue) => Data | Promise<Data>;
-    caching?: boolean;
+    disableCaching?: boolean;
   }
 ) {
   const {
@@ -18,13 +18,15 @@ export function useFetcher<FetchedValue, Data = FetchedValue>(
     revalidateOnFocus = false,
     transform = (fetchedValue: FetchedValue) =>
       (fetchedValue as unknown) as Data,
-    caching = false,
+    disableCaching = false,
     ...fetchParams
   } = React.useMemo(() => {
     return params || {};
   }, [params]);
 
-  const { run, data, setData, error, status } = useAsync<Data>({ caching });
+  const { run, data, setData, error, status } = useAsync<Data>({
+    disableCaching,
+  });
 
   const transformRef = React.useRef(transform);
   React.useEffect(() => {

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -78,7 +78,6 @@ export const useSessionsPoller = () => {
       data.sessions.map((session) =>
         convertKeyToCamelCase(session, ["project_uuid", "pipeline_uuid"])
       ),
-    caching: true,
   });
 
   // We cannot poll conditionally, e.g. only poll if a session status is transitional, e.g. LAUNCHING, STOPPING

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useStepExecutionState.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useStepExecutionState.tsx
@@ -39,7 +39,6 @@ export const useStepExecutionState = (
       callback(data.status);
       return convertStepsToObject(data);
     },
-    caching: true,
   });
 
   useInterval(() => {


### PR DESCRIPTION
## Description

By default `useAsync` set `data` to `undefined` when fetching data. This causes UI flickering when polling, unless `caching` is set to `true`. Instead, it'd be easier to reverse it to `disableCaching` so that `useAsync` persists data by default. The consumer could decide to render `data` or not depending on `status`.

Fixes: #1021  

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] In case I changed one of the services’ `models.py` I have performed the appropriate database
      migrations (refer to `scripts/migration_manager.sh`).
- [x] In case I changed code in the `orchest-sdk` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md)
- [x] In case I changed code in the `orchest-cli` I followed its [release
      checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md)
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards
      compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update
      the corresponding `requirements.txt`.
