### PR TITLE
Add "Not exposed" status in the services dropdown

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
@@ -5,13 +5,13 @@ import { getServiceURLs } from "@/utils/webserver-utils";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import TuneIcon from "@mui/icons-material/Tune";
 import Divider from "@mui/material/Divider";
-import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import ListSubheader from "@mui/material/ListSubheader";
 import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import MenuList from "@mui/material/MenuList";
 import Typography from "@mui/material/Typography";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
@@ -79,6 +79,7 @@ export const ServicesMenu = ({
       open={isOpen}
       onClose={onClose}
       MenuListProps={{
+        dense: true,
         "aria-labelledby": "running-services-button",
       }}
       anchorOrigin={{
@@ -90,15 +91,14 @@ export const ServicesMenu = ({
         horizontal: "center",
       }}
     >
-      <ListItem>
-        <Typography
-          variant="subtitle1"
-          component="h3"
-          sx={{ paddingBottom: 0 }}
-        >
-          Running services
-        </Typography>
-      </ListItem>
+      <ListSubheader
+        sx={{
+          color: (theme) => theme.palette.common.black,
+          margin: (theme) => theme.spacing(0.5, 0, -1.5),
+        }}
+      >
+        Running services
+      </ListSubheader>
       {serviceLinks && serviceLinks.length > 0 ? (
         serviceLinks.map((serviceLink) => {
           const serviceStatusMessage = !serviceLink.exposed
@@ -107,22 +107,23 @@ export const ServicesMenu = ({
             ? `No endpoints.`
             : null;
           return (
-            <List
+            <MenuList
+              dense
               key={serviceLink.name}
               subheader={<ListSubheader>{serviceLink.name}</ListSubheader>}
             >
               {serviceStatusMessage && (
-                <ListItem>
-                  <Typography variant="caption">
-                    <i>{serviceStatusMessage}</i>
+                <MenuItem disabled sx={{ opacity: `0.8 !important` }}>
+                  <Typography variant="caption" sx={{ fontStyle: "italic" }}>
+                    {serviceStatusMessage}
                   </Typography>
-                </ListItem>
+                </MenuItem>
               )}
 
               {serviceLink.exposed &&
                 serviceLink.urls.map((url) => {
                   return (
-                    <ListItemButton
+                    <MenuItem
                       key={url}
                       component="a"
                       href={url}
@@ -130,13 +131,13 @@ export const ServicesMenu = ({
                       rel="noreferrer"
                     >
                       <ListItemIcon>
-                        <OpenInNewIcon />
+                        <OpenInNewIcon fontSize="small" />
                       </ListItemIcon>
-                      <ListItemText primary={formatUrl(url)} />
-                    </ListItemButton>
+                      <ListItemText>{formatUrl(url)}</ListItemText>
+                    </MenuItem>
                   );
                 })}
-            </List>
+            </MenuList>
           );
         })
       ) : (
@@ -145,14 +146,16 @@ export const ServicesMenu = ({
         </ListItem>
       )}
       <Divider />
-      <List>
-        <ListItemButton onClick={openSettings} onAuxClick={openSettings}>
+      <MenuList dense>
+        <MenuItem onClick={openSettings} onAuxClick={openSettings}>
           <ListItemIcon>
-            <TuneIcon />
+            <TuneIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText primary={`${!isReadOnly ? "Edit" : "View"} services`} />
-        </ListItemButton>
-      </List>
+          <ListItemText>{`${
+            !isReadOnly ? "Edit" : "View"
+          } services`}</ListItemText>
+        </MenuItem>
+      </MenuList>
     </Menu>
   );
 };

--- a/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ServicesMenu.tsx
@@ -63,14 +63,13 @@ export const ServicesMenu = ({
 
   const serviceLinks =
     services && projectUuid && pipelineUuid
-      ? Object.entries(services)
-          .filter((serviceTuple) => serviceTuple[1].exposed)
-          .map(([serviceName, service]) => {
-            return {
-              name: serviceName,
-              urls: getServiceURLs(service, projectUuid, pipelineUuid, runUuid),
-            };
-          })
+      ? Object.entries(services).map(([serviceName, service]) => {
+          return {
+            name: serviceName,
+            urls: getServiceURLs(service, projectUuid, pipelineUuid, runUuid),
+            exposed: service.exposed,
+          };
+        })
       : null;
 
   return (
@@ -102,34 +101,41 @@ export const ServicesMenu = ({
       </ListItem>
       {serviceLinks && serviceLinks.length > 0 ? (
         serviceLinks.map((serviceLink) => {
+          const serviceStatusMessage = !serviceLink.exposed
+            ? `Not exposed.`
+            : serviceLink.urls.length === 0
+            ? `No endpoints.`
+            : null;
           return (
             <List
               key={serviceLink.name}
               subheader={<ListSubheader>{serviceLink.name}</ListSubheader>}
             >
-              {serviceLink.urls.length === 0 && (
+              {serviceStatusMessage && (
                 <ListItem>
                   <Typography variant="caption">
-                    <i>This service has no endpoints.</i>
+                    <i>{serviceStatusMessage}</i>
                   </Typography>
                 </ListItem>
               )}
-              {serviceLink.urls.map((url) => {
-                return (
-                  <ListItemButton
-                    key={url}
-                    component="a"
-                    href={url}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <ListItemIcon>
-                      <OpenInNewIcon />
-                    </ListItemIcon>
-                    <ListItemText primary={formatUrl(url)} />
-                  </ListItemButton>
-                );
-              })}
+
+              {serviceLink.exposed &&
+                serviceLink.urls.map((url) => {
+                  return (
+                    <ListItemButton
+                      key={url}
+                      component="a"
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <ListItemIcon>
+                        <OpenInNewIcon />
+                      </ListItemIcon>
+                      <ListItemText primary={formatUrl(url)} />
+                    </ListItemButton>
+                  );
+                })}
             </List>
           );
         })


### PR DESCRIPTION
## Description

Show the running services that are exposed in the Services dropdown to improve clarity.

Fixes: #1070 

## Checklist

- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
