### PR TITLE
Fix app crashing when viewing parameters under some circumstances

### DIFF
--- a/services/orchest-webserver/client/src/components/ParameterEditor.tsx
+++ b/services/orchest-webserver/client/src/components/ParameterEditor.tsx
@@ -64,7 +64,7 @@ const ParameterEditor: React.FC<IParameterEditorProps> = (props) => {
   React.useEffect(() => {
     if (activeParameter) {
       // `editor` is not defined in CodeMirror. So we need this workaround.
-      (codeMirrorRef.current as any).editor.focus(); // eslint-disable-line @typescript-eslint/no-explicit-any
+      (codeMirrorRef.current as any)?.editor?.focus(); // eslint-disable-line @typescript-eslint/no-explicit-any
     }
   }, [activeParameter]);
 


### PR DESCRIPTION
## Description

From Slack:

Looks like there is an issue with the ParameterEditor component of the FE, to reproduce:
- create a pipeline with parameters
- create a job with some parameterized runs
- start the job
- go back to the job, open the parameters view

This PR fixes that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
