### PR TITLE
fix: show a Snackbar when stopping all sessions.

### DIFF
--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -13,6 +13,7 @@ import MemoryIcon from "@mui/icons-material/Memory";
 import SaveIcon from "@mui/icons-material/Save";
 import Button from "@mui/material/Button";
 import LinearProgress from "@mui/material/LinearProgress";
+import Snackbar from "@mui/material/Snackbar";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { hasValue, uuidv4 } from "@orchest/lib-utils";
@@ -187,7 +188,7 @@ const ConfigureJupyterLabView: React.FC = () => {
       hasStartedKillingSessions && // attempted to build image but got stuck, so started to kill sessions
       !sessionsKillAllInProgress && // the operation of deleting sessions is done
       sessions &&
-      sessions.length === 0; // all sessions are finally cleaned up;
+      Object.keys(sessions).length === 0; // all sessions are finally cleaned up;
 
     if (isAllSessionsDeletedForBuildingImage) {
       setHasStartedKillingSessions(false);
@@ -199,6 +200,12 @@ const ConfigureJupyterLabView: React.FC = () => {
     hasStartedKillingSessions,
     buildImage,
   ]);
+
+  const showStoppingAllSessionsWarning =
+    hasStartedKillingSessions && // attempted to build image but got stuck, so started to kill sessions
+    !sessionsKillAllInProgress && // the operation of deleting sessions is done
+    sessions &&
+    Object.keys(sessions).length > 0;
 
   return (
     <Layout>
@@ -296,6 +303,11 @@ const ConfigureJupyterLabView: React.FC = () => {
           <LinearProgress />
         )}
       </div>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        open={showStoppingAllSessionsWarning}
+        message="Stopping all active sessions..."
+      />
     </Layout>
   );
 };


### PR DESCRIPTION
## Description

Show a Snackbar if user chooses to stop all sessions in order to build JupyterLab. After all sessions are stopped, it will start to build JupyterLab automatically.

<img width="958" alt="Screenshot 2022-07-19 at 12 42 27" src="https://user-images.githubusercontent.com/627607/179732231-1a8ff90c-a2d8-4514-861b-15c153fbdb79.png">

