### PR TITLE
Improve section about bumping Docker Desktop resources

### DIFF
--- a/docs/source/development/troubleshooting.rst
+++ b/docs/source/development/troubleshooting.rst
@@ -25,7 +25,7 @@ Minikube is unresponsive on Docker Desktop
 
 Sometimes Minikube becomes unresponsive on Docker Desktop. Some tell-tale signs of this are:
 
-- You're getting exit code ``137`` when building Orchest images (``scripts/build_containers.sh``),
+- You're getting exit code ``137`` when building Orchest images (``scripts/build_containers.sh``)
 - k9s fails to connect to minikube's context and ``docker logs minikube`` hangs, even though minikube is started
 - Minikube commands hang or are really slow
 

--- a/docs/source/development/troubleshooting.rst
+++ b/docs/source/development/troubleshooting.rst
@@ -232,9 +232,3 @@ Missing environment variables in pods
      scale down and back up the controller deployment, or any other preferred solution.
    
    - start Orchest, ``orchest start``.
-
-   
-Minikube is unresponsive on MacOS
----------------------------------
-
-After leaving your computer locked/hibernated for a longer period of time

--- a/docs/source/development/troubleshooting.rst
+++ b/docs/source/development/troubleshooting.rst
@@ -19,11 +19,19 @@ Some other kubectl commands that can be useful when debugging Orchest:
    # Attach a shell in a particular service
    kubectl exec -n orchest -it deployment/orchest-api bash
 
-Exit code ``137`` when building Orchest images (scripts/build_containers.sh)
-----------------------------------------------------------------------------
-For Docker Desktop users, make sure increase the allocated memory to Docker Engine. This can be done
-by going to Docker Desktop > Settings > Advanced > Increase the *Memory* slider (`GitHub issue for
-reference <https://github.com/moby/moby/issues/22211>`_).
+   
+Minikube is unresponsive on Docker Desktop
+------------------------------------------
+
+Sometimes Minikube becomes unresponsive on Docker Desktop. Some tell-tale signs of this are:
+
+- You're getting exit code ``137`` when building Orchest images (``scripts/build_containers.sh``),
+- k9s fails to connect to minikube's context and ``docker logs minikube`` hangs, even though minikube is started
+- Minikube commands hang or are really slow
+
+This happens because too little memory is being allocated to Docker Engine. 
+To fix it: open Docker Desktop and go to `Settings > Advanced` and then increase the "Memory" slider 
+(`See this GitHub issue for reference <https://github.com/moby/moby/issues/22211>`_).
 
 Inspecting the ``orchest-api`` API schema
 -----------------------------------------
@@ -226,4 +234,7 @@ Missing environment variables in pods
    - start Orchest, ``orchest start``.
 
    
+Minikube is unresponsive on MacOS
+---------------------------------
 
+After leaving your computer locked/hibernated for a longer period of time


### PR DESCRIPTION
## Description

I had a similar issue as described in the Troubleshooting docs already, but I didn't have to build the Orchest docker image, so I never encountered the "Exit code 137" issue.

I changed it to be one example under a more generalized heading for the problem: minikube being unresponsive. It should still be searchable in the docs, and easily be indexed on Google. :)

Here is the rendered page: https://orchest--1091.org.readthedocs.build/en/1091/development/troubleshooting.html#minikube-is-unresponsive-on-docker-desktop

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
