### PR TITLE
Only use `image-puller` `initContainer` if `jupyter-server` is customized by user

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -149,6 +149,27 @@ def get_init_container_manifest(
     return init_container
 
 
+def add_image_puller_if_needed(
+    image_to_pull: str,
+    container_runtime: str,
+    container_runtime_image: str,
+    deployment_manifest: Dict[str, Any],
+):
+
+    global_domains = ["docker.io"]
+    domain, name = split_docker_domain(image_to_pull)
+
+    if domain not in global_domains:
+        image_puller_manifest = get_init_container_manifest(
+            f"{domain}/{name}",
+            container_runtime,
+            container_runtime_image,
+        )
+        deployment_manifest["spec"]["template"]["spec"]["initContainers"] = [
+            image_puller_manifest
+        ]
+
+
 # splitDockerDomain splits a repository name to domain and remotename
 # string. If no valid domain is found, the default domain is used.
 # Repository name needs to be already validated before.

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -123,11 +123,11 @@ def get_step_and_kernel_volumes_and_volume_mounts(
 def get_init_container_manifest(
     image_to_pull: str,
     container_runtime: str,
-    container_runtime_image: str,
+    image_puller_image: str,
 ) -> Dict[str, Any]:
     init_container = {
         "name": "image-puller",
-        "image": container_runtime_image,
+        "image": image_puller_image,
         "env": [
             {
                 "name": "IMAGE_TO_PULL",
@@ -151,23 +151,43 @@ def get_init_container_manifest(
 
 def add_image_puller_if_needed(
     image_to_pull: str,
+    registry_ip: str,
     container_runtime: str,
-    container_runtime_image: str,
+    image_puller_image: str,
     deployment_manifest: Dict[str, Any],
 ) -> None:
+    """This function injects the image puller init Container into the
+    deployment manifest if the image is in our local docker-registry..
 
-    global_domains = ["docker.io"]
+    Args:
+        image_to_pull:
+            The image that image_puller has to pull.
+        registry_ip:
+            our registry ip address
+        container_runtime:
+            The container runtime of the node.
+        image_puller_image:
+            The image of the image puller.
+        deployment_manifest:
+            The deployment manifest.
+
+    """
     domain, name = split_docker_domain(image_to_pull)
 
-    if domain not in global_domains:
+    if domain == registry_ip:
         image_puller_manifest = get_init_container_manifest(
             f"{domain}/{name}",
             container_runtime,
-            container_runtime_image,
+            image_puller_image,
         )
-        deployment_manifest["spec"]["template"]["spec"]["initContainers"] = [
-            image_puller_manifest
-        ]
+        if deployment_manifest["spec"]["template"]["spec"]["initContainers"] is None:
+            deployment_manifest["spec"]["template"]["spec"]["initContainers"] = [
+                image_puller_manifest
+            ]
+        else:
+            deployment_manifest["spec"]["template"]["spec"]["initContainers"].append(
+                image_puller_manifest
+            )
 
 
 # splitDockerDomain splits a repository name to domain and remotename

--- a/lib/python/orchest-internals/_orchest/internals/utils.py
+++ b/lib/python/orchest-internals/_orchest/internals/utils.py
@@ -154,7 +154,7 @@ def add_image_puller_if_needed(
     container_runtime: str,
     container_runtime_image: str,
     deployment_manifest: Dict[str, Any],
-):
+) -> None:
 
     global_domains = ["docker.io"]
     domain, name = split_docker_domain(image_to_pull)

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -11,11 +11,7 @@ import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from _orchest.internals import config as _config
-from _orchest.internals.utils import (
-    get_init_container_manifest,
-    get_userdir_relpath,
-    split_docker_domain,
-)
+from _orchest.internals.utils import add_image_puller_if_needed, get_userdir_relpath
 from app import utils
 from app.connections import k8s_core_api
 from app.types import SessionConfig, SessionType
@@ -411,12 +407,6 @@ def _get_jupyter_server_deployment_service_manifest(
         project_uuid, userdir_pvc, project_dir, pipeline_path
     )
 
-    image_puller_manifest = get_init_container_manifest(
-        utils.get_jupyter_server_image_to_use(),
-        _config.CONTAINER_RUNTIME,
-        _config.CONTAINER_RUNTIME_IMAGE,
-    )
-
     deployment_manifest = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -439,9 +429,6 @@ def _get_jupyter_server_deployment_service_manifest(
                     "volumes": [
                         volumes_dict["userdir-pvc"],
                         volumes_dict["container-runtime-socket"],
-                    ],
-                    "initContainers": [
-                        image_puller_manifest,
                     ],
                     "containers": [
                         {
@@ -482,6 +469,13 @@ def _get_jupyter_server_deployment_service_manifest(
             },
         },
     }
+
+    add_image_puller_if_needed(
+        utils.get_jupyter_server_image_to_use(),
+        _config.CONTAINER_RUNTIME,
+        _config.CONTAINER_RUNTIME_IMAGE,
+        deployment_manifest,
+    )
 
     service_manifest = {
         "apiVersion": "v1",
@@ -901,14 +895,6 @@ def _get_user_service_deployment_service_manifest(
         },
     }
 
-    domain, name = split_docker_domain(image)
-
-    image_puller_manifest = get_init_container_manifest(
-        f"{domain}/{name}",
-        _config.CONTAINER_RUNTIME,
-        _config.CONTAINER_RUNTIME_IMAGE,
-    )
-
     deployment_manifest = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -929,9 +915,6 @@ def _get_user_service_deployment_service_manifest(
                         "requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}
                     },
                     "volumes": volumes,
-                    "initContainers": [
-                        image_puller_manifest,
-                    ],
                     "containers": [
                         {
                             "name": metadata["name"],
@@ -949,6 +932,13 @@ def _get_user_service_deployment_service_manifest(
             },
         },
     }
+
+    add_image_puller_if_needed(
+        image,
+        _config.CONTAINER_RUNTIME,
+        _config.CONTAINER_RUNTIME_IMAGE,
+        deployment_manifest,
+    )
 
     # K8S doesn't like empty commands.
     if service_config.get("command", ""):

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -472,6 +472,7 @@ def _get_jupyter_server_deployment_service_manifest(
 
     add_image_puller_if_needed(
         utils.get_jupyter_server_image_to_use(),
+        utils.get_registry_ip(),
         _config.CONTAINER_RUNTIME,
         _config.CONTAINER_RUNTIME_IMAGE,
         deployment_manifest,
@@ -935,6 +936,7 @@ def _get_user_service_deployment_service_manifest(
 
     add_image_puller_if_needed(
         image,
+        utils.get_registry_ip(),
         _config.CONTAINER_RUNTIME,
         _config.CONTAINER_RUNTIME_IMAGE,
         deployment_manifest,

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -226,14 +226,18 @@ def get_jupyter_server_image_to_use() -> str:
     if active_custom_images:
         custom_image = active_custom_images[0]
         # K8S_TODO
-        registry_ip = k8s_core_api.read_namespaced_service(
-            _config.REGISTRY, _config.ORCHEST_NAMESPACE
-        ).spec.cluster_ip
+        registry_ip = get_registry_ip()
         return f"{registry_ip}/{_config.JUPYTER_IMAGE_NAME}:{custom_image.tag}"
     else:
         # ctr needs full image name, including the registry
         # (even docker hub) to pull
         return f"docker.io/orchest/jupyter-server:{CONFIG_CLASS.ORCHEST_VERSION}"
+
+
+def get_registry_ip() -> str:
+    return k8s_core_api.read_namespaced_service(
+        _config.REGISTRY, _config.ORCHEST_NAMESPACE
+    ).spec.cluster_ip
 
 
 def _set_celery_worker_parallelism_at_runtime(


### PR DESCRIPTION
## Description

This PR adds the image_puller manifest to jupyter-server and user-services if the image is not on global docker registries

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
