### PR TITLE
Add version warning for latest docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ myst-parser
 docutils==0.16
 sphinx-hoverxref==1.1.1
 sphinx-design
+sphinx-version-warning

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,16 @@ extensions = [
     "sphinx.ext.napoleon",
     "hoverxref.extension",
     "sphinx_design",
+    "versionwarning.extension",
 ]
+
+versionwarning_body_selector = 'div.content[role="main"]'
+versionwarning_messages = {
+    "latest": (
+        'You are reading the "latest" documentation, '
+        "which corresponds to an unreleased version of Orchest."
+    ),
+}
 
 hoverxref_auto_ref = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,8 @@ versionwarning_body_selector = 'div.content[role="main"]'
 versionwarning_messages = {
     "latest": (
         'You are reading the "latest" documentation, '
-        "which corresponds to an unreleased version of Orchest."
+        "which corresponds to an unreleased version of Orchest. "
+        'Consider browsing the <a href="/en/stable/">stable</a> documentation instead.'
     ),
 }
 


### PR DESCRIPTION
## Description

Add version warning for `latest` docs to minimize confusion.

This is how it looks like:

![image](https://user-images.githubusercontent.com/316517/180226625-07ba9c5a-d0ae-4d15-b2a0-671c37bf4f08.png)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
