### PR TITLE
Extract PipelineEditorContextMenu from useContextMenu

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -226,8 +226,6 @@ export const PipelineViewport = React.forwardRef<
       }
 
       if (dragFile) onDropFiles();
-    } else {
-      console.log("Right click");
     }
   };
 

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -16,7 +16,11 @@ import { usePipelineCanvasContext } from "../contexts/PipelineCanvasContext";
 import { usePipelineEditorContext } from "../contexts/PipelineEditorContext";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "../file-manager/useValidateFilesOnSteps";
-import { MenuItem, useContextMenu } from "../hooks/useContextMenu";
+import {
+  ContextMenuItem,
+  PipelineEditorContextMenu,
+  useContextMenu,
+} from "../hooks/useContextMenu";
 import { RunStepsType } from "../hooks/useInteractiveRuns";
 import { INITIAL_PIPELINE_POSITION } from "../hooks/usePipelineCanvasState";
 import { STEP_HEIGHT, STEP_WIDTH } from "../PipelineStep";
@@ -275,7 +279,7 @@ export const PipelineViewport = React.forwardRef<
 
   const zoom = useGestureOnViewport(localRef, pipelineSetHolderOrigin);
 
-  const menuItems: MenuItem[] = [
+  const menuItems: ContextMenuItem[] = [
     {
       type: "item",
       title: "Create new step",
@@ -329,23 +333,20 @@ export const PipelineViewport = React.forwardRef<
     {
       type: "item",
       title: "Zoom in",
-      action: ({ contextMenuPosition }) => {
-        zoom(contextMenuPosition, 0.25);
+      action: ({ position }) => {
+        zoom(position, 0.25);
       },
     },
     {
       type: "item",
       title: "Zoom out",
-      action: ({ contextMenuPosition }) => {
-        zoom(contextMenuPosition, -0.25);
+      action: ({ position }) => {
+        zoom(position, -0.25);
       },
     },
   ];
 
-  const { handleContextMenu, menu } = useContextMenu(
-    menuItems,
-    isContextMenuOpenState
-  );
+  const { handleContextMenu, ...contextMenuProps } = useContextMenu();
 
   return (
     <div
@@ -421,7 +422,10 @@ export const PipelineViewport = React.forwardRef<
       >
         {disabled && <Overlay />}
         {children}
-        {menu}
+        <PipelineEditorContextMenu
+          {...contextMenuProps}
+          menuItems={menuItems}
+        />
       </PipelineCanvas>
     </div>
   );


### PR DESCRIPTION
## Description

Extract PipelineEditorContextMenu from the hook, so that the hook only contains states, easier for unit testing.

Also some minor improvements:
- remove unnecessary state `contextMenuIsOpen` because context menu only requires `position`.
- remove `itemId` from the args of `ContextMenuItemAction`. Because itemId is contextual (e.g. stepUuid in PipelineStep), it should be part of implementation of the action function of menuItems, but not part of the args of the action function.

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
