### PR TITLE
Fix: App crashing due to bad length check

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -342,7 +342,7 @@ export const FileTree = React.memo(function FileTreeComponent({
 
   const handleMoves = React.useCallback(
     async (moves: readonly Move[]) => {
-      if (!moves) return;
+      if (!moves?.length) return;
 
       for (const check of Object.values(checks)) {
         if (!(await check(moves))) {


### PR DESCRIPTION
## Description

Fixes an error where if a file is dropped at its starting location, the app crashes.

https://user-images.githubusercontent.com/8259221/179940467-b934b014-b5cb-4579-bb42-b5d38e72787d.mov

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.