### PR TITLE
Fix `Run selected steps` in the context menu not working issue.

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -384,8 +384,6 @@ export const PipelineEditor = () => {
     setPipelineJson((value) => value, true);
   }, [setPipelineJson]);
 
-  const isContextMenuOpenState = React.useState(false);
-
   const autoLayoutPipeline = () => {
     const spacingFactor = 0.7;
     const gridMargin = 20;
@@ -642,7 +640,6 @@ export const PipelineEditor = () => {
           canvasFuncRef={canvasFuncRef}
           executeRun={executeRun}
           autoLayoutPipeline={autoLayoutPipeline}
-          isContextMenuOpenState={isContextMenuOpenState}
         >
           {connections.map((connection) => {
             const { startNodeUUID, endNodeUUID } = connection;
@@ -764,7 +761,6 @@ export const PipelineEditor = () => {
                 interactiveConnections={interactiveConnections}
                 onDoubleClick={onDoubleClickStep}
                 getPosition={getPosition}
-                isContextMenuOpenState={isContextMenuOpenState}
               >
                 <ConnectionDot
                   incoming

--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -130,10 +130,6 @@ const PipelineStepComponent = React.forwardRef<
     onDoubleClick: (stepUUID: string) => void;
     interactiveConnections: Connection[];
     getPosition: (node: HTMLElement | undefined | null) => Position | null;
-    isContextMenuOpenState: [
-      boolean,
-      React.Dispatch<React.SetStateAction<boolean>>
-    ];
     children: React.ReactNode;
   }
 >(function PipelineStep(
@@ -150,7 +146,6 @@ const PipelineStepComponent = React.forwardRef<
     // the cursor-controlled step also renders all the interactive connections, to ensure the precision of the positions
     interactiveConnections,
     getPosition,
-    isContextMenuOpenState,
     children, // expose children, so that children doesn't re-render when step is being dragged
   },
   ref
@@ -178,6 +173,7 @@ const PipelineStepComponent = React.forwardRef<
       stepSelector,
       selectedConnection,
     },
+    isContextMenuOpen,
   } = usePipelineEditorContext();
   const { selectedFiles, dragFile, resetMove } = useFileManagerContext();
 
@@ -296,7 +292,7 @@ const PipelineStepComponent = React.forwardRef<
   const onMouseDown = React.useCallback(
     (e: React.MouseEvent) => {
       // user is panning the canvas or context menu is open
-      if (keysDown.has("Space") || isContextMenuOpenState[0]) return;
+      if (keysDown.has("Space") || isContextMenuOpen) return;
 
       e.stopPropagation();
       e.preventDefault();
@@ -305,7 +301,7 @@ const PipelineStepComponent = React.forwardRef<
         forceUpdate();
       }
     },
-    [forceUpdate, keysDown, isContextMenuOpenState]
+    [forceUpdate, keysDown, isContextMenuOpen]
   );
 
   const { handleContextMenu, ...contextMenuProps } = useContextMenu();
@@ -322,7 +318,7 @@ const PipelineStepComponent = React.forwardRef<
 
   const onClick = async (e: React.MouseEvent) => {
     // user is panning the canvas or context menu is open
-    if (keysDown.has("Space") || isContextMenuOpenState[0]) return;
+    if (keysDown.has("Space") || isContextMenuOpen) return;
 
     e.stopPropagation();
     e.preventDefault();

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -64,6 +64,8 @@ export type PipelineEditorContextType = {
   session: OrchestSession | undefined;
   getOnCanvasPosition: (offset: Position) => Position;
   disabled: boolean;
+  isContextMenuOpen: boolean;
+  setIsContextMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const PipelineEditorContext = React.createContext<PipelineEditorContextType | null>(
@@ -191,6 +193,8 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     [eventVars.scaleFactor, mouseTracker, pipelineCanvasRef]
   );
 
+  const [isContextMenuOpen, setIsContextMenuOpen] = React.useState(false);
+
   return (
     <PipelineEditorContext.Provider
       value={{
@@ -221,6 +225,8 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
         session,
         getOnCanvasPosition,
         disabled,
+        isContextMenuOpen,
+        setIsContextMenuOpen,
       }}
     >
       {children}

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useContextMenu.tsx
@@ -4,6 +4,7 @@ import Menu, { MenuProps } from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
+import { usePipelineEditorContext } from "../contexts/PipelineEditorContext";
 type ContextMenuItemAction = {
   type: "item";
   title: string;
@@ -59,9 +60,11 @@ export const PipelineEditorContextMenu: React.FC<{
 };
 
 export function useContextMenu() {
+  const { setIsContextMenuOpen } = usePipelineEditorContext();
   const [position, setPosition] = React.useState<Position>();
   const onClose = React.useCallback(() => {
     setPosition(undefined);
+    setIsContextMenuOpen(false);
   }, []);
   const onSelectMenuItem = React.useCallback(
     (event: React.MouseEvent, item: ContextMenuItemAction) => {
@@ -81,6 +84,7 @@ export function useContextMenu() {
       x: event.clientX,
       y: event.clientY,
     });
+    setIsContextMenuOpen(true);
   };
 
   return {

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -59,11 +59,7 @@ export const PipelineViewport = React.forwardRef<
   React.HTMLAttributes<HTMLDivElement> & {
     canvasFuncRef: React.MutableRefObject<CanvasFunctions | undefined>;
     executeRun: (uuids: string[], type: RunStepsType) => Promise<void>;
-    autoLayoutPipeline;
-    isContextMenuOpenState: [
-      boolean,
-      React.Dispatch<React.SetStateAction<boolean>>
-    ];
+    autoLayoutPipeline: () => void;
   }
 >(function PipelineViewportComponent(
   {
@@ -72,7 +68,6 @@ export const PipelineViewport = React.forwardRef<
     canvasFuncRef,
     executeRun,
     autoLayoutPipeline,
-    isContextMenuOpenState,
     style,
     ...props
   },
@@ -90,6 +85,7 @@ export const PipelineViewport = React.forwardRef<
     environments,
     pipelineCanvasRef,
     getOnCanvasPosition,
+    isContextMenuOpen,
   } = usePipelineEditorContext();
   const {
     pipelineCanvasState: {
@@ -193,7 +189,7 @@ export const PipelineViewport = React.forwardRef<
   }, [resizeCanvas, localRef]);
 
   const onMouseDown = (e: React.MouseEvent) => {
-    if (disabled || isContextMenuOpenState[0]) return;
+    if (disabled || isContextMenuOpen) return;
     if (eventVars.selectedConnection) {
       dispatch({ type: "DESELECT_CONNECTION" });
     }
@@ -209,7 +205,7 @@ export const PipelineViewport = React.forwardRef<
   };
 
   const onMouseUp = (e: React.MouseEvent) => {
-    if (disabled || isContextMenuOpenState[0]) return;
+    if (disabled || isContextMenuOpen) return;
     if (e.button === 0) {
       if (eventVars.stepSelector.active) {
         dispatch({ type: "SET_STEP_SELECTOR_INACTIVE" });


### PR DESCRIPTION
## Description

`onContextMenu` was interfered by `mouseup` event listeners, which causes the intended action was not fired and breaks the context menu. This PR fixes this issue by properly blocking the event listeners.

Fixes: #1108 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
