### PR TITLE
Set correct permissions on `/pip-cache`

### DIFF
--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -150,16 +150,17 @@ def _get_buildah_image_build_workflow_manifest(
                         "command": ["/bin/sh", "-c"],
                         "args": [
                             (
-                                # Change the UID/GID to jovyan/users
-                                "chown -R 1000:100 /pip-cache; "
+                                # Creating the cache directories
+                                "mkdir -p -m 777 /builder-pvc/cache/pip && "
+                                "mkdir -p -m 777 /builder-pvc/cache/conda && "
                                 # Build
                                 f"buildah build -f {dockerfile_path} --layers=true "
                                 # Package managers caches.
                                 # jovyan is the user of the base image.
-                                "-v /pip-cache:/home/jovyan/.cache/pip "
+                                "-v /builder-pvc/cache/pip:/home/jovyan/.cache/pip "
                                 # Obtained by running "conda info". Note
                                 # that this cache is also used by mamba.
-                                "-v /conda-cache:/opt/conda/pkgs "
+                                "-v /builder-pvc/cache/conda:/opt/conda/pkgs "
                                 # https://github.com/containers/buildah/issues/2741
                                 "--format docker "
                                 "--force-rm=true "
@@ -192,13 +193,8 @@ def _get_buildah_image_build_workflow_manifest(
                             },
                             {
                                 "name": "image-builder-cache-pvc",
-                                "subPath": "pip-cache",
-                                "mountPath": "/pip-cache",
-                            },
-                            {
-                                "name": "image-builder-cache-pvc",
-                                "subPath": "conda-cache",
-                                "mountPath": "/conda-cache",
+                                "subPath": "cache",
+                                "mountPath": "/builder-pvc/cache",
                             },
                             {
                                 "name": "image-builder-cache-pvc",

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -150,6 +150,8 @@ def _get_buildah_image_build_workflow_manifest(
                         "command": ["/bin/sh", "-c"],
                         "args": [
                             (
+                                # Change the UID/GID to jovyan/users
+                                "chown -R 1000:100 /pip-cache; "
                                 # Build
                                 f"buildah build -f {dockerfile_path} --layers=true "
                                 # Package managers caches.


### PR DESCRIPTION
## Description

This PR fixes the `pip-cache` warning during environment image building by `chown`ing the pip-cache to 1000/100 which is jovyan/users. The warning:

> WARNING: The directory '/home/jovyan/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.

The warning was observed when running on GKE.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

