### PR TITLE
Add endpoint to trigger a job run "manually"

### DIFF
--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -494,6 +494,17 @@ def register_orchest_api_views(app, db):
 
         return resp.content, resp.status_code, resp.headers.items()
 
+    @app.route("/catch/api-proxy/api/jobs/<job_uuid>/runs/trigger", methods=["POST"])
+    def catch_api_proxy_job_run_trigger(job_uuid):
+
+        resp = requests.post(
+            "http://"
+            + app.config["ORCHEST_API_ADDRESS"]
+            + f"/api/jobs/{job_uuid}/runs/trigger"
+        )
+
+        return resp.content, resp.status_code, resp.headers.items()
+
     @app.route("/catch/api-proxy/api/jobs/<job_uuid>", methods=["PUT"])
     def catch_api_proxy_job_put(job_uuid):
 

--- a/services/orchest-webserver/client/src/job-view/JobView.tsx
+++ b/services/orchest-webserver/client/src/job-view/JobView.tsx
@@ -23,8 +23,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import PlayArrowOutlinedIcon from "@mui/icons-material/PlayArrowOutlined";
 import RefreshIcon from "@mui/icons-material/Refresh";
-import Three60Icon from "@mui/icons-material/ThreeSixty";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -440,7 +440,7 @@ const JobView: React.FC = () => {
                 <Button
                   variant="contained"
                   onClick={triggerScheduledRuns}
-                  startIcon={<Three60Icon />}
+                  startIcon={<PlayArrowOutlinedIcon />}
                 >
                   Trigger scheduled runs
                 </Button>

--- a/services/orchest-webserver/client/src/job-view/JobView.tsx
+++ b/services/orchest-webserver/client/src/job-view/JobView.tsx
@@ -24,6 +24,7 @@ import FileCopyIcon from "@mui/icons-material/FileCopy";
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import Three60Icon from "@mui/icons-material/ThreeSixty";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -135,6 +136,22 @@ const JobView: React.FC = () => {
     } catch (error) {
       console.error(error);
       setAlert("Error", `Failed to resume job: ${error}`);
+    }
+  };
+
+  const triggerScheduledRuns = async () => {
+    if (!job) return Promise.reject();
+    try {
+      await run(
+        fetcher<{ next_scheduled_time: string }>(
+          `/catch/api-proxy/api/jobs/${job.uuid}/runs/trigger`,
+          { method: "POST" }
+        )
+      );
+      reload();
+    } catch (error) {
+      console.error(error);
+      setAlert("Error", `Failed to trigger job runs: ${error}`);
     }
   };
 
@@ -411,6 +428,21 @@ const JobView: React.FC = () => {
                   startIcon={<PlayArrowIcon />}
                 >
                   Resume
+                </Button>
+              )}
+
+              {((job.schedule !== null &&
+                ["PAUSED", "STARTED"].includes(job.status)) ||
+                // One off scheduled jobs that are pending.
+                (job.schedule === null &&
+                  job.next_scheduled_time !== null &&
+                  job.status === "PENDING")) && (
+                <Button
+                  variant="contained"
+                  onClick={triggerScheduledRuns}
+                  startIcon={<Three60Icon />}
+                >
+                  Trigger scheduled runs
                 </Button>
               )}
 

--- a/services/orchest-webserver/client/src/job-view/JobView.tsx
+++ b/services/orchest-webserver/client/src/job-view/JobView.tsx
@@ -442,7 +442,7 @@ const JobView: React.FC = () => {
                   onClick={triggerScheduledRuns}
                   startIcon={<PlayArrowOutlinedIcon />}
                 >
-                  Trigger scheduled runs
+                  Trigger job now
                 </Button>
               )}
 


### PR DESCRIPTION
## Description

Adds an endpoint (and later some FE changes) to allow triggering a job run (a batch of pipeline runs) for jobs that are `PENDING|STARTED|PAUSED`. 

Fixes: #1181 

## Checklist

- [X] I have manually tested my changes and I am happy with the result.

@yannickperrenet @ricklamers 
The BE is not very strict about requirements to trigger a job run, but I'm not sure about exposing a button for one-off.  jobs that are STARTED. Maybe it should be shown only for cronjobs which are `STARTED|PAUSED` and `PENDING` one-off jobs (one-off jobs scheduled in the future?). Also happy to make the BE more picky about the required state

