### PR TITLE
Add more commands to Command Palette

### DIFF
--- a/services/orchest-webserver/client/src/components/CommandPalette.tsx
+++ b/services/orchest-webserver/client/src/components/CommandPalette.tsx
@@ -27,20 +27,14 @@ type Command = {
   };
 };
 
-function fetchObjects<T>(path: string, attribute?: string) {
-  return new Promise<T[]>((resolve, reject) => {
-    fetcher<Record<string, T[]> | T[]>(path)
-      .then((response) => {
-        resolve(attribute ? response[attribute] : response);
-      })
-      .catch((e) => {
-        console.error(e);
-        reject([]);
-      })
-      .finally(() => {
-        resolve([]);
-      });
-  });
+async function fetchObjects<T>(path: string, attribute?: string): Promise<T[]> {
+  try {
+    const response = await fetcher<Record<string, T[]> | T[]>(path);
+    return attribute ? response[attribute] : response;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
 }
 
 const fetchPipelines = () => {
@@ -131,13 +125,27 @@ const commandsFromProject = (project: Project): Command => {
     action: "openList",
     children: [
       {
-        title: "Project settings: " + project.path,
+        title: `Project settings: ${project.path}`,
         action: "openPage",
         data: {
           path: siteMap.projectSettings.path,
-          query: {
-            projectUuid: project.uuid,
-          },
+          query: { projectUuid: project.uuid },
+        },
+      },
+      {
+        title: `Jobs: ${project.path}`,
+        action: "openPage",
+        data: {
+          path: siteMap.jobs.path,
+          query: { projectUuid: project.uuid },
+        },
+      },
+      {
+        title: `Environments: ${project.path}`,
+        action: "openPage",
+        data: {
+          path: siteMap.environments.path,
+          query: { projectUuid: project.uuid },
         },
       },
     ],

--- a/services/orchest-webserver/client/src/components/CommandPalette.tsx
+++ b/services/orchest-webserver/client/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useHotKeys } from "@/hooks/useHotKeys";
-import { pageCommands, siteMap } from "@/routingConfig";
+import { getPageCommands, siteMap } from "@/routingConfig";
 import { Job, Project } from "@/types";
 import Box from "@mui/material/Box";
 import LinearProgress from "@mui/material/LinearProgress";
@@ -181,7 +181,7 @@ const isVisible = (el: HTMLLIElement, holder: HTMLDivElement) => {
 
 export const CommandPalette: React.FC = () => {
   // global states
-  const { navigateTo } = useCustomRoute();
+  const { navigateTo, projectUuid } = useCustomRoute();
 
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -233,7 +233,7 @@ export const CommandPalette: React.FC = () => {
       ]);
 
       setCommands([
-        ...pageCommands,
+        ...getPageCommands(projectUuid),
         ...projectCommands.list,
         ...pipelineCommands,
         ...jobCommands,
@@ -243,7 +243,7 @@ export const CommandPalette: React.FC = () => {
       // handle failure silently because this is done in the background
       console.error(`Failed to fetch for command palette: ${error}`);
     }
-  }, []);
+  }, [projectUuid]);
 
   const onQueryChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>

--- a/services/orchest-webserver/client/src/hooks/useMatchProjectRoot.ts
+++ b/services/orchest-webserver/client/src/hooks/useMatchProjectRoot.ts
@@ -3,7 +3,7 @@ import React from "react";
 import { matchPath } from "react-router-dom";
 import { useHistoryListener } from "./useCustomRoute";
 
-const findRouteMatch = (routes: Pick<RouteData, "path" | "root">[]) => {
+export const findRouteMatch = (routes: Pick<RouteData, "path" | "root">[]) => {
   for (const route of routes) {
     const match = matchPath(window.location.pathname, {
       path: route.path,

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -1,3 +1,5 @@
+import { findRouteMatch } from "./hooks/useMatchProjectRoot";
+
 export type RouteName =
   | "projects"
   | "examples"
@@ -249,12 +251,20 @@ const excludedPaths = [
 ];
 
 // used in CommandPalette
-export const pageCommands = getOrderedRoutes((title: string) => title)
-  .filter((route) => !excludedPaths.includes(route.path))
-  .map((route) => {
-    return {
-      title: "Page: " + route.title,
-      action: "openPage",
-      data: { path: route.path, query: {} },
-    };
-  });
+export const getPageCommands = (projectUuid: string | undefined) =>
+  getOrderedRoutes((title: string) => title)
+    .filter((route) => !excludedPaths.includes(route.path))
+    .map((route) => {
+      const match = findRouteMatch(withinProjectPaths);
+      const query: Record<string, string> =
+        match && projectUuid ? { projectUuid } : {};
+
+      return {
+        title: `Page: ${route.title}`,
+        action: "openPage",
+        data: {
+          path: route.path,
+          query,
+        },
+      };
+    });


### PR DESCRIPTION
## Description

This PR adds opening "Environments" and "Jobs" per project in the Command Palette. And also fix a minor bug: when user is viewing Environments of a project (i.e. `/environments?project_uuid=12345`), the page commands `Page: Environments` and `Page:Jobs` should open environments and jobs for project `12345` (currently it's broken because `project_uuid` is not passed into the command).

Fixes: #573 

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
