### PR TITLE
Remove Argo Server

### DIFF
--- a/services/orchest-controller/deploy/thirdparty/argo-workflows/orchest-values.yaml
+++ b/services/orchest-controller/deploy/thirdparty/argo-workflows/orchest-values.yaml
@@ -271,7 +271,7 @@ executor:
 
 server:
   # -- Deploy the Argo Server
-  enabled: true
+  enabled: false
   # -- Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /.
   ## only updates base url of resources on client side,
   ## it's expected that a proxy server rewrites the request URL and gets rid of this prefix

--- a/userdir/.gitignore
+++ b/userdir/.gitignore
@@ -1,2 +1,0 @@
-.ipynb_checkpoints
-*.db

--- a/userdir/.orchest/database/.gitignore
+++ b/userdir/.orchest/database/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/userdir/.orchest/kernels/.gitignore
+++ b/userdir/.orchest/kernels/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/userdir/.orchest/rabbitmq-mnesia/.gitignore
+++ b/userdir/.orchest/rabbitmq-mnesia/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/userdir/.orchest/user-configurations/jupyterlab/.gitignore
+++ b/userdir/.orchest/user-configurations/jupyterlab/.gitignore
@@ -1,1 +1,0 @@
-setup_script.sh

--- a/userdir/.orchest/user-configurations/jupyterlab/lab/.gitignore
+++ b/userdir/.orchest/user-configurations/jupyterlab/lab/.gitignore
@@ -1,3 +1,0 @@
-*
-
-!.gitignore

--- a/userdir/.orchest/user-configurations/jupyterlab/user-settings/.gitignore
+++ b/userdir/.orchest/user-configurations/jupyterlab/user-settings/.gitignore
@@ -1,3 +1,0 @@
-*
-
-!.gitignore

--- a/userdir/README.md
+++ b/userdir/README.md
@@ -1,1 +1,0 @@
-This directory contains the pipeline files of the user that are associated to this Orchest instance.

--- a/userdir/data/.gitignore
+++ b/userdir/data/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/userdir/jobs/.gitignore
+++ b/userdir/jobs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/userdir/projects/.gitignore
+++ b/userdir/projects/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Description

Removes Argo Server (we have never used but never disabled it) and `userdir` from the top-level repo directory (we dynamically create the structure in the app now).

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
