### PR TITLE
Fix attempting to start a session when environment build in progress issue.

### DIFF
--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -207,7 +207,7 @@ const reducer = (
 };
 
 const initialState: IProjectsContextState = {
-  pipelineIsReadOnly: false,
+  pipelineIsReadOnly: true,
   pipelineSaveStatus: "saved",
   pipelines: undefined,
   projects: [],

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineEditorContext.tsx
@@ -83,7 +83,7 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     state: { pipelines, projectUuid, pipeline },
   } = useProjectsContext();
   const pipelineUuid = pipeline?.uuid;
-  const { jobUuid, runUuid: runUuidFromRoute } = useCustomRoute();
+  const { jobUuid } = useCustomRoute();
 
   // No pipeline found. Editor is frozen and shows "Pipeline not found".
   const disabled = hasValue(pipelines) && pipelines.length === 0;
@@ -137,13 +137,9 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     [dispatch, instantiateConnection]
   );
 
-  const { runUuid, setRunUuid } = useFetchInteractiveRun(
-    projectUuid,
-    pipelineUuid,
-    runUuidFromRoute
-  );
+  const { runUuid, setRunUuid } = useFetchInteractiveRun();
 
-  const isReadOnly = useIsReadOnly(projectUuid, jobUuid, runUuid);
+  const isReadOnly = useIsReadOnly();
 
   const {
     pipelineCwd,
@@ -154,7 +150,7 @@ export const PipelineEditorContextProvider: React.FC = ({ children }) => {
     error: fetchDataError,
   } = useInitializePipelineEditor(runUuid, isReadOnly, initializeEventVars);
 
-  const session = useAutoStartSession({ isReadOnly });
+  const session = useAutoStartSession();
 
   React.useEffect(() => {
     const startTracking = (e: MouseEvent) =>

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -9,14 +9,14 @@ import { siteMap } from "@/routingConfig";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 
-export const useAutoStartSession = ({ isReadOnly = false }) => {
+export const useAutoStartSession = () => {
   const {
     state: { sessions },
     getSession,
     startSession,
   } = useSessionsContext();
   const {
-    state: { pipeline },
+    state: { pipeline, pipelineIsReadOnly },
   } = useProjectsContext();
   const { setAlert, setConfirm } = useAppContext();
   const { pipelineUuid: pipelineUuidFromRoute, navigateTo } = useCustomRoute();
@@ -30,7 +30,7 @@ export const useAutoStartSession = ({ isReadOnly = false }) => {
     hasValue(sessions) && // `sessions` is available to look up
     hasValue(pipeline?.uuid) && // `pipeline` is loaded.
     pipelineUuidFromRoute === pipeline?.uuid && // Only auto-start the pipeline that user is viewing.
-    !isReadOnly &&
+    !pipelineIsReadOnly &&
     !hasValue(session); // `session` of the current pipeline is not yet launched.
 
   // The only case that auto-start should be disabled is that

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -17,6 +17,7 @@ export const useAutoStartSession = () => {
   } = useSessionsContext();
   const {
     state: { pipeline, pipelineIsReadOnly },
+    dispatch,
   } = useProjectsContext();
   const { setAlert, setConfirm } = useAppContext();
   const { pipelineUuid: pipelineUuidFromRoute, navigateTo } = useCustomRoute();
@@ -52,9 +53,12 @@ export const useAutoStartSession = () => {
       const isBuildingJupyterEnvironment =
         !hasStartedOperation &&
         error.status === 423 &&
-        error.message === "JupyterEnvironmentBuildInProgress";
-
-      if (isBuildingJupyterEnvironment) {
+        error.message === "JupyterEnvironmentBuildInProgress"
+      ) {
+        dispatch({
+          type: "SET_PIPELINE_IS_READONLY",
+          payload: true,
+        });
         setConfirm(
           "Notice",
           "A JupyterLab environment build is in progress. You can cancel to view the pipeline in read-only mode.",
@@ -68,7 +72,7 @@ export const useAutoStartSession = () => {
         );
       }
     },
-    [navigateTo, setConfirm, startSession]
+    [navigateTo, setAlert, setConfirm, startSession, dispatch]
   );
 
   React.useEffect(() => {

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -49,8 +49,7 @@ export const useAutoStartSession = () => {
         pipelineUuid,
         BUILD_IMAGE_SOLUTION_VIEW.PIPELINE
       );
-
-      const isBuildingJupyterEnvironment =
+      if (
         !hasStartedOperation &&
         error.status === 423 &&
         error.message === "JupyterEnvironmentBuildInProgress"
@@ -70,6 +69,8 @@ export const useAutoStartSession = () => {
             confirmLabel: "Configure JupyterLab",
           }
         );
+      } else if (error?.message) {
+        setAlert("Error", `Error while starting the session: ${String(error)}`);
       }
     },
     [navigateTo, setAlert, setConfirm, startSession, dispatch]

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useInitializePipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useInitializePipelineEditor.tsx
@@ -22,17 +22,17 @@ export const useInitializePipelineEditor = (
   const {
     navigateTo,
     projectUuid: projectUuidFromRoute,
-    pipelineUuid: pipelineuuidFromRoute,
+    pipelineUuid: pipelineUuidFromRoute,
     jobUuid,
   } = useCustomRoute();
 
   useEnsureValidPipeline();
 
-  // Because `useEnsureValidPipeline` will auto-redirect if pipelineuuidFromRoute is invalid,
-  // `pipelineUuid` is only valid until `pipeline?.uuid === pipelineuuidFromRoute`,
+  // Because `useEnsureValidPipeline` will auto-redirect if pipelineUuidFromRoute is invalid,
+  // `pipelineUuid` is only valid until `pipeline?.uuid === pipelineUuidFromRoute`,
   // During the transition, it shouldn't fetch pipelineJson.
   const pipelineUuid =
-    pipeline?.uuid === pipelineuuidFromRoute ? pipeline?.uuid : undefined;
+    pipeline?.uuid === pipelineUuidFromRoute ? pipeline?.uuid : undefined;
 
   const {
     pipelineJson,
@@ -89,8 +89,8 @@ export const useInitializePipelineEditor = (
   // Because pipelineJson will be cached by SWR, initialization should only starts when uuid matches.
   const shouldInitialize =
     !isFetchingPipelineJson &&
-    pipelineuuidFromRoute &&
-    pipelineuuidFromRoute === pipelineJson?.uuid;
+    pipelineUuidFromRoute &&
+    pipelineUuidFromRoute === pipelineJson?.uuid;
 
   // initialize eventVars.steps
   React.useEffect(() => {

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -352,17 +352,17 @@ export function getPipelineJSONEndpoint({
   pipelineUuid,
   jobUuid,
   projectUuid,
-  runUuid,
+  jobRunUuid,
 }: {
   pipelineUuid: string | undefined;
   projectUuid: string | undefined;
   jobUuid?: string | undefined;
-  runUuid?: string | undefined;
+  jobRunUuid?: string | undefined;
 }) {
   if (!pipelineUuid || !projectUuid) return "";
   let pipelineURL = `/async/pipelines/json/${projectUuid}/${pipelineUuid}`;
 
-  const queryArgs = { job_uuid: jobUuid, pipeline_run_uuid: runUuid };
+  const queryArgs = { job_uuid: jobUuid, pipeline_run_uuid: jobRunUuid };
   // NOTE: pipeline_run_uuid only makes sense if job_uuid is given
   // i.e. a job run requires both uuid's
   const queryString = jobUuid


### PR DESCRIPTION
## Description

When environment build is in progress, it shouldn't attempt to start a session, otherwise it will prompt an error, e.g. https://www.loom.com/share/cff42bbb98e64fa88660c281268fcc43.

This PR fixes this issue by setting read-only `true` as default and then set it to `false` if conditions met. So that it won't attempt to launch a session when view is just mounted.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
