### PR TITLE
Pass detected ingress class name to orchest-api

### DIFF
--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -513,7 +513,7 @@ def _get_jupyter_server_deployment_service_manifest(
         "kind": "Ingress",
         "metadata": metadata,
         "spec": {
-            "ingressClassName": "nginx",
+            "ingressClassName": _config.INGRESS_CLASS,
             "rules": [ingress_rule],
         },
     }
@@ -1014,7 +1014,7 @@ def _get_user_service_deployment_service_manifest(
             "kind": "Ingress",
             "metadata": ingress_metadata,
             "spec": {
-                "ingressClassName": "nginx",
+                "ingressClassName": _config.INGRESS_CLASS,
                 "rules": [ingress_rule],
             },
         }

--- a/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
@@ -59,7 +59,7 @@ func getNodeAgentDaemonset(metadata metav1.ObjectMeta,
 
 	var one int64 = 1
 
-	socketPath := utils.GetFromFromEnvVar(component.Spec.Template.Env, "CONTAINER_RUNTIME_SOCKET")
+	socketPath := utils.GetKeyFromEnvVar(component.Spec.Template.Env, "CONTAINER_RUNTIME_SOCKET")
 	hostPathSocket := corev1.HostPathType("Socket")
 
 	template := corev1.PodTemplateSpec{

--- a/services/orchest-controller/pkg/utils/k8s_utils.go
+++ b/services/orchest-controller/pkg/utils/k8s_utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	orchestv1alpha1 "github.com/orchest/orchest/services/orchest-controller/pkg/apis/orchest/v1alpha1"
@@ -258,7 +259,7 @@ func GetInstanceOfObj(obj interface{}) client.Object {
 	return nil
 }
 
-func GetFromFromEnvVar(envVars []corev1.EnvVar, key string) string {
+func GetKeyFromEnvVar(envVars []corev1.EnvVar, key string) string {
 
 	for _, envVar := range envVars {
 		if envVar.Name == key {
@@ -275,6 +276,10 @@ func GetEnvVarFromMap(envVars map[string]string) []corev1.EnvVar {
 	for name, value := range envVars {
 		result = append(result, corev1.EnvVar{Name: name, Value: value})
 	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
 
 	return result
 }
@@ -303,12 +308,12 @@ func MergeEnvVars(envVarLists ...[]corev1.EnvVar) []corev1.EnvVar {
 
 // UpsertEnvVariable inserts the env variable from map to the list is not exist or update it
 // if replace it true and returns true if changed the envVarList
-func UpsertEnvVariable(envVarList *[]corev1.EnvVar, defaultEnvVarMap map[string]string, update bool) bool {
+func UpsertEnvVariable(envVarList *[]corev1.EnvVar, eEnvVarMap map[string]string, update bool) bool {
 
 	changed := false
 	envVarMap := GetMapFromEnvVar(*envVarList)
 
-	for defaultName, defaultValue := range defaultEnvVarMap {
+	for defaultName, defaultValue := range eEnvVarMap {
 		if value, ok := envVarMap[defaultName]; !ok || (update && value != defaultValue) {
 			envVarMap[defaultName] = defaultValue
 			*envVarList = append(*envVarList, corev1.EnvVar{Name: defaultName, Value: defaultValue})


### PR DESCRIPTION
## Description

This PR passes the IngressClass name to `orchest-api` as an environment variable, so `orchest-api` can create an ingress resource with the correct class name so that it would be reachable.

Fixes: #1120

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
