### PR TITLE
Fix JupyterLab not expanding to the full visual area

### DIFF
--- a/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
+++ b/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
@@ -67,9 +67,7 @@ class Jupyter {
   }
 
   show() {
-    console.log("DEV start showing");
     if (this.reloadOnShow) {
-      console.log("DEV start reloading");
       this.reloadOnShow = false;
       this._reloadFilesFromDisk();
     }
@@ -82,8 +80,6 @@ class Jupyter {
 
     window.clearInterval(this.showCheckInterval);
     this.showCheckInterval = window.setInterval(() => {
-      console.log("DEV start iframe", this.iframeHasLoaded);
-
       if (this.iframeHasLoaded) {
         if (this.hasJupyterRenderingGlitched()) {
           console.log("Reloading iframe because JupyterLab failed to render");

--- a/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
+++ b/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
@@ -67,7 +67,9 @@ class Jupyter {
   }
 
   show() {
+    console.log("DEV start showing");
     if (this.reloadOnShow) {
+      console.log("DEV start reloading");
       this.reloadOnShow = false;
       this._reloadFilesFromDisk();
     }
@@ -80,6 +82,8 @@ class Jupyter {
 
     window.clearInterval(this.showCheckInterval);
     this.showCheckInterval = window.setInterval(() => {
+      console.log("DEV start iframe", this.iframeHasLoaded);
+
       if (this.iframeHasLoaded) {
         if (this.hasJupyterRenderingGlitched()) {
           console.log("Reloading iframe because JupyterLab failed to render");
@@ -359,6 +363,18 @@ class Jupyter {
     $(this.iframe).attr("width", "100%");
     $(this.iframe).attr("height", "100%");
     $(this.iframe).attr("data-test-id", "jupyterlab-iframe");
+
+    const expandToFullScreenInterval = window.setInterval(() => {
+      const width = this.iframe?.getAttribute("width");
+      const height = this.iframe?.getAttribute("height");
+
+      if (this.iframe && (width !== "100%" || height !== "100%")) {
+        this.iframe?.setAttribute("width", "100%");
+        this.iframe?.setAttribute("height", "100%");
+        return;
+      }
+      window.clearInterval(expandToFullScreenInterval);
+    }, 10);
 
     this.jupyterHolder.append(this.iframe);
   }


### PR DESCRIPTION
## Description

Sometimes JupyterLab does not expand to the full visible area. This PR fixes this issue by iteratively checking and expanding the iframe.

Fixes: #1075 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
