### PR TITLE
Fix: peer dependency issue when building web server

### DIFF
--- a/services/orchest-webserver/Dockerfile
+++ b/services/orchest-webserver/Dockerfile
@@ -3,8 +3,8 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 # Install required system packages and refresh certs
 RUN apt-get update \
-    && apt-get install -y ca-certificates git rsync netcat \
-    && update-ca-certificates --fresh
+  && apt-get install -y ca-certificates git rsync netcat \
+  && update-ca-certificates --fresh
 
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install -y nodejs
@@ -33,7 +33,7 @@ COPY ./pnpm_files/* /orchest/
 WORKDIR /orchest
 
 RUN npm run setup
-RUN pnpm i && \
+RUN pnpm i --strict-peer-dependencies=false && \
   pnpm run build --stream --filter "@orchest/client-orchest" && \
   # Clean node_modules to reduce image size
   find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +


### PR DESCRIPTION
## Description

When building the webserver container, the following error appears:

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

services/orchest-webserver/client
├─┬ react-codemirror2 7.2.1
│ └── ✕ unmet peer react@">=15.5 <=16.x": found 17.0.2
└─┬ xterm-for-react 1.0.4
  ├── ✕ unmet peer react@^16.0.0: found 17.0.2
  └── ✕ unmet peer react-dom@^16.0.0: found 17.0.2
```

This PR fixes that!

The core issue is that our `.npmrc` isn't copied into the container because it is at the root of the repo, and not at the root of the webserver project.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
