### PR TITLE
Use the position of the Context Menu as the center when zoom in & zoom out

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -831,9 +831,11 @@ export const PipelineEditor = () => {
                   // it causes issue when user press space bar to navigate the canvas
                   // thus, onPointerDown should be used here, so zoom-out only is triggered if user mouse down on the button
                   canvasFuncRef.current?.centerPipelineOrigin();
-                  dispatch({
-                    type: "SET_SCALE_FACTOR",
-                    payload: eventVars.scaleFactor - 0.25,
+                  dispatch((current) => {
+                    return {
+                      type: "SET_SCALE_FACTOR",
+                      payload: current.scaleFactor - 0.25,
+                    };
                   });
                 }}
               >
@@ -843,9 +845,11 @@ export const PipelineEditor = () => {
                 title="Zoom in"
                 onPointerDown={() => {
                   canvasFuncRef.current?.centerPipelineOrigin();
-                  dispatch({
-                    type: "SET_SCALE_FACTOR",
-                    payload: eventVars.scaleFactor + 0.25,
+                  dispatch((current) => {
+                    return {
+                      type: "SET_SCALE_FACTOR",
+                      payload: current.scaleFactor + 0.25,
+                    };
                   });
                 }}
               >

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -429,7 +429,6 @@ const PipelineStepComponent = React.forwardRef<
     cursorControlledStep,
     resetDraggingVariables,
     disabledDragging,
-    steps,
     selectedSteps,
     metadataPositions,
     detectDraggingBehavior,
@@ -477,7 +476,7 @@ const PipelineStepComponent = React.forwardRef<
       type: "item",
       title: "Duplicate",
       disabled: isReadOnly || selectionContainsNotebooks,
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ itemId }) => {
         if (itemId) {
           dispatch({ type: "DUPLICATE_STEPS", payload: [itemId] });
         }
@@ -487,7 +486,7 @@ const PipelineStepComponent = React.forwardRef<
       type: "item",
       title: "Delete",
       disabled: isReadOnly,
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ itemId }) => {
         if (itemId) {
           dispatch({ type: "REMOVE_STEPS", payload: selectedSteps });
         }
@@ -496,7 +495,7 @@ const PipelineStepComponent = React.forwardRef<
     {
       type: "item",
       title: "Properties",
-      action: (e: React.MouseEvent, _itemId?: string) => {
+      action: () => {
         dispatch({ type: "SELECT_SUB_VIEW", payload: 0 });
       },
     },
@@ -504,19 +503,19 @@ const PipelineStepComponent = React.forwardRef<
       type: "item",
       title: "Open in JupyterLab",
       disabled: isReadOnly,
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ event, itemId }) => {
         if (itemId) {
           dispatch({ type: "SET_OPENED_STEP", payload: itemId });
-          onOpenNotebook(e);
+          onOpenNotebook(event);
         }
       },
     },
     {
       type: "item",
       title: "Open in File Viewer",
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ event, itemId }) => {
         if (itemId) {
-          onOpenFilePreviewView(e, itemId);
+          onOpenFilePreviewView(event, itemId);
         }
       },
     },
