### PR TITLE
Fix: Allow multiple pipeline files (`.orchest` extension) to be present in a subdirectory

### DIFF
--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -464,12 +464,13 @@ def find_pipelines_in_dir(path, relative_to=None):
 
             dirs[:] = [d for d in dirs if d not in ignore_dirs]
 
+            if relative_to is not None:
+                root = root[len(relative_to) :]
+                if root.startswith("/"):
+                    root = root[1:]
+
             for fName in files:
                 if fName.endswith(".orchest"):
-                    if relative_to is not None:
-                        root = root[len(relative_to) :]
-                        if root.startswith("/"):
-                            root = root[1:]
 
                     # Path normalization is important for correctly
                     # detecting pipelines that were deleted through the


### PR DESCRIPTION
## Description

utils tried to change the root directory of found .orchest files to a
relative path for each found file. This breaks if there are more than
one .orchest files in a subdirectoy.

When only done once per directoy it is fixed. So just moved the code a few lines up.

Fixes: #1106

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
