### PR TITLE
Document known ipykernel incompatibility

### DIFF
--- a/docs/source/getting_started/faq.md
+++ b/docs/source/getting_started/faq.md
@@ -86,3 +86,18 @@ current deployment to a Kubernetes based one.
 
 Just know that we are super excited to make the Kubernetes version available part of the open core
 and we are invested to provide a smooth migration experience 🔥
+
+## I'm getting `ModuleNotFoundError: No module named` exceptions even after declaring my dependencies
+
+If you are getting weird `ModuleNotFoundError` exceptions
+for libraries that supposedly you declared already,
+there is a chance that you might have reinstalled `ipykernel` with `pip`,
+[which causes a known incompatibility].
+There are two ways to fix this issue:
+
+1. Add `python -m ipykernel install --sys-prefix` at the end of your setup script,
+   which restores the paths `ipykernel` needs to work.
+2. Use mamba (or conda) instead of pip to install your dependencies,
+   which avoid this incompatibility.
+
+[which causes a known incompatibility]: https://github.com/orchest/orchest/issues/425


### PR DESCRIPTION
## Description

Document known ipykernel incompatibility.

Closes gh-425.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
