### PR TITLE
Docs: enable `sphinx-hoverxref` on all references

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 sphinx_press_theme
 myst-parser
-docutils==0.16
+docutils
 sphinx-hoverxref==1.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 sphinx_press_theme
 myst-parser
-docutils
+docutils==0.16
 sphinx-hoverxref==1.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx_press_theme
 myst-parser
 docutils==0.16
+sphinx-hoverxref==1.1.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,10 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "hoverxref.extension",
 ]
+
+hoverxref_auto_ref = True
 
 myst_enable_extensions = [
     "deflist",


### PR DESCRIPTION
## Description

This is a continuation of the work from #1039 since it was reported that there were some tooltips that were showing empty content.

This commit will enable hoverxref on all the references of the documentation so we can debug it deeply and understand why there some cases where the content comes empty.

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [ ] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
