### PR TITLE
Update third-parties on Orchest update

### DIFF
--- a/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
+++ b/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
@@ -41,7 +41,7 @@ storage: filesystem
 
 tlsSecretName: registry-tls-secret
 secrets:
-  haSharedSecret: ""
+  haSharedSecret: "haSharedSecret"
   htpasswd: ""
 # Secrets for Azure
 #   azure:

--- a/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
+++ b/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
@@ -41,6 +41,10 @@ storage: filesystem
 
 tlsSecretName: registry-tls-secret
 secrets:
+  # If this value is not specified, the docker-registry helm chart (./helm/templates/secret.yaml) 
+  # randomly generates a new one, so each time the controller compares the deployed manifests with 
+  # the new manifest (to decide whether it needs an update or not), it thinks the manifest is 
+  # changed and re-deploy docker-registry 
   haSharedSecret: "haSharedSecret"
   htpasswd: ""
 # Secrets for Azure

--- a/services/orchest-controller/pkg/addons/addons.go
+++ b/services/orchest-controller/pkg/addons/addons.go
@@ -35,8 +35,8 @@ func NewDefaultAddonsConfig() AddonsConfig {
 }
 
 type Addon interface {
-	// Installs addon if the config is changed
-	Enable(ctx context.Context, namespace string, config *orchestv1alpha1.ApplicationConfig) error
+	// Enable the addon. preInstallHooks should be called, before enabling the addon
+	Enable(ctx context.Context, preInstallHooks []func() error, namespace string, config *orchestv1alpha1.ApplicationConfig) error
 
 	// Uninstall the addon
 	Uninstall(ctx context.Context, namespace string) error
@@ -104,7 +104,7 @@ func (m *AddonManager) EnableAddon(ctx context.Context, addonName, namespace str
 	go func(ctx context.Context, cancel context.CancelFunc) {
 		if addon, ok := m.addons[addonName]; ok {
 			// addon is registered with the addon manager
-			err := addon.Enable(ctx, namespace, nil)
+			err := addon.Enable(ctx, nil, namespace, nil)
 			if err != nil {
 				klog.Errorf("failed to deploy addon: %s, err: %s", addonName, err)
 				cancel()

--- a/services/orchest-controller/pkg/addons/helm_deployer.go
+++ b/services/orchest-controller/pkg/addons/helm_deployer.go
@@ -25,40 +25,57 @@ func NewHelmDeployer(name, deployDir string, valuesPath string) Addon {
 }
 
 // Installs deployer if the config is changed
-func (d *HelmDeployer) Enable(ctx context.Context, namespace string,
+func (d *HelmDeployer) Enable(ctx context.Context, preInstallHooks []func() error,
+	namespace string,
 	config *orchestv1alpha1.ApplicationConfig) error {
 
-	// First we need to check if there is already a release
-	_, err := helm.GetReleaseConfig(ctx, d.name, namespace)
-	if err == nil {
-		return nil
-	}
+	releaseName := fmt.Sprintf("%s-%s", namespace, d.name)
 
-	/*
-		// Transform the values struct to helm values
-		newValues := helm.StructToValues(valuesStruct)
-	*/
-
-	argBuilder := helm.NewHelmArgBuilder()
-	args := argBuilder.WithUpgradeInstall().
-		WithName(fmt.Sprintf("%s-%s", namespace, d.name)).
+	// Generate the deploy args
+	deployArgsBuilder := helm.NewHelmArgBuilder()
+	deployArgs := deployArgsBuilder.WithName(releaseName).
 		WithNamespace(namespace).
 		WithCreateNamespace().
 		WithAtomic().WithTimeout(time.Second * 180)
 
 	if d.valuesPath != "" {
-		args.WithValuesFile(d.valuesPath)
+		deployArgs.WithValuesFile(d.valuesPath)
 	}
 
 	if config.Helm != nil && config.Helm.Parameters != nil {
 		for _, parameter := range config.Helm.Parameters {
-			args.WithSetValue(parameter.Name, parameter.Value)
+			deployArgs.WithSetValue(parameter.Name, parameter.Value)
 		}
 	}
 
-	args.WithRepository(d.deployDir)
+	deployArgs.WithRepository(d.deployDir)
 
-	return helm.DeployRelease(ctx, args.Build())
+	// First we need to check if there is already a release
+	oldConfig, err := helm.GetReleaseConfig(ctx, releaseName, namespace)
+	if err == nil {
+		// check if update is required or not
+		newConfig, err := helm.RunCommand(ctx, deployArgs.WithTemplate().Build())
+		if err != nil {
+			// Failed to get new config, probably it is best to not update
+			return err
+		}
+		// Unfortunately, the value returned from helm get manifest has 1 extra byte,
+		// so in order to compare it with the new config, we have to remove the tail of it.
+		if newConfig == oldConfig[:len(oldConfig)-1] {
+			// There is no need for update, return without err
+			return nil
+		}
+	}
+
+	for _, preInstall := range preInstallHooks {
+		err = preInstall()
+		if err != nil {
+			return nil
+		}
+	}
+
+	helm.RunCommand(ctx, deployArgs.WithUpgradeInstall().Build())
+	return nil
 
 }
 

--- a/services/orchest-controller/pkg/addons/helm_deployer.go
+++ b/services/orchest-controller/pkg/addons/helm_deployer.go
@@ -3,6 +3,7 @@ package addons
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	orchestv1alpha1 "github.com/orchest/orchest/services/orchest-controller/pkg/apis/orchest/v1alpha1"
@@ -60,8 +61,7 @@ func (d *HelmDeployer) Enable(ctx context.Context, preInstallHooks []func() erro
 			return err
 		}
 		// Unfortunately, the value returned from helm get manifest has 1 extra byte,
-		// so in order to compare it with the new config, we have to remove the tail of it.
-		if newConfig == oldConfig[:len(oldConfig)-1] {
+		if strings.TrimSpace(newConfig) == strings.TrimSpace(oldConfig) {
 			// There is no need for update, return without err
 			return nil
 		}

--- a/services/orchest-controller/pkg/addons/helm_deployer.go
+++ b/services/orchest-controller/pkg/addons/helm_deployer.go
@@ -51,16 +51,21 @@ func (d *HelmDeployer) Enable(ctx context.Context, preInstallHooks []func() erro
 
 	deployArgs.WithRepository(d.deployDir)
 
-	// First we need to check if there is already a release
+	// First, we need to check if there is already a release, and if yes get the manifests stored
+	// in helm-related secret, and if the manifest can not be found, we will deploy the release
 	oldConfig, err := helm.GetReleaseConfig(ctx, releaseName, namespace)
 	if err == nil {
-		// check if update is required or not
+		// oldConfig exists, check if an update is required by getting the new config and comparing
+		// it to the old config, if the manifest is the same, no update is required.
+
+		// helm template generates the manifest without connecting to the k8s API server
 		newConfig, err := helm.RunCommand(ctx, deployArgs.WithTemplate().Build())
 		if err != nil {
 			// Failed to get new config, probably it is best to not update
 			return err
 		}
 		// Unfortunately, the value returned from helm get manifest has 1 extra byte,
+		// so we need to trim it off.
 		if strings.TrimSpace(newConfig) == strings.TrimSpace(oldConfig) {
 			// There is no need for update, return without err
 			return nil

--- a/services/orchest-controller/pkg/addons/path_deployer.go
+++ b/services/orchest-controller/pkg/addons/path_deployer.go
@@ -109,7 +109,8 @@ func NewPathDeployer(name, root string, gClient client.Client, scheme *runtime.S
 }
 
 // Installs deployer if the config is changed
-func (d *PathDeployer) Enable(ctx context.Context, namespace string, config *orchestv1alpha1.ApplicationConfig) error {
+func (d *PathDeployer) Enable(ctx context.Context, preInstall []func() error,
+	namespace string, config *orchestv1alpha1.ApplicationConfig) error {
 
 	for _, obj := range d.objects {
 		err := d.gClient.Create(ctx, obj, &client.CreateOptions{})

--- a/services/orchest-controller/pkg/controller/controller_utils.go
+++ b/services/orchest-controller/pkg/controller/controller_utils.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"hash/fnv"
 	"reflect"
 
 	orchestv1alpha1 "github.com/orchest/orchest/services/orchest-controller/pkg/apis/orchest/v1alpha1"
@@ -18,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -183,13 +180,6 @@ func UpsertObject(ctx context.Context, generalClient client.Client, object clien
 	}
 
 	return nil
-}
-
-func ComputeHash(object interface{}) string {
-	hasher := fnv.New32a()
-	utils.DeepHashObject(hasher, object)
-
-	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }
 
 func GetMetadata(resourceName, hash string,

--- a/services/orchest-controller/pkg/controller/orchestcomponent/auth_server.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/auth_server.go
@@ -25,7 +25,7 @@ func NewAuthServerReconciler(ctrl *OrchestComponentController) OrchestComponentR
 
 func (reconciler *AuthServerReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.AuthServer, component)
 	metadata := controller.GetMetadata(controller.AuthServer, hash, component, OrchestComponentKind)
 	newDep := getAuthServerDeployment(metadata, matchLabels, component)
@@ -148,7 +148,7 @@ func getAuthServerDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 
 	return deployment

--- a/services/orchest-controller/pkg/controller/orchestcomponent/celery_worker.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/celery_worker.go
@@ -23,7 +23,7 @@ func NewCeleryWorkerReconciler(ctrl *OrchestComponentController) OrchestComponen
 
 func (reconciler *CeleryWorkerReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.CeleryWorker, component)
 	metadata := controller.GetMetadata(controller.CeleryWorker, hash, component, OrchestComponentKind)
 	newDep := getCeleryWorkerDeployment(metadata, matchLabels, component)
@@ -143,7 +143,7 @@ func getCeleryWorkerDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 	return deployment
 }

--- a/services/orchest-controller/pkg/controller/orchestcomponent/component_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/component_utils.go
@@ -7,6 +7,7 @@ import (
 
 	orchestv1alpha1 "github.com/orchest/orchest/services/orchest-controller/pkg/apis/orchest/v1alpha1"
 	"github.com/orchest/orchest/services/orchest-controller/pkg/controller"
+	"github.com/orchest/orchest/services/orchest-controller/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netsv1 "k8s.io/api/networking/v1"
@@ -173,7 +174,7 @@ func getIngressManifest(metadata metav1.ObjectMeta, path, ingressClass string,
 }
 
 func isDeploymentUpdated(newDep *appsv1.Deployment, oldDep *appsv1.Deployment) bool {
-	if oldHash, _ := oldDep.Labels[controller.DeploymentHashLabelKey]; oldHash == controller.ComputeHash(&newDep.Spec) {
+	if oldHash, _ := oldDep.Labels[controller.DeploymentHashLabelKey]; oldHash == utils.ComputeHash(&newDep.Spec) {
 		return true
 	}
 	return false

--- a/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
@@ -23,7 +23,7 @@ func NewNodeAgentReconciler(ctrl *OrchestComponentController) OrchestComponentRe
 
 func (reconciler *NodeAgentReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.NodeAgent, component)
 	metadata := controller.GetMetadata(controller.NodeAgent, hash, component, OrchestComponentKind)
 	newDs := getNodeAgentDaemonset(metadata, matchLabels, component)

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
@@ -33,7 +33,7 @@ func (reconciler *OrchestApiReconciler) Reconcile(ctx context.Context, component
 		}
 	}
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.OrchestApi, component)
 	metadata := controller.GetMetadata(controller.OrchestApi, hash, component, OrchestComponentKind)
 	newDep := getOrchestApiDeployment(metadata, matchLabels, component,
@@ -106,7 +106,7 @@ func (reconciler *OrchestApiReconciler) Uninstall(ctx context.Context, component
 		return false, err
 	} else if kerrors.IsNotFound(err) {
 		// Cleanup pod is not found, we should create it
-		hash := controller.ComputeHash(component)
+		hash := utils.ComputeHash(component)
 		matchLabels := controller.GetResourceMatchLables(controller.OrchestApiCleanup, component)
 		metadata := controller.GetMetadata(controller.OrchestApiCleanup, hash, component, OrchestComponentKind)
 		cleanupPod := getCleanupPod(metadata, matchLabels, component)
@@ -230,7 +230,7 @@ func getOrchestApiDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 
 	return deployment

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_database.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_database.go
@@ -24,7 +24,7 @@ func NewOrchestDatabaseReconciler(ctrl *OrchestComponentController) OrchestCompo
 
 func (reconciler *OrchestDatabaseReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.OrchestDatabase, component)
 	metadata := controller.GetMetadata(controller.OrchestDatabase, hash, component, OrchestComponentKind)
 	newDep := getOrchestDatabaseDeployment(metadata, matchLabels, component)
@@ -146,7 +146,7 @@ func getOrchestDatabaseDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 
 	return deployment

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
@@ -25,7 +25,7 @@ func NewOrchestWebServerReconciler(ctrl *OrchestComponentController) OrchestComp
 
 func (reconciler *OrchestWebServerReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.OrchestWebserver, component)
 	metadata := controller.GetMetadata(controller.OrchestWebserver, hash, component, OrchestComponentKind)
 	newDep := getOrchestWebserverDeployment(metadata, matchLabels, component)
@@ -168,7 +168,7 @@ func getOrchestWebserverDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 
 	return deployment

--- a/services/orchest-controller/pkg/controller/orchestcomponent/rabbitmq_server.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/rabbitmq_server.go
@@ -23,7 +23,7 @@ func NewRabbitmqServerReconciler(ctrl *OrchestComponentController) OrchestCompon
 
 func (reconciler *RabbitmqServerReconciler) Reconcile(ctx context.Context, component *orchestv1alpha1.OrchestComponent) error {
 
-	hash := controller.ComputeHash(component)
+	hash := utils.ComputeHash(component)
 	matchLabels := controller.GetResourceMatchLables(controller.Rabbitmq, component)
 	metadata := controller.GetMetadata(controller.Rabbitmq, hash, component, OrchestComponentKind)
 	newDep := getRabbitMqDeployment(metadata, matchLabels, component)
@@ -127,7 +127,7 @@ func getRabbitMqDeployment(metadata metav1.ObjectMeta,
 	}
 
 	deployment.Labels = utils.CloneAndAddLabel(metadata.Labels, map[string]string{
-		controller.DeploymentHashLabelKey: controller.ComputeHash(&deployment.Spec),
+		controller.DeploymentHashLabelKey: utils.ComputeHash(&deployment.Spec),
 	})
 
 	return deployment

--- a/services/orchest-controller/pkg/helm/builder.go
+++ b/services/orchest-controller/pkg/helm/builder.go
@@ -6,7 +6,8 @@ import (
 )
 
 type HelmArgBuilder struct {
-	args []string
+	command []string
+	args    []string
 }
 
 func NewHelmArgBuilder() *HelmArgBuilder {
@@ -18,17 +19,27 @@ func NewHelmArgBuilder() *HelmArgBuilder {
 }
 
 func (builder *HelmArgBuilder) WithUpgradeInstall() *HelmArgBuilder {
-	builder.args = append(builder.args, "upgrade", "--install")
+	builder.command = []string{"upgrade", "--install"}
 	return builder
 }
 
 func (builder *HelmArgBuilder) WithUnInstall() *HelmArgBuilder {
-	builder.args = append(builder.args, "uninstall")
+	builder.command = []string{"uninstall", "--install"}
+	return builder
+}
+
+func (builder *HelmArgBuilder) WithTemplate() *HelmArgBuilder {
+	builder.command = []string{"template", "--debug"}
+	return builder
+}
+
+func (builder *HelmArgBuilder) WithGetManifest() *HelmArgBuilder {
+	builder.command = []string{"get", "manifest"}
 	return builder
 }
 
 func (builder *HelmArgBuilder) WithStatus() *HelmArgBuilder {
-	builder.args = append(builder.args, "status")
+	builder.command = []string{"status"}
 	return builder
 }
 
@@ -83,5 +94,5 @@ func (builder *HelmArgBuilder) WithRepository(repo string) *HelmArgBuilder {
 }
 
 func (builder *HelmArgBuilder) Build() []string {
-	return builder.args
+	return append(builder.command, builder.args...)
 }

--- a/services/orchest-controller/pkg/helm/builder.go
+++ b/services/orchest-controller/pkg/helm/builder.go
@@ -24,7 +24,7 @@ func (builder *HelmArgBuilder) WithUpgradeInstall() *HelmArgBuilder {
 }
 
 func (builder *HelmArgBuilder) WithUnInstall() *HelmArgBuilder {
-	builder.command = []string{"uninstall", "--install"}
+	builder.command = []string{"uninstall"}
 	return builder
 }
 

--- a/services/orchest-controller/pkg/utils/util.go
+++ b/services/orchest-controller/pkg/utils/util.go
@@ -1,9 +1,12 @@
 package utils
 
 import (
+	"fmt"
 	"hash"
+	"hash/fnv"
 
 	"github.com/davecgh/go-spew/spew"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 func Contains(list []string, s string) bool {
@@ -23,6 +26,13 @@ func Remove(list []string, s string) []string {
 		}
 	}
 	return list
+}
+
+func ComputeHash(object interface{}) string {
+	hasher := fnv.New32a()
+	DeepHashObject(hasher, object)
+
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }
 
 func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {


### PR DESCRIPTION
## Description

In this PR, the controller checks the deployed manifests of third parties with newly generated manifests and if they are not equal, it updates the helm releases. in this way even if we upgrade the helm templates of third parties, the controller still can update them.

Fixes: #1092 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

