### PR TITLE
Use the IP of the existing registry service

### DIFF
--- a/services/orchest-controller/pkg/controller/controller_utils.go
+++ b/services/orchest-controller/pkg/controller/controller_utils.go
@@ -74,7 +74,7 @@ func AddFinalizerIfNotPresent(ctx context.Context,
 		return false, nil
 	}
 
-	klog.Infof("Object does not have finalizer, Object: %s", object.GetName())
+	klog.V(2).Infof("Object does not have finalizer, Object: %s", object.GetName())
 	copy := object.DeepCopyObject().(client.Object)
 
 	copy.SetFinalizers(append(copy.GetFinalizers(), finalizer))

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -551,7 +551,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 		app := &copy.Spec.Applications[i]
 		if app.Name == addons.DockerRegistry {
 
-			registryChanged, err := setRegistryServiceIP(ctx, occ.Client(), app)
+			registryChanged, err := setRegistryServiceIP(ctx, occ.Client(), copy.Namespace, app)
 			if err != nil {
 				klog.Error(err)
 				return changed, err

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -410,25 +410,19 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 
 	envChanged := utils.UpsertEnvVariable(&copy.Spec.Orchest.Env,
 		occ.config.OrchestDefaultEnvVars, false)
-	if envChanged {
-		changed = true
-	}
+	changed = changed || envChanged
 
 	envChanged = utils.UpsertEnvVariable(&copy.Spec.Orchest.Env,
 		map[string]string{
 			"ORCHEST_CLUSTER":   orchest.Name,
 			"ORCHEST_NAMESPACE": orchest.Namespace,
 		}, false)
-	if envChanged {
-		changed = true
-	}
+	changed = changed || envChanged
 
 	if copy.Spec.Orchest.OrchestHost != nil {
 		envChanged := utils.UpsertEnvVariable(&copy.Spec.Orchest.Env,
 			map[string]string{"ORCHEST_FQDN": *copy.Spec.Orchest.OrchestHost}, true)
-		if envChanged {
-			changed = true
-		}
+		changed = changed || envChanged
 	}
 
 	// Orchest-API configs
@@ -445,9 +439,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 
 	envChanged = utils.UpsertEnvVariable(&copy.Spec.Orchest.OrchestApi.Env,
 		occ.config.OrchestApiDefaultEnvVars, false)
-	if envChanged {
-		changed = true
-	}
+	changed = changed || envChanged
 
 	// Orchest-Webserver configs
 	webserverImage := utils.GetFullImageName(copy.Spec.Orchest.Registry, controller.OrchestWebserver, copy.Spec.Orchest.Version)
@@ -463,9 +455,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 
 	envChanged = utils.UpsertEnvVariable(&copy.Spec.Orchest.OrchestWebServer.Env,
 		occ.config.OrchestWebserverDefaultEnvVars, false)
-	if envChanged {
-		changed = true
-	}
+	changed = changed || envChanged
 
 	// Celery-Worker configs
 	celeryWorkerImage := utils.GetFullImageName(copy.Spec.Orchest.Registry, controller.CeleryWorker, copy.Spec.Orchest.Version)
@@ -481,9 +471,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 
 	envChanged = utils.UpsertEnvVariable(&copy.Spec.Orchest.CeleryWorker.Env,
 		occ.config.CeleryWorkerDefaultEnvVars, false)
-	if envChanged {
-		changed = true
-	}
+	changed = changed || envChanged
 
 	// Auth-Server configs
 	authServerImage := utils.GetFullImageName(copy.Spec.Orchest.Registry, controller.AuthServer, copy.Spec.Orchest.Version)
@@ -557,9 +545,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 				return changed, err
 			}
 
-			if registryChanged {
-				changed = true
-			}
+			changed = changed || registryChanged
 		}
 	}
 

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -272,6 +272,13 @@ func setRegistryServiceIP(ctx context.Context, client kubernetes.Interface,
 		app.Config.Helm.Parameters = []orchestv1alpha1.HelmParameter{}
 	}
 
+	// We first check if there is an IP assigned by the controller for the service in Config
+	// then we check the actual IP of the service if exists, and if they are different the actual
+	// IP takes precedence and the configured IP will be changed to the actual one, (this is to
+	// fix the issue of the instances updated to v2022.07.6 because, controller in that version
+	// assigned the service IP, regardless of the IP of the present service.) If there was
+	// no service, we just find a free IP and set it in the configs
+
 	// We check the current controller assigned service IP first
 	serviceIpIndex := -1
 	for index, param := range app.Config.Helm.Parameters {

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -295,7 +295,7 @@ func setRegistryServiceIP(ctx context.Context, client kubernetes.Interface,
 	// If the service is present
 	if currentIP != "" {
 		if serviceIpIndex >= 0 {
-			changed = app.Config.Helm.Parameters[serviceIpIndex].Value != currentIP && changed
+			changed = app.Config.Helm.Parameters[serviceIpIndex].Value != currentIP || changed
 			app.Config.Helm.Parameters[serviceIpIndex].Value = currentIP
 			return changed, nil
 		} else {

--- a/services/orchest-controller/pkg/helm/helm.go
+++ b/services/orchest-controller/pkg/helm/helm.go
@@ -85,7 +85,7 @@ func RemoveRelease(ctx context.Context, name, namespace string) error {
 		WithUnInstall().
 		WithName(name).
 		WithNamespace(namespace).
-		WithJsonOutput().Build()
+		Build()
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
 


### PR DESCRIPTION
## Description

This issue fixes the problem in updating to v2022.07.6.

In v2022.07.6 we introduced assigning the IP address of the registry service, but if the registry already exists, and the assigned IP by k8s differs from our IP, k8s fails to update the registry.

Fixes: #issue

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
