### PR TITLE
Fix: a rebased branch cannot be re-deployed.

### DIFF
--- a/scripts/redeploy_branch.sh
+++ b/scripts/redeploy_branch.sh
@@ -31,12 +31,19 @@ set -e
 
 echo "Checking out branch ${1}..."
 
-if git show-ref --quiet refs/heads/$1 ; then
+if [ "${1}" != "dev" ] && git show-ref --quiet refs/heads/$1 ; then
     git checkout dev
     git branch -D $1    
 fi
+
 git fetch --all
-git checkout $1
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "${1}" ]]; then
+  git checkout $1
+fi
+
+git pull origin $1
 
 
 # Needed to get the auth users.

--- a/scripts/redeploy_branch.sh
+++ b/scripts/redeploy_branch.sh
@@ -30,6 +30,8 @@ fi
 set -e
 
 echo "Checking out branch ${1}..."
+git checkout dev
+git branch -D $1
 git fetch --all
 git checkout $1
 git pull origin $1

--- a/scripts/redeploy_branch.sh
+++ b/scripts/redeploy_branch.sh
@@ -30,11 +30,14 @@ fi
 set -e
 
 echo "Checking out branch ${1}..."
-git checkout dev
-git branch -D $1
+
+if git show-ref refs/heads/$1 ; then
+    git checkout dev
+    git branch -D $1    
+fi
+exit 1
 git fetch --all
 git checkout $1
-git pull origin $1
 
 
 # Needed to get the auth users.

--- a/scripts/redeploy_branch.sh
+++ b/scripts/redeploy_branch.sh
@@ -31,11 +31,10 @@ set -e
 
 echo "Checking out branch ${1}..."
 
-if git show-ref refs/heads/$1 ; then
+if git show-ref --quiet refs/heads/$1 ; then
     git checkout dev
     git branch -D $1    
 fi
-exit 1
 git fetch --all
 git checkout $1
 


### PR DESCRIPTION


## Description

If the remote branch is rebased, `git` will fail to pull. Deleting the local branch and re-fetch-and-pull from remote
would solve the problem.


