### PR TITLE
Show a proper warning in PipelineEditor if Jupyterlab is being built.

### DIFF
--- a/services/orchest-webserver/client/src/components/BuildPendingDialog.tsx
+++ b/services/orchest-webserver/client/src/components/BuildPendingDialog.tsx
@@ -24,7 +24,7 @@ const buildFailMessage = `Some environment builds of this project have failed.
 
 const solutionMessages = {
   [BUILD_IMAGE_SOLUTION_VIEW.PIPELINE]:
-    " You can cancel to open the project in read-only mode.",
+    " You can cancel to view the pipeline in read-only mode.",
   [BUILD_IMAGE_SOLUTION_VIEW.JUPYTER_LAB]:
     " To start JupyterLab all environments in the project need to be built.",
 };


### PR DESCRIPTION
## Description

Currently, if JupyterLab is being built, visiting PipelineEditor will get an error about "JupyterEnvironmentBuildInProgress", which is not very user-friendly. This PR makes it so that it prompts an explanation, similar to the environment-images-build warning.

<img width="957" alt="Screenshot 2022-07-19 at 13 20 39" src="https://user-images.githubusercontent.com/627607/179738853-28998d0b-26b2-4e5d-b48c-8ea665d2286f.png">


## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
