### PR TITLE
UI Overhaul: Change copy and action of "Job run snapshots"

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/ReadOnlyBanner.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ReadOnlyBanner.tsx
@@ -18,9 +18,9 @@ import { usePipelineUiStateContext } from "./contexts/PipelineUiStateContext";
 const generateReadOnlyMessage = (jobName: string | undefined) =>
   jobName ? (
     <>
-      {`This is a read-only pipeline snapshot from `}
-      <b>{jobName}</b>
-      {` job. Make edits in the Pipeline editor.`}
+      {`This is a read-only pipeline snapshot from the `}
+      <strong>{jobName}</strong>
+      {` job.`}
     </>
   ) : null;
 
@@ -57,18 +57,18 @@ export const ReadOnlyBanner = () => {
 
   const { triggerBuilds, viewBuildStatus } = useBuildEnvironmentImages();
 
-  const { job, projectUuid, pipelineUuid } = usePipelineDataContext();
+  const { job, projectUuid } = usePipelineDataContext();
 
   const { title, action, actionLabel } = React.useMemo(() => {
     switch (pipelineReadOnlyReason) {
       case "isJobRun":
         return {
-          title: "Pipeline snapshot",
-          actionLabel: "Open in editor",
+          title: "Job run snapshot",
+          actionLabel: "View all runs",
           action: (event: React.MouseEvent) =>
             navigateTo(
-              siteMap.pipeline.path,
-              { query: { projectUuid, pipelineUuid } },
+              siteMap.job.path,
+              { query: { projectUuid, jobUuid: job?.uuid } },
               event
             ),
         };
@@ -114,15 +114,15 @@ export const ReadOnlyBanner = () => {
         return {};
     }
   }, [
-    navigateTo,
     pipelineReadOnlyReason,
-    environmentsToBeBuilt,
-    buildingEnvironments,
-    projectUuid,
-    pipelineUuid,
+    environmentsToBeBuilt.length,
+    buildingEnvironments.length,
     viewBuildStatus,
-    triggerBuilds,
+    navigateTo,
+    projectUuid,
+    job?.uuid,
     dispatch,
+    triggerBuilds,
   ]);
 
   const showLinearProgress =


### PR DESCRIPTION
## Description

This should make it more convenient to navigate back to job runs.
The pipeline can still be navigate to using the "PIPELINES" menu item.

![image](https://user-images.githubusercontent.com/8259221/186692547-f9474d23-7c59-4c82-bef4-fb0429b3ada2.png)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
