### PR TITLE
Fix: Pipeline editor readonly after viewing job

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
@@ -26,10 +26,10 @@ export const useIsReadOnly = (
     [dispatch]
   );
 
-  const hasActiveRun = hasValue(runUuid && jobUuid);
+  const hasActiveRun = Boolean(runUuid && jobUuid);
 
   React.useEffect(() => {
-    if (hasActiveRun) setIsReadOnly(true);
+    setIsReadOnly(hasActiveRun);
   }, [hasActiveRun, setIsReadOnly]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Description

When the pipeline is viewed as a job run, it gets stuck in a read-only mode even if you browse back to the interactive pipeline. This PR fixes that.

https://www.loom.com/share/cbfd02356a3543d39c876d41f06e6ce2 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.