### PR TITLE
Keep track of pipeline runs creation time at the database level

### DIFF
--- a/services/orchest-api/app/app/models/_core.py
+++ b/services/orchest-api/app/app/models/_core.py
@@ -8,6 +8,7 @@ TODO:
 
 """
 import copy
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 from sqlalchemy import (
@@ -679,6 +680,15 @@ class PipelineRun(BaseModel):
     pipeline_uuid = db.Column(db.String(36), index=True, unique=False, nullable=False)
     uuid = db.Column(db.String(36), primary_key=True)
     status = db.Column(db.String(15), unique=False, nullable=True)
+    created_time = db.Column(
+        db.DateTime,
+        unique=False,
+        nullable=False,
+        index=True,
+        default=datetime.now(timezone.utc),
+        # To migrate existing entries.
+        server_default=text("timezone('utc', now())"),
+    )
     started_time = db.Column(db.DateTime, unique=False, nullable=True)
     finished_time = db.Column(db.DateTime, unique=False, nullable=True)
     type = db.Column(db.String(50))

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -315,6 +315,9 @@ pipeline_run = Model(
         "project_uuid": fields.String(required=True, description="UUID of project"),
         "pipeline_uuid": fields.String(required=True, description="UUID of pipeline"),
         "status": fields.String(required=True, description="Status of the run"),
+        "created_time": fields.String(
+            required=True, description="Time at which the pipeline run was created"
+        ),
         "started_time": fields.String(
             required=True, description="Time at which the pipeline started executing"
         ),

--- a/services/orchest-api/app/migrations/versions/3433a9040ff4_.py
+++ b/services/orchest-api/app/migrations/versions/3433a9040ff4_.py
@@ -1,0 +1,38 @@
+"""Add pipeline_runs.created_time
+
+Revision ID: 3433a9040ff4
+Revises: 1b1938d5587a
+Create Date: 2022-06-27 08:46:15.127876
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3433a9040ff4"
+down_revision = "1b1938d5587a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pipeline_runs",
+        sa.Column(
+            "created_time",
+            sa.DateTime(),
+            server_default=sa.text("timezone('utc', now())"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        op.f("ix_pipeline_runs_created_time"),
+        "pipeline_runs",
+        ["created_time"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_pipeline_runs_created_time"), table_name="pipeline_runs")
+    op.drop_column("pipeline_runs", "created_time")


### PR DESCRIPTION
## Description

A minor improvement to improve debugging


## Checklist

- [X] The PR branch is set up to merge into `dev` instead of `master`.
- [X] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [X] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
