### PR TITLE
Keep jobs pipeline definitions up to date

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/compat.py
+++ b/lib/python/orchest-internals/_orchest/internals/compat.py
@@ -92,6 +92,12 @@ def _migrate_1_1_0(pipeline: dict) -> None:
                 service["ports"] = [5672]
             elif "tensorflow" in image:
                 service["ports"] = [6006]
+            elif "voila" in image:
+                service["ports"] = [8866]
+            elif "mlflow" in image:
+                service["ports"] = [5000]
+            elif "shiny" in image:
+                service["ports"] = [8000]
             else:
                 service["ports"] = [8080]
 

--- a/lib/python/orchest-internals/_orchest/internals/compat.py
+++ b/lib/python/orchest-internals/_orchest/internals/compat.py
@@ -79,7 +79,21 @@ def _migrate_1_1_0(pipeline: dict) -> None:
             del service["entrypoint"]
 
         if not service.get("ports", []):
-            service["ports"] = [8080]
+            image = service["image"].lower()
+            if "redis" in image:
+                service["ports"] = [6379]
+            elif "postgres" in image:
+                service["ports"] = [5432]
+            elif "streamlit" in image:
+                service["ports"] = [8501]
+            elif "mysql" in image:
+                service["ports"] = [3306]
+            elif "rabbitmq" in image:
+                service["ports"] = [5672]
+            elif "tensorflow" in image:
+                service["ports"] = [6006]
+            else:
+                service["ports"] = [8080]
 
         service["exposed"] = service.get("exposed", False)
         service["requires_authentication"] = service.get(

--- a/lib/python/orchest-internals/_orchest/internals/compat.py
+++ b/lib/python/orchest-internals/_orchest/internals/compat.py
@@ -176,3 +176,11 @@ def migrate_pipeline(pipeline: dict) -> None:
         ]
         migration_func(pipeline)
         pipeline["version"] = migrate_to_version
+
+
+def latest_pipeline_version() -> str:
+    """Gets the latest version of the pipeline schema."""
+    version = "1.0.0"
+    while version in _version_to_migration_function:
+        _, version = _version_to_migration_function[version]
+    return version

--- a/lib/python/orchest-internals/_orchest/internals/compat.py
+++ b/lib/python/orchest-internals/_orchest/internals/compat.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, List, Optional, Tuple
-
 """Provides a simple migration layer for pipeline jsons.
 
 Given a pipeline version, a mapping will be used to establish if the
@@ -15,6 +13,8 @@ which it will migrate.
 Note that the system only supports forward migrations.
 
 """
+from typing import Any, Dict, List, Optional, Tuple
+
 from _orchest.internals import utils as _utils
 
 

--- a/services/orchest-webserver/app/app/core/pipelines.py
+++ b/services/orchest-webserver/app/app/core/pipelines.py
@@ -7,8 +7,9 @@ import uuid
 import requests
 from flask.globals import current_app
 
+from _orchest.internals import compat as _compat
 from _orchest.internals.two_phase_executor import TwoPhaseFunction
-from app import compat, error
+from app import error
 from app.connections import db
 from app.models import Pipeline
 from app.utils import (
@@ -332,7 +333,7 @@ class MovePipeline(TwoPhaseFunction):
             with open(old_path, "r") as json_file:
                 pipeline_def = json.load(json_file)
                 # Ensures that pipeline_def applies the right schema
-                compat.migrate_pipeline(pipeline_def)
+                _compat.migrate_pipeline(pipeline_def)
                 self.collateral_kwargs["pipeline_def_backup"] = copy.deepcopy(
                     pipeline_def
                 )

--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -10,11 +10,11 @@ from typing import Optional
 import requests
 from flask import current_app, safe_join
 
+from _orchest.internals import compat as _compat
 from _orchest.internals import config as _config
 from _orchest.internals import utils as _utils
 from _orchest.internals.utils import copytree, is_services_definition_valid, rmtree
 from app import error
-from app.compat import migrate_pipeline
 from app.config import CONFIG_CLASS as StaticConfig
 from app.models import Environment, Pipeline, Project
 from app.schemas import EnvironmentSchema
@@ -315,8 +315,8 @@ def get_pipeline_json(pipeline_uuid=None, project_uuid=None, pipeline_path=None)
         with open(pipeline_path, "r") as json_file:
             pipeline_json = json.load(json_file)
 
-            # Apply pipeline migrations
-            migrate_pipeline(pipeline_json)
+            # Apply pipeline migrations.
+            _compat.migrate_pipeline(pipeline_json)
 
             return pipeline_json
     except Exception as e:


### PR DESCRIPTION
## Description

This PR fixes the fact that jobs pipeline definitions aren't kept up to date when it comes to the pipeline definition schema. This would have caused issues if the `orchest-api` depended on the pipeline definition of a job being on the latest schema version after a change in the pipeline schema. This was discovered when trying to migrate a pre-k8s Orchest `orchest-api` database to the latest version.

Todos:
- [ ] improve the default port used in `_migrate_1_1_0`


## Checklist

- [X] I have manually tested my changes and I am happy with the result.
- [X] The PR branch is set up to merge into `dev` instead of `master`.
- [X] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
