### PR TITLE
Fallback to buildah pull if docker pull fails

### DIFF
--- a/utility-containers/image-puller/Dockerfile
+++ b/utility-containers/image-puller/Dockerfile
@@ -28,5 +28,8 @@ FROM ubuntu:22.04
 COPY --from=base /bin/ctr /bin/ctr
 COPY --from=base /bin/docker /bin/docker
 
+RUN apt-get update && apt-get install -y buildah && buildah version && \
+    apt-get clean
+
 COPY ./pull_image.sh /pull_image.sh
 RUN chmod +x /pull_image.sh

--- a/utility-containers/image-puller/pull_image.sh
+++ b/utility-containers/image-puller/pull_image.sh
@@ -1,10 +1,22 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -euo pipefail
 
 if [ "$CONTAINER_RUNTIME" = containerd ]; then
     ctr -n=k8s.io -a=/var/run/runtime.sock i pull "${IMAGE_TO_PULL}" --skip-verify
 elif [ "$CONTAINER_RUNTIME" = docker ]; then
+    set +e
     docker -H unix:///var/run/runtime.sock pull "${IMAGE_TO_PULL}" --disable-content-trust
+
+    if [ $? -ne 0 ]; then
+        set -e
+        echo "Docker pull failed, pulling with buildah."
+        buildah pull --tls-verify=false "${IMAGE_TO_PULL}"
+        echo "Pushing from buildah to docker-daemon."
+        # Expected by builda when docker-daemon is specified.
+        ln -s /var/run/runtime.sock /var/run/docker.sock
+        buildah push --disable-compression "${IMAGE_TO_PULL}" "docker-daemon:${IMAGE_TO_PULL}"
+    fi
+
 else
     echo "Container runtime is not supported"
     exit 1

--- a/utility-containers/image-puller/pull_image.sh
+++ b/utility-containers/image-puller/pull_image.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 if [ "$CONTAINER_RUNTIME" = containerd ]; then
     ctr -n=k8s.io -a=/var/run/runtime.sock i pull "${IMAGE_TO_PULL}" --skip-verify
 elif [ "$CONTAINER_RUNTIME" = docker ]; then
+
+    image_exist=$(docker -H unix:///var/run/runtime.sock images -q "${IMAGE_TO_PULL}")
+    if [ -n "${image_exist}" ]; then
+        echo "Image ${IMAGE_TO_PULL} exists, skip pulling."
+        exit 0
+    fi
+
     set +e
     docker -H unix:///var/run/runtime.sock pull "${IMAGE_TO_PULL}" --disable-content-trust
 


### PR DESCRIPTION
## Description

Fallbacks to using `buildah` to pull from the insecure internal registry and push to the docker daemon if pulling with docker fails, i.e. if we are in an environment or k8s flavor where docker won't pull from an insecure registry.