### PR TITLE
Fixed a formatting error in `docs/fundamentals/projects.rst`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ An example badge to import our [quickstart](https://github.com/orchest/quickstar
 <a href="https://github.com/nhaghighat"><img src="https://avatars.githubusercontent.com/u/3792293?v=4" title="nhaghighat" width="50" height="50"></a>
 <a href="https://github.com/porcupineyhairs"><img src="https://avatars.githubusercontent.com/u/61983466?v=4" title="porcupineyhairs" width="50" height="50"></a>
 <a href="https://github.com/ncspost"><img src="https://avatars.githubusercontent.com/ncspost?v=4" title="ncspost" width="50" height="50"></a>
+<a href="https://github.com/cavriends"><img src="https://avatars.githubusercontent.com/u/4497501?v=4" title="cavriends" width="50" height="50"></a>

--- a/docs/source/fundamentals/projects.rst
+++ b/docs/source/fundamentals/projects.rst
@@ -26,6 +26,7 @@ You can access Project files in your code running inside :ref:`environments <env
 Getting started
 ---------------
 You can get started with Projects by:
+
 * Creating a new project
 * Importing an existing project using its git repository URL (see :ref:`how to import a project <how to import a project>`).
 * Importing Orchest curated or community contributed examples.


### PR DESCRIPTION
## Description

I was reading the documentation and encountered an incorrectly rendered bullet list. It's solved by adding a single space. As it's such a small change, feel free to close the PR and add it yourselves. I've build the docs locally to verify if the change is truly a fix.

Fixes: NA 

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [ ] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [ ] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [ ] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [ ] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
