### PR TITLE
Periodically cleanup builder cache

### DIFF
--- a/services/orchest-api/app/app/core/scheduler.py
+++ b/services/orchest-api/app/app/core/scheduler.py
@@ -145,7 +145,7 @@ class Jobs:
 
     def handle_cleanup_builder_cache(self, app: Flask, interval: int = 0) -> None:
         """Handles cleaning up the builder cache."""
-        interval = max(app.config["IMAGES_DELETION_INTERVAL"], interval)
+        interval = max(app.config["CLEANUP_BUILDER_CACHE_INTERVAL"], interval)
         return self._handle_recurring_scheduler_job(
             SchedulerJobType.CLEANUP_BUILDER_CACHE.value,
             interval,

--- a/services/orchest-api/app/app/core/scheduler.py
+++ b/services/orchest-api/app/app/core/scheduler.py
@@ -28,9 +28,10 @@ logger = logging.getLogger("job-scheduler")
 
 
 class SchedulerJobType(enum.Enum):
-    SCHEDULE_JOB_RUNS = "SCHEDULE_JOB_RUNS"
+    CLEANUP_BUILDER_CACHE = "CLEANUP_BUILDER_CACHE"
     PROCESS_IMAGES_FOR_DELETION = "PROCESS_IMAGES_FOR_DELETION"
     PROCESS_NOTIFICATIONS_DELIVERIES = "PROCESS_NOTIFICATIONS_DELIVERIES"
+    SCHEDULE_JOB_RUNS = "SCHEDULE_JOB_RUNS"
 
 
 def add_recurring_jobs_to_scheduler(
@@ -49,6 +50,16 @@ def add_recurring_jobs_to_scheduler(
     """
     jobs = Jobs()
     recurring_jobs = {
+        "cleanup builder cache": {
+            "allowed_to_run": True,
+            # For jobs with a long period rely on the DB instead of the
+            # internal scheduler given that the pod might restart and
+            # the progress through the interval would get lost. In this
+            # particular case the real interval is in days, and is
+            # handled by handle_cleanup_builder_cache.
+            "interval": 3600,
+            "job_func": jobs.handle_cleanup_builder_cache,
+        },
         "schedule job runs": {
             "allowed_to_run": True,
             "interval": app.config["SCHEDULER_INTERVAL"],
@@ -129,6 +140,16 @@ class Jobs:
             SchedulerJobType.PROCESS_NOTIFICATIONS_DELIVERIES.value,
             interval,
             process_notification_deliveries,
+            app,
+        )
+
+    def handle_cleanup_builder_cache(self, app: Flask, interval: int = 0) -> None:
+        """Handles cleaning up the builder cache."""
+        interval = max(app.config["IMAGES_DELETION_INTERVAL"], interval)
+        return self._handle_recurring_scheduler_job(
+            SchedulerJobType.CLEANUP_BUILDER_CACHE.value,
+            interval,
+            cleanup_builder_cache,
             app,
         )
 
@@ -362,4 +383,12 @@ def process_notification_deliveries(app) -> None:
         app.logger.debug("Sending process notifications deliveries task.")
         celery = make_celery(app)
         res = celery.send_task(name="app.core.tasks.process_notifications_deliveries")
+        res.forget()
+
+
+def cleanup_builder_cache(app) -> None:
+    with app.app_context():
+        app.logger.debug("Sending cleanup builder cache task.")
+        celery = make_celery(app)
+        res = celery.send_task(name="app.core.tasks.cleanup_builder_cache")
         res.forget()

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -17,7 +17,7 @@ from app import errors as self_errors
 from app import utils
 from app.celery_app import make_celery
 from app.connections import k8s_custom_obj_api
-from app.core import environments, notifications, registry
+from app.core import environments, image_utils, notifications, registry
 from app.core.environment_image_builds import build_environment_image_task
 from app.core.jupyter_image_builds import build_jupyter_image_task
 from app.core.pipelines import Pipeline, run_pipeline_workflow
@@ -365,3 +365,9 @@ def process_notifications_deliveries(self):
     with application.app_context():
         notifications.process_notifications_deliveries_task()
     return "SUCCESS"
+
+
+@celery.task(bind=True, base=AbortableTask)
+def cleanup_builder_cache(self):
+    with application.app_context():
+        image_utils.cleanup_builder_cache()

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -28,6 +28,7 @@ class Config:
     SCHEDULER_INTERVAL = 10
     # Same as above, but for image deletion and GC.
     IMAGES_DELETION_INTERVAL = 120
+    CLEANUP_BUILDER_CACHE_INTERVAL = 3600 * 24 * 7
     NOTIFICATIONS_DELIVERIES_INTERVAL = 1
 
     GPU_ENABLED_INSTANCE = _config.GPU_ENABLED_INSTANCE
@@ -74,6 +75,7 @@ class Config:
         "app.core.tasks.start_non_interactive_pipeline_run": {"queue": "jobs"},
         "app.core.tasks.delete_job_pipeline_run_directories": {"queue": "jobs"},
         "app.core.tasks.run_pipeline": {"queue": "celery"},
+        "app.core.tasks.cleanup_builder_cache": {"queue": "builds"},
         "app.core.tasks.build_environment_image": {"queue": "builds"},
         "app.core.tasks.build_jupyter_image": {"queue": "builds"},
         "app.core.tasks.registry_garbage_collection": {"queue": "builds"},


### PR DESCRIPTION
## Description

Adds an `orchest-api` level scheduler job that periodically cleanups the builder cache since it's (AFAIK) the only storage that user actions can't affect.

Opinion on adding an `orchest-api` endpoint that queues such a task? Even without a GUI button would be fine, just to know that we have at least a temporary solution for "power" users that need/want it to be cleaned up asap, might also prove useful for the cloud.