### PR TITLE
Autofocus the parameter edit field in Job Edit view.

### DIFF
--- a/services/orchest-webserver/client/src/components/ParameterEditor.tsx
+++ b/services/orchest-webserver/client/src/components/ParameterEditor.tsx
@@ -62,9 +62,10 @@ const ParameterEditor: React.FC<IParameterEditorProps> = (props) => {
 
   const codeMirrorRef = React.useRef<CodeMirror | null>(null);
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (activeParameter) codeMirrorRef.current?.editor.focus(); // `editor` was not defined.
+    if (activeParameter) {
+      // `editor` is not defined in CodeMirror. So we need this workaround.
+      (codeMirrorRef.current as any).editor.focus(); // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
   }, [activeParameter]);
 
   return (


### PR DESCRIPTION
## Description

When user clicks on a parameter, the edit field (CodeMirror) should be focused.

Fixes: #431 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
