### PR TITLE
Refactor SessionContext and AppContext.

### DIFF
--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -281,7 +281,7 @@ def register_orchest_api_views(app, db):
         )
         return resp.content, resp.status_code, resp.headers.items()
 
-    @app.route("/catch/api-proxy/api/sessions/", methods=["GET"])
+    @app.route("/catch/api-proxy/api/sessions", methods=["GET"])
     def catch_api_proxy_sessions_get():
 
         resp = requests.get(
@@ -307,7 +307,7 @@ def register_orchest_api_views(app, db):
 
         return resp.content, resp.status_code, resp.headers.items()
 
-    @app.route("/catch/api-proxy/api/sessions/", methods=["POST"])
+    @app.route("/catch/api-proxy/api/sessions", methods=["POST"])
     def catch_api_proxy_sessions_post():
 
         json_obj = request.json

--- a/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
+++ b/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
@@ -1,7 +1,7 @@
-import { BUILD_IMAGE_SOLUTION_VIEW } from "@/components/BuildPendingDialog";
+import { BUILD_IMAGE_SOLUTION_VIEW } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import StyledButtonOutlined from "@/styled-components/StyledButton";
-import { IOrchestSession } from "@/types";
+import { OrchestSession } from "@/types";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import { SxProps, Theme } from "@mui/material";
@@ -12,9 +12,8 @@ import React from "react";
 
 export type TSessionToggleButtonRef = HTMLButtonElement;
 type ISessionToggleButtonProps = {
-  status?: IOrchestSession["status"] | "";
+  status?: OrchestSession["status"] | "";
   pipelineUuid: string;
-  projectUuid: string;
   isSwitch?: boolean;
   label?: React.ReactElement | string | number;
   className?: string;
@@ -22,20 +21,14 @@ type ISessionToggleButtonProps = {
 };
 
 const SessionToggleButton = (props: ISessionToggleButtonProps) => {
-  const { state, getSession, toggleSession } = useSessionsContext();
+  const { getSession, startSession, stopSession } = useSessionsContext();
 
-  const { className, isSwitch, label, pipelineUuid, projectUuid, sx } = props;
+  const { className, isSwitch, label, pipelineUuid, sx } = props;
 
-  const status =
-    props.status ||
-    getSession({
-      pipelineUuid,
-      projectUuid,
-    })?.status ||
-    "";
+  const session = getSession(pipelineUuid);
+  const status = props.status || session?.status || "";
 
-  const disabled =
-    state.sessionsIsLoading || ["STOPPING", "LAUNCHING"].includes(status);
+  const disabled = ["STOPPING", "LAUNCHING"].includes(status);
   const statusLabel =
     {
       STOPPING: "Session stopping…",
@@ -43,14 +36,19 @@ const SessionToggleButton = (props: ISessionToggleButtonProps) => {
       RUNNING: "Stop session",
     }[status] || "Start session";
 
-  const handleEvent = (e: React.MouseEvent | React.ChangeEvent) => {
+  const handleEvent = (
+    e: React.MouseEvent | React.ChangeEvent,
+    checked?: boolean
+  ) => {
     e.preventDefault();
     e.stopPropagation();
-    toggleSession({
-      pipelineUuid,
-      projectUuid,
-      requestedFromView: BUILD_IMAGE_SOLUTION_VIEW.PIPELINE,
-    });
+
+    const shouldStart = checked === true || !session;
+    if (shouldStart) {
+      startSession(pipelineUuid, BUILD_IMAGE_SOLUTION_VIEW.PIPELINE);
+    } else {
+      stopSession(pipelineUuid);
+    }
   };
   const isSessionAlive = status === "RUNNING";
 

--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -1,8 +1,6 @@
 import { useAsync } from "@/hooks/useAsync";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import {
-  BuildRequest,
-  EnvironmentValidationData,
   OrchestConfig,
   OrchestServerConfig,
   OrchestUserConfig,
@@ -11,9 +9,6 @@ import {
 import { fetcher } from "@orchest/lib-utils";
 import React from "react";
 
-/** Utility functions
- =====================================================
- */
 function parseLineBreak(lines: string) {
   if (lines === undefined) return [];
 
@@ -84,7 +79,6 @@ type PromptMessageConverter<T extends PromptMessage> = T extends Alert
 
 type AppContextState = {
   promptMessages: PromptMessage[];
-  buildRequest?: BuildRequest;
   hasUnsavedChanges: boolean;
   isShowingOnboarding: boolean;
   // we already store hasCompletedOnboarding in localstorage, which is enough for most cases,
@@ -105,10 +99,6 @@ type Action =
   | {
       type: "SET_PROMPT_MESSAGES";
       payload: PromptMessage[];
-    }
-  | {
-      type: "SET_BUILD_REQUEST";
-      payload: BuildRequest | undefined;
     }
   | {
       type: "SET_HAS_UNSAVED_CHANGES";
@@ -145,14 +135,6 @@ export type ConfirmDispatcher = (
       }
 ) => Promise<boolean>;
 
-export type RequestBuildDispatcher = (
-  projectUuid: string,
-  environmentValidationData: EnvironmentValidationData,
-  requestedFromView: string,
-  onBuildComplete: () => void,
-  onCancel?: () => void
-) => void;
-
 type PromptMessageDispatcher<T extends PromptMessage> = T extends Alert
   ? AlertDispatcher
   : T extends Confirm
@@ -164,7 +146,6 @@ type AppContext = {
   dispatch: React.Dispatch<AppContextAction>;
   setAlert: AlertDispatcher;
   setConfirm: ConfirmDispatcher;
-  requestBuild: RequestBuildDispatcher;
   deletePromptMessage: () => void;
   setAsSaved: (value?: boolean) => void;
   isDrawerOpen: boolean;
@@ -185,10 +166,6 @@ const reducer = (state: AppContextState, _action: AppContextAction) => {
     }
     case "SET_PROMPT_MESSAGES": {
       return { ...state, promptMessages: action.payload };
-    }
-
-    case "SET_BUILD_REQUEST": {
-      return { ...state, buildRequest: action.payload };
     }
 
     case "SET_HAS_UNSAVED_CHANGES": {
@@ -403,28 +380,6 @@ export const AppContextProvider: React.FC<{ shouldStart?: boolean }> = ({
     [dispatch]
   );
 
-  const requestBuild = React.useCallback(
-    (
-      projectUuid: string,
-      environmentValidationData: EnvironmentValidationData,
-      requestedFromView: string,
-      onBuildComplete: () => void,
-      onCancel?: () => void
-    ) => {
-      dispatch({
-        type: "SET_BUILD_REQUEST",
-        payload: {
-          projectUuid,
-          environmentValidationData,
-          requestedFromView,
-          onBuildComplete,
-          onCancel,
-        },
-      });
-    },
-    [dispatch]
-  );
-
   return (
     <Context.Provider
       value={{
@@ -434,7 +389,6 @@ export const AppContextProvider: React.FC<{ shouldStart?: boolean }> = ({
         dispatch,
         setAlert,
         setConfirm,
-        requestBuild,
         deletePromptMessage,
         setAsSaved,
         isDrawerOpen,

--- a/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 type TSessionStatus = OrchestSession["status"];
 
-const ENDPOINT = "/catch/api-proxy/api/sessions";
+export const SESSIONS_ENDPOINT = "/catch/api-proxy/api/sessions";
 
 const isStoppable = (status: TSessionStatus) =>
   ["RUNNING", "LAUNCHING"].includes(status || "");
@@ -21,8 +21,7 @@ const launchSession = ({
   projectUuid: string;
   pipelineUuid: string;
 }) => {
-  // NOTE: the trailing slash is required, otherwise the request will be picked up by other route.
-  return fetcher<OrchestSession>(`${ENDPOINT}/`, {
+  return fetcher<OrchestSession>(SESSIONS_ENDPOINT, {
     method: "POST",
     headers: HEADER.JSON,
     body: JSON.stringify({
@@ -39,7 +38,7 @@ const killSession = ({
   projectUuid: string;
   pipelineUuid: string;
 }) => {
-  return fetcher(`${ENDPOINT}/${projectUuid}/${pipelineUuid}`, {
+  return fetcher(`${SESSIONS_ENDPOINT}/${projectUuid}/${pipelineUuid}`, {
     method: "DELETE",
   });
 };

--- a/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/SessionsContext.tsx
@@ -8,19 +8,17 @@ import { fetcher, hasValue, HEADER } from "@orchest/lib-utils";
 import React from "react";
 
 type TSessionStatus = OrchestSession["status"];
+type SessionIdentifier = {
+  projectUuid: string;
+  pipelineUuid: string;
+};
 
 export const SESSIONS_ENDPOINT = "/catch/api-proxy/api/sessions";
 
 const isStoppable = (status: TSessionStatus) =>
   ["RUNNING", "LAUNCHING"].includes(status || "");
 
-const launchSession = ({
-  projectUuid,
-  pipelineUuid,
-}: {
-  projectUuid: string;
-  pipelineUuid: string;
-}) => {
+const launchSession = ({ projectUuid, pipelineUuid }: SessionIdentifier) => {
   return fetcher<OrchestSession>(SESSIONS_ENDPOINT, {
     method: "POST",
     headers: HEADER.JSON,
@@ -31,13 +29,7 @@ const launchSession = ({
   });
 };
 
-const killSession = ({
-  projectUuid,
-  pipelineUuid,
-}: {
-  projectUuid: string;
-  pipelineUuid: string;
-}) => {
+const killSession = ({ projectUuid, pipelineUuid }: SessionIdentifier) => {
   return fetcher(`${SESSIONS_ENDPOINT}/${projectUuid}/${pipelineUuid}`, {
     method: "DELETE",
   });
@@ -69,10 +61,7 @@ type SessionsContextAction = ReducerActionWithCallback<
 export const getSessionKey = ({
   projectUuid,
   pipelineUuid,
-}: {
-  projectUuid: string;
-  pipelineUuid: string;
-}) => `${projectUuid}|${pipelineUuid}`;
+}: SessionIdentifier) => `${projectUuid}|${pipelineUuid}`;
 
 type SessionsContext = {
   state: SessionsContextState;

--- a/services/orchest-webserver/client/src/environments-view/common.tsx
+++ b/services/orchest-webserver/client/src/environments-view/common.tsx
@@ -2,7 +2,7 @@ import {
   DefaultEnvironment,
   Environment,
   EnvironmentImageBuild,
-  IOrchestSession,
+  OrchestSession,
 } from "@/types";
 import { fetcher, HEADER } from "@orchest/lib-utils";
 
@@ -21,7 +21,7 @@ export const requestToRemoveEnvironment = (
 };
 
 export const fetchSessionsInProject = async (projectUuid: string) => {
-  const sessionData = await fetcher<{ sessions: IOrchestSession[] }>(
+  const sessionData = await fetcher<{ sessions: OrchestSession[] }>(
     `/catch/api-proxy/api/sessions/?project_uuid=${projectUuid}`
   );
   return sessionData.sessions;

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -1,6 +1,10 @@
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
-import { getSessionKey, useSessionsContext } from "@/contexts/SessionsContext";
+import {
+  getSessionKey,
+  SESSIONS_ENDPOINT,
+  useSessionsContext,
+} from "@/contexts/SessionsContext";
 import { siteMap } from "@/routingConfig";
 import { OrchestSession } from "@/types";
 import { hasValue } from "@orchest/lib-utils";
@@ -52,7 +56,7 @@ export const useSessionsPoller = () => {
   const { data: sessions, error, fetchData: fetchSessions } = useFetcher<
     FetchSessionResponse,
     Record<string, OrchestSession>
-  >("/catch/api-proxy/api/sessions/", {
+  >(SESSIONS_ENDPOINT, {
     disableFetchOnMount: true,
     transform: (data) =>
       data.sessions.reduce((sessionsObj, session) => {

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -185,10 +185,7 @@ const PipelineSettingsView: React.FC = () => {
   const [servicesChanged, setServicesChanged] = React.useState(false);
   const [envVarsChanged, setEnvVarsChanged] = React.useState(false);
 
-  const session = getSession({
-    pipelineUuid,
-    projectUuid,
-  });
+  const session = getSession(pipelineUuid);
   if (!session && !hasUnsavedChanges && (servicesChanged || envVarsChanged)) {
     setServicesChanged(false);
     setEnvVarsChanged(false);

--- a/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/LogsView.tsx
@@ -149,7 +149,7 @@ export const LogsView: React.FC = () => {
   // Conditional fetch session
   let session =
     !jobUuid && hasValue(projectUuid) && hasValue(pipelineUuid)
-      ? getSession({ projectUuid, pipelineUuid })
+      ? getSession(pipelineUuid)
       : undefined;
 
   const close = () => {

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -3,9 +3,9 @@ import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useForceUpdate } from "@/hooks/useForceUpdate";
 import {
   Environment,
-  IOrchestSession,
   MouseTracker,
   NewConnection,
+  OrchestSession,
   PipelineJson,
   Position,
   StepsDict,
@@ -61,7 +61,7 @@ export type PipelineEditorContextType = {
     startNodeUUID: string;
     endNodeUUID: string | undefined;
   };
-  session: IOrchestSession | undefined;
+  session: OrchestSession | undefined;
   getOnCanvasPosition: (offset: Position) => Position;
   disabled: boolean;
 };

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -5,7 +5,7 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelines } from "@/hooks/useFetchPipelines";
 import { siteMap } from "@/routingConfig";
-import { IOrchestSessionUuid, PipelineMetaData } from "@/types";
+import { OrchestSession, PipelineMetaData } from "@/types";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import TreeView from "@mui/lab/TreeView";
@@ -155,7 +155,7 @@ export const FileTree = React.memo(function FileTreeComponent({
 }) {
   const { setConfirm, setAlert } = useAppContext();
   const { projectUuid, pipelineUuid, navigateTo } = useCustomRoute();
-  const { getSession, toggleSession } = useSessionsContext();
+  const { getSession, stopSession } = useSessionsContext();
   const {
     state: { pipelines = [], pipeline },
     dispatch,
@@ -289,18 +289,14 @@ export const FileTree = React.memo(function FileTreeComponent({
 
       if (filePaths.length === 0) return [true, []];
 
-      const pipelinesWithSession: (IOrchestSessionUuid &
-        PipelineMetaData)[] = [];
+      const pipelinesWithSession: (OrchestSession & PipelineMetaData)[] = [];
 
       for (let filePath of filePaths) {
         const foundPipeline = pipelineDics[filePath.path.replace(/^\//, "")];
 
         if (!foundPipeline) continue;
 
-        const session = getSession({
-          pipelineUuid: foundPipeline.uuid,
-          projectUuid,
-        });
+        const session = getSession(foundPipeline.uuid);
 
         if (session) {
           pipelinesWithSession.push({
@@ -332,7 +328,7 @@ export const FileTree = React.memo(function FileTreeComponent({
             }`,
             onConfirm: async (resolve) => {
               await Promise.all(
-                pipelinesWithSession.map((session) => toggleSession(session))
+                pipelinesWithSession.map((session) => stopSession(session.uuid))
               );
               resolve(true);
               return true;
@@ -343,7 +339,7 @@ export const FileTree = React.memo(function FileTreeComponent({
 
       return [pipelinesWithSession.length === 0, pipelinesWithSession];
     },
-    [getSession, projectUuid, setConfirm, toggleSession, pipelineDics]
+    [getSession, projectUuid, setConfirm, stopSession, pipelineDics]
   );
 
   // by default, handleChangeFilePath will reload

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/TreeItem.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/TreeItem.tsx
@@ -3,7 +3,6 @@ import { OrchestFileIcon } from "@/components/common/icons/OrchestFileIcon";
 import { useAppContext } from "@/contexts/AppContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
-import { useCustomRoute } from "@/hooks/useCustomRoute";
 import MuiTreeItem, { treeItemClasses, TreeItemProps } from "@mui/lab/TreeItem";
 import { SxProps, Theme } from "@mui/material";
 import Box from "@mui/material/Box";
@@ -51,9 +50,8 @@ export const TreeItem = ({
   const {
     state: { pipelines = [] },
   } = useProjectsContext();
-  const { projectUuid } = useCustomRoute();
   const { setConfirm } = useAppContext();
-  const { getSession, toggleSession } = useSessionsContext();
+  const { getSession, stopSession } = useSessionsContext();
 
   const icon = !fileName ? undefined : fileName.endsWith(".orchest") ? (
     <OrchestFileIcon size={22} />
@@ -88,10 +86,9 @@ export const TreeItem = ({
             const foundPipeline = pipelines.find(
               (pipeline) => pipeline.path === filePathRelativeToProjectDir
             );
-            const session = foundPipeline
-              ? getSession({ pipelineUuid: foundPipeline.uuid, projectUuid })
-              : null;
-            if (session) {
+            const session = getSession(foundPipeline?.uuid);
+
+            if (foundPipeline?.uuid && session) {
               setConfirm(
                 "Warning",
                 <>
@@ -102,7 +99,7 @@ export const TreeItem = ({
                 {
                   confirmLabel: "Stop session",
                   onConfirm: async (resolve) => {
-                    toggleSession(session);
+                    stopSession(foundPipeline.uuid);
                     resolve(true);
                     return true;
                   },

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
@@ -1,6 +1,7 @@
-import { useAppContext } from "@/contexts/AppContext";
-import { useProjectsContext } from "@/contexts/ProjectsContext";
-import { checkGate } from "@/utils/webserver-utils";
+import {
+  BUILD_IMAGE_SOLUTION_VIEW,
+  useProjectsContext,
+} from "@/contexts/ProjectsContext";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 
@@ -12,8 +13,8 @@ export const useIsReadOnly = (
   const {
     dispatch,
     state: { pipelineIsReadOnly },
+    ensureEnvironmentsAreBuilt,
   } = useProjectsContext();
-  const { requestBuild } = useAppContext();
 
   const setIsReadOnly = React.useCallback(
     (value: boolean) => {
@@ -31,26 +32,11 @@ export const useIsReadOnly = (
     if (hasActiveRun) setIsReadOnly(true);
   }, [hasActiveRun, setIsReadOnly]);
 
-  // Check gate is needed whenever user enters Pipeline Editor,
-  // `useAutoStartSession` only cares about the "current" pipeline that is opened in the Pipeline Editor,
-  // but it's needed to check ALL sessions in the project.
   React.useEffect(() => {
     if (!hasActiveRun && hasValue(projectUuid)) {
-      // for non pipelineRun - read only check gate
-      checkGate(projectUuid)
-        .then(() => {
-          setIsReadOnly(false);
-        })
-        .catch((result) => {
-          if (result.reason === "gate-failed") {
-            setIsReadOnly(true);
-            requestBuild(projectUuid, result.data, "Pipeline", () => {
-              setIsReadOnly(false);
-            });
-          }
-        });
+      ensureEnvironmentsAreBuilt(BUILD_IMAGE_SOLUTION_VIEW.PIPELINE);
     }
-  }, [hasActiveRun, projectUuid, requestBuild, setIsReadOnly]);
+  }, [hasActiveRun, projectUuid, ensureEnvironmentsAreBuilt]);
 
   return pipelineIsReadOnly;
 };

--- a/services/orchest-webserver/client/src/pipeline-view/sessions-panel/SessionsPanel.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/sessions-panel/SessionsPanel.tsx
@@ -1,13 +1,13 @@
 import SessionToggleButton from "@/components/SessionToggleButton";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
-import { IOrchestSession } from "@/types";
+import { OrchestSession } from "@/types";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-type SessionStatus = IOrchestSession["status"] | "";
+type SessionStatus = OrchestSession["status"] | "";
 
 export const SessionsPanel = () => {
   const {
@@ -33,14 +33,11 @@ export const SessionsPanel = () => {
         }}
       >
         {pipelines.map((pipeline) => {
-          const sessionStatus = (getSession({
-            pipelineUuid: pipeline.uuid,
-            projectUuid,
-          })?.status || "") as SessionStatus;
+          const sessionStatus = (getSession(pipeline.uuid)?.status ||
+            "") as SessionStatus;
 
           return (
             <SessionToggleButton
-              projectUuid={projectUuid}
               pipelineUuid={pipeline.uuid}
               status={sessionStatus}
               sx={{

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -101,12 +101,7 @@ export interface OrchestServerConfig {
   user_config: OrchestUserConfig;
 }
 
-export interface IOrchestSessionUuid {
-  projectUuid: string;
-  pipelineUuid: string;
-}
-
-export interface IOrchestSession extends IOrchestSessionUuid {
+export interface OrchestSession {
   status?: "RUNNING" | "LAUNCHING" | "STOPPING";
   base_url?: string;
   user_services?: {
@@ -390,14 +385,6 @@ export type EnvironmentValidationData = {
   fail: string[];
   pass: string[];
   validation: "fail" | "pass";
-};
-
-export type BuildRequest = {
-  projectUuid: string;
-  environmentValidationData: EnvironmentValidationData;
-  requestedFromView: string;
-  onBuildComplete: () => void;
-  onCancel?: () => void;
 };
 
 export type Pagination = {

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -207,6 +207,7 @@ export function getServiceURLs(
   );
 }
 
+// Ensure that environments in the project are ALL built.
 export function checkGate(project_uuid: string) {
   return new Promise<void>((resolve, reject) => {
     // we validate whether all environments have been built on the server


### PR DESCRIPTION
## Description

The implementation of SessionContext and `requestBuild` in AppContext has become obsolete and starts to become the bottleneck for building new features. This PR cleans up the legacy code for better performance and readability.

The changes are as follows:
- Convert the implementation of `requestBuild` from callbacks-based to promise-based, so no need to put callbacks in state.buildRequest.
- Move the code for `requestBuild` from `AppContext` to `ProjectsContext` because requestBuild only makes sense within a project.
- Convert state.sessions from an array to an object for better performance with less code.
- Replace `toggleSession` with `startSession` and `stopSession`.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