@@ -527,7 +526,7 @@ const PipelineStepComponent = React.forwardRef<
       type: "item",
       title: "Run this step",
       disabled: isReadOnly,
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ itemId }) => {
         if (itemId) {
           executeRun([itemId], "selection");
         }
@@ -537,7 +536,7 @@ const PipelineStepComponent = React.forwardRef<
       type: "item",
       title: "Run incoming",
       disabled: isReadOnly,
-      action: (e: React.MouseEvent, itemId?: string) => {
+      action: ({ itemId }) => {
         if (itemId) {
           executeRun([itemId], "incoming");
         }

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
@@ -1,3 +1,4 @@
+import { Position } from "@/types";
 import Divider from "@mui/material/Divider";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
@@ -7,7 +8,11 @@ type MenuItemAction = {
   type: "item";
   title: string;
   disabled?: boolean;
-  action: (e: React.MouseEvent, itemId?: string) => void;
+  action: (props: {
+    event: React.MouseEvent;
+    itemId?: string;
+    contextMenuPosition: Position;
+  }) => void;
 };
 
 type MenuItemSeparator = {
@@ -28,12 +33,16 @@ export function useContextMenu(
 
   const [contextMenuIsOpen, setContextMenuIsOpen] = contextMenuState;
 
-  const handleClicked = (e: React.MouseEvent, item: MenuItemAction) => {
+  const handleClicked = (event: React.MouseEvent, item: MenuItemAction) => {
     if (contextMenu === null) {
       return;
     }
 
-    item.action(e, itemId);
+    item.action({
+      event,
+      itemId,
+      contextMenuPosition: { x: contextMenu.mouseX, y: contextMenu.mouseY },
+    });
     handleClose();
   };
 

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -273,7 +273,7 @@ export const PipelineViewport = React.forwardRef<
     };
   }, [pipelineSetHolderSize]);
 
-  useGestureOnViewport(localRef, pipelineSetHolderOrigin);
+  const zoom = useGestureOnViewport(localRef, pipelineSetHolderOrigin);
 
   const menuItems: MenuItem[] = [
     {
@@ -329,21 +329,15 @@ export const PipelineViewport = React.forwardRef<
     {
       type: "item",
       title: "Zoom in",
-      action: () => {
-        dispatch({
-          type: "SET_SCALE_FACTOR",
-          payload: eventVars.scaleFactor + 0.25,
-        });
+      action: ({ contextMenuPosition }) => {
+        zoom(contextMenuPosition, 0.25);
       },
     },
     {
       type: "item",
       title: "Zoom out",
-      action: () => {
-        dispatch({
-          type: "SET_SCALE_FACTOR",
-          payload: eventVars.scaleFactor - 0.25,
-        });
+      action: ({ contextMenuPosition }) => {
+        zoom(contextMenuPosition, -0.25);
       },
     },
   ];

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
@@ -120,10 +120,15 @@ export const useGestureOnViewport = (
           ],
         }));
       },
-      onPinch: ({ pinching, delta, event }) => {
+      onPinch: ({ pinching, delta: [delta], event, velocity: [velocity] }) => {
         if (disabled || !pinching) return;
+        // `delta` value jumps from time to time (i.e. super big or super small).
+        // We limit its range to ensure consistent zooming speed.
         const { clientX, clientY } = event as WheelEvent;
-        zoom({ x: clientX, y: clientY }, delta[0] / 12);
+        zoom(
+          { x: clientX, y: clientY },
+          Math.min(Math.max(velocity, 0.02), 0.06) * (delta < 0 ? -1 : 1)
+        );
       },
     },
     {

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/useGestureOnViewport.tsx
@@ -1,3 +1,4 @@
+import { Position } from "@/types";
 import { getOffset } from "@/utils/jquery-replacement";
 import { createUseGesture, pinchAction, wheelAction } from "@use-gesture/react";
 import React from "react";
@@ -7,7 +8,7 @@ import { usePipelineEditorContext } from "../contexts/PipelineEditorContext";
 
 const useGesture = createUseGesture([wheelAction, pinchAction]);
 
-const isTrachpad = (event: WheelEvent) => {
+const isTouchpad = (event: WheelEvent) => {
   // deltaMode represents the unit of the delta values scroll amount
   // 0: pixel; 1: line; 2: page
   if (!event.wheelDeltaY && event.deltaMode === 0) return true;
@@ -42,23 +43,16 @@ export const useGestureOnViewport = (
   } = usePipelineCanvasContext();
 
   const getPositionRelativeToCanvas = React.useCallback(
-    ([x, y]: [number, number]) => {
+    ({ x, y }: Position): Position => {
       trackMouseMovement(x, y); // in case that user start zoom-in/out before moving their cursor
       let canvasOffset = getOffset(pipelineCanvasRef.current);
 
-      return [
-        scaleCorrected(x - canvasOffset.left, eventVars.scaleFactor),
-        scaleCorrected(y - canvasOffset.top, eventVars.scaleFactor),
-      ] as [number, number];
+      return {
+        x: scaleCorrected(x - canvasOffset.left, eventVars.scaleFactor),
+        y: scaleCorrected(y - canvasOffset.top, eventVars.scaleFactor),
+      };
     },
     [pipelineCanvasRef, eventVars.scaleFactor, trackMouseMovement]
-  );
-
-  const getMousePositionRelativeToCanvas = React.useCallback(
-    (e: WheelEvent | React.WheelEvent) => {
-      return getPositionRelativeToCanvas([e.clientX, e.clientY]);
-    },
-    [getPositionRelativeToCanvas]
   );
 
   React.useEffect(() => {
@@ -74,18 +68,13 @@ export const useGestureOnViewport = (
   }, []);
 
   const zoom = React.useCallback(
-    (event: WheelEvent | PointerEvent | TouchEvent, scaleDiff: number) => {
+    (mousePosition: Position, scaleDiff: number) => {
       if (disabled) return;
-      let pipelineMousePosition = getMousePositionRelativeToCanvas(
-        event as WheelEvent
-      );
 
+      const { x, y } = getPositionRelativeToCanvas(mousePosition);
       // set origin at scroll wheel trigger
-      if (
-        pipelineMousePosition[0] !== pipelineOrigin[0] ||
-        pipelineMousePosition[1] !== pipelineOrigin[1]
-      ) {
-        pipelineSetHolderOrigin(pipelineMousePosition);
+      if (x !== pipelineOrigin[0] || y !== pipelineOrigin[1]) {
+        pipelineSetHolderOrigin([x, y]);
       }
 
       dispatch((current) => {
@@ -98,20 +87,28 @@ export const useGestureOnViewport = (
     [
       disabled,
       dispatch,
-      getMousePositionRelativeToCanvas,
       pipelineOrigin,
+      getPositionRelativeToCanvas,
       pipelineSetHolderOrigin,
     ]
   );
 
   useGesture(
     {
-      onWheel: ({ pinching, wheeling, delta: [deltaX, deltaY], event }) => {
+      onWheel: ({
+        pinching,
+        first,
+        wheeling,
+        delta: [deltaX, deltaY],
+        event,
+      }) => {
         if (disabled || pinching || !wheeling) return;
 
         // mouse wheel
-        if (!isTrachpad(event)) {
-          zoom(event, -deltaY / 3000);
+        // Weird behavior: `!isTouchpad(event)` is true whenever the pinching direction changes
+        // Exclude it when `first` is true.
+        if (!first && !isTouchpad(event)) {
+          zoom({ x: event.clientX, y: event.clientY }, -deltaY / 2048);
           return;
         }
 
@@ -125,7 +122,8 @@ export const useGestureOnViewport = (
       },
       onPinch: ({ pinching, delta, event }) => {
         if (disabled || !pinching) return;
-        zoom(event, delta[0] / 12);
+        const { clientX, clientY } = event as WheelEvent;
+        zoom({ x: clientX, y: clientY }, delta[0] / 12);
       },
     },
     {
@@ -134,4 +132,6 @@ export const useGestureOnViewport = (
       eventOptions: { passive: false, capture: true },
     }
   );
+
+  return zoom;
 };


### PR DESCRIPTION
## Description

Currently, `Zoom in` and `Zoom out` in the Context Menu assume the center point of the canvas as the center. 
This PR makes it so that it will zoom in/out precisely with the position of the Context Menu. 

<img width="918" alt="Screenshot 2022-06-07 at 17 43 39" src="https://user-images.githubusercontent.com/627607/172425297-c5a5cc7b-025a-4110-b009-0d11060bb82e.png">

This PR also fixes another minor issue:
When zoom in/out with pinching, the speed of zoom in/out is consistent; sometimes it becomes faster and faster (or slower and slower). This PR makes it consistent and smooth.

## Checklist


- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
