### PR TITLE
Celery worker queries `orchest-api` for parallelism setting on start

### DIFF
--- a/services/orchest-api/Dockerfile_celery
+++ b/services/orchest-api/Dockerfile_celery
@@ -3,7 +3,7 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Needed to daemonize celery workers.
 RUN apt-get update \
-     && apt-get install -y supervisor rsync netcat \
+     && apt-get install -y supervisor rsync netcat jq curl \
      && mkdir -p /var/log/supervisor
 
 # Get all requirements in place.
@@ -30,9 +30,11 @@ COPY celery_daemon_configs/worker_builds.conf \
 # To be consistent with the other services.
 WORKDIR /orchest/services/orchest-api/app/
 
+COPY ./start_celery_daemon.sh /
+
 ARG ORCHEST_VERSION
 ENV ORCHEST_VERSION=${ORCHEST_VERSION}
 # -n to run in the foreground, -m is the umask of the supervisord
 # process, the umask needs to be setup for each child/service process.
 # -u 0 is to run as root.
-ENTRYPOINT ["/usr/bin/supervisord", "-n", "-m 002", "-u 0"]
+ENTRYPOINT ["/start_celery_daemon.sh"]

--- a/services/orchest-api/start_celery_daemon.sh
+++ b/services/orchest-api/start_celery_daemon.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+JP=$(curl http://orchest-api/api/ctl/orchest-settings -s | jq -r .MAX_JOB_RUNS_PARALLELISM)
+IP=$(curl http://orchest-api/api/ctl/orchest-settings -s | jq -r .MAX_INTERACTIVE_RUNS_PARALLELISM)
+
+MAX_JOB_RUNS_PARALLELISM="${JP}" \
+MAX_INTERACTIVE_RUNS_PARALLELISM="${IP}" \
+/usr/bin/supervisord -n -m 002 -u 0

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -104,10 +104,8 @@ func NewDefaultControllerConfig() ControllerConfig {
 			"FLASK_ENV": "production",
 		},
 		CeleryWorkerDefaultEnvVars: map[string]string{
-			"ORCHEST_GPU_ENABLED_INSTANCE":     "FALSE",
-			"FLASK_ENV":                        "production",
-			"MAX_JOB_RUNS_PARALLELISM":         "1",
-			"MAX_INTERACTIVE_RUNS_PARALLELISM": "1",
+			"ORCHEST_GPU_ENABLED_INSTANCE": "FALSE",
+			"FLASK_ENV":                    "production",
 		},
 		OrchestDatabaseDefaultEnvVars: map[string]string{
 			"PGDATA":                    "/userdir/.orchest/database/data",


### PR DESCRIPTION
## Description

Fixes a bug where the job and interactive runs parallelism level wouldn't be applied to the celery-worker. 