### PR TITLE
Feature: Generate parameter forms from jsonschema

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
       "dependencies",
       "devDependencies"
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "json-schema-ref-parser": "https://github.com/Bakerburgh/json-schema-ref-parser"
+    }
   }
 }

--- a/services/auth-server/client/package.json
+++ b/services/auth-server/client/package.json
@@ -16,7 +16,12 @@
     "@mui/material": "^5.2.3",
     "@orchest/lib-utils": "workspace:*",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "@jsonforms/core": "^2.5.2",
+    "@jsonforms/material-renderers": "^2.5.2",
+    "@jsonforms/react": "^2.5.2",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -1024,6 +1024,7 @@ def register_views(app, db):
         pipeline_uuid = request.args.get("pipeline_uuid")
         project_uuid = request.args.get("project_uuid")
         job_uuid = request.args.get("job_uuid")
+        run_uuid = request.args.get("run_uuid")
 
         # currently this endpoint only handles "/data"
         # if path is absolute
@@ -1063,6 +1064,15 @@ def register_views(app, db):
                 raise app_error.OutOfDataDirectoryError(
                     "Path points outside of the data directory."
                 )
+        elif path.endswith("schema.json"):
+            pipeline_dir = get_pipeline_directory(
+                pipeline_uuid=pipeline_uuid,
+                project_uuid=project_uuid,
+                job_uuid=job_uuid,
+                pipeline_run_uuid=run_uuid,
+            )
+            file_path = normalize_project_relative_path(path)
+            file_path = os.path.join(pipeline_dir, file_path)
         else:
             path_parent_dir = get_snapshot_directory(
                 pipeline_uuid, project_uuid, job_uuid

--- a/services/orchest-webserver/client/src/hooks/useCheckFileValidity.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckFileValidity.tsx
@@ -91,3 +91,43 @@ export const useCheckFileValidity = ({
 
   return [isValidPathPattern && data, status === "PENDING"] as const;
 };
+
+/**
+ * checks if a file exists with the given path, poll per 1000 ms
+ * @param project_uuid {string|undefined}
+ * @param pipeline_uuid {string|undefined}
+ * @param path {string|undefined}
+ * @returns boolean
+ */
+export const useReadFile = ({
+  path,
+  projectUuid,
+  pipelineUuid,
+  jobUuid,
+  runUuid,
+  allowedExtensions,
+  useProjectRoot = false,
+}: ValidateFileProps) => {
+  const isQueryArgsComplete =
+    hasValue(projectUuid) && hasValue(pipelineUuid) && hasValue(path);
+
+  const isValidPathPattern =
+    isQueryArgsComplete && isValidPath(path, allowedExtensions);
+
+  const delayedPath = useDebounce(path, 250);
+
+  const { data = false, status } = useFetcher<{ message: string }, boolean>(
+    isValidPathPattern
+      ? `${FILE_MANAGEMENT_ENDPOINT}/read?${queryArgs({
+          projectUuid,
+          pipelineUuid,
+          jobUuid,
+          runUuid,
+          path: delayedPath || path,
+          useProjectRoot,
+        })}`
+      : undefined
+  );
+
+  return [data, status === "PENDING"] as const;
+};

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsContext.tsx
@@ -1,4 +1,7 @@
-import { useCheckFileValidity } from "@/hooks/useCheckFileValidity";
+import {
+  useCheckFileValidity,
+  useReadFile,
+} from "@/hooks/useCheckFileValidity";
 import { PipelineStepState } from "@/types";
 import { ALLOWED_STEP_EXTENSIONS } from "@orchest/lib-utils";
 import React from "react";
@@ -10,6 +13,10 @@ export type StepDetailsContextType = {
   isCheckingFileValidity: boolean;
   step: PipelineStepState;
   connections: ConnectionDict;
+  stepSchema: object | boolean;
+  isReadingSchemaFile: boolean;
+  stepUiSchema: object | boolean;
+  isReadingUiSchemaFile: boolean;
 };
 
 export const StepDetailsContext = React.createContext<StepDetailsContextType>(
@@ -36,6 +43,24 @@ export const StepDetailsContextProvider: React.FC = ({ children }) => {
     allowedExtensions: ALLOWED_STEP_EXTENSIONS,
   });
 
+  const [stepSchema, isReadingSchemaFile] = useReadFile({
+    projectUuid,
+    pipelineUuid,
+    jobUuid,
+    runUuid,
+    path: step?.file_path.concat(".schema.json"),
+    allowedExtensions: ["json"],
+  });
+
+  const [stepUiSchema, isReadingUiSchemaFile] = useReadFile({
+    projectUuid,
+    pipelineUuid,
+    jobUuid,
+    runUuid,
+    path: step?.file_path.concat(".uischema.json"),
+    allowedExtensions: ["json"],
+  });
+
   const connections = React.useMemo(() => {
     if (!step) return {};
 
@@ -54,6 +79,10 @@ export const StepDetailsContextProvider: React.FC = ({ children }) => {
         isCheckingFileValidity,
         connections,
         step,
+        stepSchema,
+        isReadingSchemaFile,
+        stepUiSchema,
+        isReadingUiSchemaFile,
       }}
     >
       {children}

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetailsProperties.tsx
@@ -4,6 +4,11 @@ import { firstAncestor } from "@/utils/element";
 import { isValidJson } from "@/utils/isValidJson";
 import { hasExtension, join } from "@/utils/path";
 import { toValidFilename } from "@/utils/toValidFilename";
+import {
+  materialCells,
+  materialRenderers,
+} from "@jsonforms/material-renderers";
+import { JsonForms } from "@jsonforms/react";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import FormControl from "@mui/material/FormControl";
@@ -72,6 +77,7 @@ export const StepDetailsProperties = ({
   const [editableParameters, setEditableParameters] = React.useState(
     JSON.stringify(step.parameters, null, 2)
   );
+  const [parametersData, setParametersData] = React.useState(step.parameters);
 
   const refManager = React.useMemo(() => new RefManager(), []);
 
@@ -126,6 +132,14 @@ export const StepDetailsProperties = ({
     setEditableParameters(updatedParameterJSON);
     try {
       onSave({ parameters: JSON.parse(updatedParameterJSON) }, step.uuid, true);
+      setParametersData(JSON.parse(updatedParameterJSON));
+    } catch (err) {}
+  };
+
+  const onChangeParameterData = (data: object) => {
+    setEditableParameters(JSON.stringify(data, null, 2));
+    try {
+      onSave({ parameters: data }, step.uuid, true);
     } catch (err) {}
   };
 
@@ -305,7 +319,14 @@ export const StepDetailsProperties = ({
     return isValidJson(editableParameters);
   }, [editableParameters]);
 
-  const { doesStepFileExist, isCheckingFileValidity } = useStepDetailsContext();
+  const {
+    doesStepFileExist,
+    isCheckingFileValidity,
+    stepSchema,
+    isReadingSchemaFile,
+    stepUiSchema,
+    isReadingUiSchemaFile,
+  } = useStepDetailsContext();
 
   return (
     <div className={"detail-subview"}>
@@ -393,6 +414,19 @@ export const StepDetailsProperties = ({
           />
           {!isParametersValidJson && (
             <Alert severity="warning">Your input is not valid JSON.</Alert>
+          )}
+          {stepSchema && (
+            <JsonForms
+              schema={stepSchema}
+              uischema={stepUiSchema}
+              data={parametersData}
+              renderers={materialRenderers}
+              cells={materialCells}
+              onChange={({ data, _errors }) => {
+                //setEditableParameters(JSON.stringify(data, null, 2));
+                onChangeParameterData(data);
+              }}
+            />
           )}
         </Box>
 


### PR DESCRIPTION
## Description

I work on a project which involves non-developers, and thus step parameters per json is cumbersome. The idea to solve this is to describe the parameters per jsonschema and use this information to render a nice form to edit the step parameters.

![parameters example](https://user-images.githubusercontent.com/7195718/182356803-b8b9e39f-5332-4e37-9e6c-7a9aa6a44eee.png)

The idea behind this feature: 
* use Jsonforms (https://jsonforms.io/) to render the input form for step parameters
* use per step sidecar file <stepfilename>.schema.json to provide parameter schema information
* use per step sidecar file <stepfilename>.uischema.json to provide further ui information
* schema files are optional (just no form without a schema.json)
* no read / execute of stepfile required to build form
* parameter raw json still visible and editable

The code behind the PR works but still has issues to iron out:
* jsonforms uses a ref parser, which uses node.js internals, which hinder the build with esbuild.
  * A workaround is to fix the parser to a fixed version, but that one is rather old and behind! ( https://github.com/Bakerburgh/json-schema-ref-parser )
  *  I stll lack insight into the build system and the issue to find a propper solution
* At the least the currently used theme interferes with the orchest ui 
![issues](https://user-images.githubusercontent.com/7195718/182359623-67810e31-b407-4d10-ad07-725a34e40fe6.png)
* It would be reasonable to try out other frameworks for the rendering of forms, jsonforms was just the one that delivered the best results out of the box from my limited testing.

I'm very open for discussion and pointing out issues with the idea! And I'm willing to provide proper documentation as soon as the path becomes clear.

I added two sample steps with schema: [samples.zip](https://github.com/orchest/orchest/files/9241719/samples.zip)

I'd love to see this feature in orchest to be able to create steps usable by someone else than myself ;)

## Checklist

- [ ] I have manually tested my changes and I am happy with the result.
- [ ] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).

