### PR TITLE
Fix celery-worker bringup and image builder on arm64

### DIFF
--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -37,7 +37,7 @@ class Config:
     CLIENT_HEARTBEATS_IDLENESS_THRESHOLD = datetime.timedelta(minutes=30)
 
     # Image building.
-    IMAGE_BUILDER_IMAGE = "docker.io/orchest/buildah:1.26-experimental"
+    IMAGE_BUILDER_IMAGE = "docker.io/orchest/buildah:1.26.0-patched"
     BUILD_IMAGE_LOG_FLAG = "_ORCHEST_RESERVED_LOG_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
 

--- a/services/orchest-api/start_celery_daemon.sh
+++ b/services/orchest-api/start_celery_daemon.sh
@@ -4,6 +4,14 @@ set -e
 JP=$(curl http://orchest-api/api/ctl/orchest-settings -s | jq -r .MAX_JOB_RUNS_PARALLELISM)
 IP=$(curl http://orchest-api/api/ctl/orchest-settings -s | jq -r .MAX_INTERACTIVE_RUNS_PARALLELISM)
 
+if [ -z "${JP}" ]; then
+	exit 11;
+fi
+
+if [ -z "${IP}" ]; then
+	exit 11;
+fi
+
 MAX_JOB_RUNS_PARALLELISM="${JP}" \
 MAX_INTERACTIVE_RUNS_PARALLELISM="${IP}" \
 /usr/bin/supervisord -n -m 002 -u 0


### PR DESCRIPTION
## Description
Fix celery-worker bringup and image builder on arm64

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.