### PR TITLE
fix: apply selectors properly to zustand hooks

### DIFF
--- a/services/orchest-webserver/client/src/components/Accordion.tsx
+++ b/services/orchest-webserver/client/src/components/Accordion.tsx
@@ -6,33 +6,21 @@ import MuiAccordionSummary, {
 } from "@mui/material/AccordionSummary";
 import { styled } from "@mui/material/styles";
 import React from "react";
-import { useEnvironmentsUiStateStore } from "../stores/useEnvironmentsUiStateStore";
 
-const StyledAccordion = styled((props: AccordionProps) => (
+export const Accordion = styled((props: AccordionProps) => (
   <MuiAccordion disableGutters elevation={0} square {...props} />
 ))({ "&:before": { display: "none" } });
 
-export const EnvironmentsAccordion = (props: AccordionProps) => {
-  const { reset } = useEnvironmentsUiStateStore();
-  React.useEffect(() => {
-    return () => reset();
-  }, [reset]);
-
-  return <StyledAccordion {...props} />;
-};
-
-export const EnvironmentsAccordionSummary = styled(
-  (props: AccordionSummaryProps) => (
-    <MuiAccordionSummary
-      expandIcon={
-        <ArrowForwardIosSharpIcon
-          sx={{ fontSize: (theme) => theme.spacing(2) }}
-        />
-      }
-      {...props}
-    />
-  )
-)(({ theme }) => ({
+export const AccordionSummary = styled((props: AccordionSummaryProps) => (
+  <MuiAccordionSummary
+    expandIcon={
+      <ArrowForwardIosSharpIcon
+        sx={{ fontSize: (theme) => theme.spacing(2) }}
+      />
+    }
+    {...props}
+  />
+))(({ theme }) => ({
   paddingLeft: 0,
   flexDirection: "row-reverse",
   "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
@@ -43,6 +31,6 @@ export const EnvironmentsAccordionSummary = styled(
   },
 }));
 
-export const EnvironmentsAccordionDetails = styled(MuiAccordionDetails)({
+export const AccordionDetails = styled(MuiAccordionDetails)({
   padding: 0,
 });

--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -388,7 +388,7 @@ export const ProjectsContextProvider: React.FC = ({ children }) => {
     [requestBuild, state.projectUuid]
   );
 
-  const { validate } = useEnvironmentsApi();
+  const validate = useEnvironmentsApi((state) => state.validate);
 
   const ensureEnvironmentsAreBuilt = React.useCallback(
     async (

--- a/services/orchest-webserver/client/src/environments-view/BuildEnvironmentButton.tsx
+++ b/services/orchest-webserver/client/src/environments-view/BuildEnvironmentButton.tsx
@@ -7,21 +7,24 @@ import { useBuildEnvironmentImage } from "./hooks/useBuildEnvironmentImage";
 import { useEditEnvironment } from "./stores/useEditEnvironment";
 
 export const BuildEnvironmentButton = () => {
-  const { environmentChanges } = useEditEnvironment();
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+
   const [triggerBuild, cancelBuild] = useBuildEnvironmentImage();
 
-  const buildStatus = environmentChanges?.latestBuild?.status;
+  const buildStatus = latestBuild?.status;
 
   const isBuilding =
     hasValue(buildStatus) && ["PENDING", "STARTED"].includes(buildStatus);
 
   const handleClick = () => {
-    if (!environmentChanges) return;
-
+    if (!uuid) return;
     if (isBuilding) {
-      cancelBuild(environmentChanges.uuid);
+      cancelBuild(uuid);
     } else {
-      triggerBuild([environmentChanges.uuid]);
+      triggerBuild([uuid]);
     }
   };
 

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
@@ -13,8 +13,12 @@ import { useEditEnvironment } from "./stores/useEditEnvironment";
 
 export const EnvironmentMenuList = () => {
   useSyncEnvironmentUuidWithQueryArgs();
-  const { environmentChanges } = useEditEnvironment();
-  const { environments = [], setEnvironment } = useEnvironmentsApi();
+  const environmentChanges = useEditEnvironment(
+    (state) => state.environmentChanges
+  );
+
+  const setEnvironment = useEnvironmentsApi((state) => state.setEnvironment);
+  const environments = useEnvironmentsApi((state) => state.environments);
   const { selectEnvironment } = useSelectEnvironment();
 
   const updateStoreAndRedirect = (uuid: string) => {
@@ -48,7 +52,7 @@ export const EnvironmentMenuList = () => {
         }}
         tabIndex={0} // MUI's MenuList default is -1
       >
-        {environments.map((environment) => {
+        {(environments || []).map((environment) => {
           const selected =
             hasValue(environmentChanges) &&
             environmentChanges.uuid === environment.uuid;

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMoreOptions.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMoreOptions.tsx
@@ -27,17 +27,17 @@ const getNextEnvironmentUuid = (
 
 export const EnvironmentMoreOptions = () => {
   const { setConfirm } = useGlobalContext();
-  const { environmentChanges } = useEditEnvironment();
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const name = useEditEnvironment((state) => state.environmentChanges?.name);
+  const action = useEditEnvironment(
+    (state) => state.environmentChanges?.action
+  );
+
   const { selectEnvironment } = useSelectEnvironment();
-  const [
-    deleteEnvironment,
-    isDeleting,
-    environments = [],
-  ] = useEnvironmentsApi((state) => [
-    state.delete,
-    state.isDeleting,
-    state.environments,
-  ]);
+
+  const deleteEnvironment = useEnvironmentsApi((state) => state.delete);
+  const isDeleting = useEnvironmentsApi((state) => state.isDeleting);
+  const environments = useEnvironmentsApi((state) => state.environments);
 
   const [anchorElement, setAnchorElement] = React.useState<
     Element | undefined
@@ -48,18 +48,18 @@ export const EnvironmentMoreOptions = () => {
 
   const showDeleteEnvironmentDialog = () => {
     handleClose();
-    if (!environmentChanges) return;
+    if (!name || !uuid) return;
     setConfirm(
-      `Delete "${environmentChanges.name}"`,
+      `Delete "${name}"`,
       "Are you sure you want to delete this Environment?",
       {
         onConfirm: (resolve) => {
           const nextEnvironmentUuid = getNextEnvironmentUuid(
-            environments,
-            environmentChanges.uuid
+            environments || [],
+            uuid
           );
 
-          deleteEnvironment(environmentChanges).then(() => {
+          deleteEnvironment(uuid, action).then(() => {
             selectEnvironment(nextEnvironmentUuid);
             resolve(true);
           });
@@ -96,7 +96,7 @@ export const EnvironmentMoreOptions = () => {
         transformOrigin={{ vertical: "top", horizontal: "right" }}
       >
         <MenuItem
-          disabled={!hasValue(environmentChanges) || isDeleting}
+          disabled={!uuid || isDeleting}
           onClick={showDeleteEnvironmentDialog}
         >
           <ListItemIcon>

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/BaseImageRadioOption.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/BaseImageRadioOption.tsx
@@ -77,10 +77,10 @@ export const BaseImageRadioOption = React.memo(function BaseImageRadioOption({
   children,
   ...props
 }: BaseImageRadioOptionProps) {
-  const { environmentChanges } = useEditEnvironment();
-  const disabledOnBuilding = isEnvironmentBuilding(
-    environmentChanges?.latestBuild
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
   );
+  const disabledOnBuilding = isEnvironmentBuilding(latestBuild);
 
   return (
     <BaseImageRadioOptionBase

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/BuildStatusAlert.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/BuildStatusAlert.tsx
@@ -24,8 +24,10 @@ const alertMessageMapping: Record<
 };
 
 export const BuildStatusAlert = () => {
-  const { environmentChanges } = useEditEnvironment();
-  const latestBuildStatus = environmentChanges?.latestBuild?.status;
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+  const latestBuildStatus = latestBuild?.status;
 
   const alert = alertMessageMapping[latestBuildStatus || ""];
   return (
@@ -33,9 +35,7 @@ export const BuildStatusAlert = () => {
       {hasValue(alert) && (
         <Alert
           severity={alert.severity}
-          icon={
-            <BuildStatusIcon latestBuild={environmentChanges?.latestBuild} />
-          }
+          icon={<BuildStatusIcon latestBuild={latestBuild} />}
         >
           {alert.message}
         </Alert>

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
@@ -19,8 +19,9 @@ export const EditEnvironmentContainer = ({
   useSaveEnvironmentChanges();
   useUpdateBuildStatusInEnvironmentChanges();
 
-  const { environments } = useEnvironmentsApi();
-  const hasNoEnvironment = environments?.length === 0;
+  const hasNoEnvironment = useEnvironmentsApi(
+    (state) => state.environments?.length === 0
+  );
 
   return hasNoEnvironment ? (
     <NoEnvironment />

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentName.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentName.tsx
@@ -6,18 +6,26 @@ import { useEditEnvironment } from "../stores/useEditEnvironment";
 
 export const EditEnvironmentName = () => {
   const { environmentUuid } = useCustomRoute();
-  const { environmentChanges, setEnvironmentChanges } = useEditEnvironment();
+
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const name = useEditEnvironment((state) => state.environmentChanges?.name);
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+  const setEnvironmentChanges = useEditEnvironment(
+    (state) => state.setEnvironmentChanges
+  );
+
   const [value = "", setValue] = React.useState<string>();
   const [hasEdited, setHasEdited] = React.useState(false);
 
-  const isEnvironmentLoaded =
-    environmentUuid && environmentUuid === environmentChanges?.uuid;
+  const isEnvironmentLoaded = environmentUuid && environmentUuid === uuid;
 
   React.useEffect(() => {
-    if (isEnvironmentLoaded && environmentChanges?.name) {
-      setValue(environmentChanges?.name);
+    if (isEnvironmentLoaded && name) {
+      setValue(name);
     }
-  }, [environmentChanges?.name, isEnvironmentLoaded, environmentUuid]);
+  }, [name, isEnvironmentLoaded, environmentUuid]);
 
   const isInvalid = hasEdited && value.trim().length === 0;
 
@@ -38,7 +46,7 @@ export const EditEnvironmentName = () => {
       error={isInvalid}
       helperText={isInvalid ? "Environment name cannot be blank" : " "}
       label="Environment name"
-      disabled={isEnvironmentBuilding(environmentChanges?.latestBuild)}
+      disabled={isEnvironmentBuilding(latestBuild)}
       sx={{ width: { xs: "100%", lg: "50%" } }}
     />
   );

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
@@ -11,13 +11,14 @@ import { useBuildEnvironmentImage } from "../hooks/useBuildEnvironmentImage";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 import {
   EnvironmentAccordion,
-  useEnvironmentAccordions,
+  useLogsAccordion,
 } from "./components/EnvironmentAccordion";
 
 export const EnvironmentImageBuildLogs = () => {
   const { projectUuid, environmentUuid } = useCustomRoute();
   const { config } = useGlobalContext();
-  const { isLogsOpen, setIsLogsOpen } = useEnvironmentAccordions();
+
+  const [isLogsOpen, setIsLogsOpen] = useLogsAccordion();
 
   const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
   const latestBuild = useEditEnvironment(

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
@@ -1,3 +1,4 @@
+import { AccordionDetails, AccordionSummary } from "@/components/Accordion";
 import { ImageBuildLog } from "@/components/ImageBuildLog";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
@@ -9,17 +10,23 @@ import React from "react";
 import { useBuildEnvironmentImage } from "../hooks/useBuildEnvironmentImage";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 import {
-  EnvironmentsAccordion,
-  EnvironmentsAccordionDetails,
-  EnvironmentsAccordionSummary,
-} from "./components/EnvironmentsAccordion";
-import { useEnvironmentsUiStateStore } from "./stores/useEnvironmentsUiStateStore";
+  EnvironmentAccordion,
+  useEnvironmentAccordions,
+} from "./components/EnvironmentAccordion";
 
 export const EnvironmentImageBuildLogs = () => {
   const { projectUuid, environmentUuid } = useCustomRoute();
   const { config } = useGlobalContext();
-  const { isLogsOpen, setIsLogsOpen } = useEnvironmentsUiStateStore();
-  const { environmentChanges } = useEditEnvironment();
+  const { isLogsOpen, setIsLogsOpen } = useEnvironmentAccordions();
+
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+  const environmentChangesProjectUuid = useEditEnvironment(
+    (state) => state.environmentChanges?.project_uuid
+  );
+
   const [, , isTriggeringBuild] = useBuildEnvironmentImage();
 
   const handleChange = (event: React.SyntheticEvent, isExpanded: boolean) => {
@@ -31,32 +38,32 @@ export const EnvironmentImageBuildLogs = () => {
       ? `${projectUuid}-${environmentUuid}`
       : undefined;
 
-  const streamIdentityFromStore = `${environmentChanges?.project_uuid}-${environmentChanges?.uuid}`;
+  const streamIdentityFromStore = `${environmentChangesProjectUuid}-${uuid}`;
 
   const ignoreIncomingLogs =
     isTriggeringBuild || streamIdentity !== streamIdentityFromStore;
 
   return (
-    <EnvironmentsAccordion expanded={isLogsOpen} onChange={handleChange}>
-      <EnvironmentsAccordionSummary
+    <EnvironmentAccordion expanded={isLogsOpen} onChange={handleChange}>
+      <AccordionSummary
         aria-controls="environment-build-logs"
         id="environment-build-logs-header"
       >
         <Typography component="h5" variant="h6">
           Logs
         </Typography>
-      </EnvironmentsAccordionSummary>
-      <EnvironmentsAccordionDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <ImageBuildLog
           ignoreIncomingLogs={ignoreIncomingLogs}
           hideDefaultStatus
-          build={environmentChanges?.latestBuild}
+          build={latestBuild}
           socketIONamespace={
             config?.ORCHEST_SOCKETIO_ENV_IMG_BUILDING_NAMESPACE
           }
           streamIdentity={streamIdentity}
         />
-      </EnvironmentsAccordionDetails>
-    </EnvironmentsAccordion>
+      </AccordionDetails>
+    </EnvironmentAccordion>
   );
 };

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentName.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentName.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 
 export const EnvironmentName = () => {
-  const { environmentChanges } = useEditEnvironment();
+  const name = useEditEnvironment((state) => state.environmentChanges?.name);
 
-  const isNameEmpty = environmentChanges?.name.trim().length === 0;
+  const isNameEmpty = name?.trim().length === 0;
 
   return (
     <Typography
@@ -18,7 +18,7 @@ export const EnvironmentName = () => {
           isNameEmpty ? theme.palette.action.active : "inherent",
       }}
     >
-      {isNameEmpty ? "(Unnamed)" : environmentChanges?.name}
+      {isNameEmpty ? "(Unnamed)" : name}
     </Typography>
   );
 };

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentProperties.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentProperties.tsx
@@ -4,12 +4,12 @@ import Typography from "@mui/material/Typography";
 import React from "react";
 import {
   EnvironmentAccordion,
-  useEnvironmentAccordions,
+  usePropertiesAccordion,
 } from "./components/EnvironmentAccordion";
 import { EditEnvironmentName } from "./EditEnvironmentName";
 
 export const EnvironmentProperties = () => {
-  const { isPropertiesOpen, setIsPropertiesOpen } = useEnvironmentAccordions();
+  const [isPropertiesOpen, setIsPropertiesOpen] = usePropertiesAccordion();
 
   const handleChangeIsOpen = (
     event: React.SyntheticEvent,

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentProperties.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentProperties.tsx
@@ -1,19 +1,15 @@
+import { AccordionDetails, AccordionSummary } from "@/components/Accordion";
 import { EnvironmentImagesRadioGroup } from "@/environments-view/edit-environment/EnvironmentImagesRadioGroup";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import {
-  EnvironmentsAccordion,
-  EnvironmentsAccordionDetails,
-  EnvironmentsAccordionSummary,
-} from "./components/EnvironmentsAccordion";
+  EnvironmentAccordion,
+  useEnvironmentAccordions,
+} from "./components/EnvironmentAccordion";
 import { EditEnvironmentName } from "./EditEnvironmentName";
-import { useEnvironmentsUiStateStore } from "./stores/useEnvironmentsUiStateStore";
 
 export const EnvironmentProperties = () => {
-  const {
-    isPropertiesOpen,
-    setIsPropertiesOpen,
-  } = useEnvironmentsUiStateStore();
+  const { isPropertiesOpen, setIsPropertiesOpen } = useEnvironmentAccordions();
 
   const handleChangeIsOpen = (
     event: React.SyntheticEvent,
@@ -23,24 +19,22 @@ export const EnvironmentProperties = () => {
   };
 
   return (
-    <EnvironmentsAccordion
+    <EnvironmentAccordion
       expanded={isPropertiesOpen}
       onChange={handleChangeIsOpen}
     >
-      <EnvironmentsAccordionSummary
+      <AccordionSummary
         aria-controls="environment-properties"
         id="environment-properties-header"
       >
         <Typography component="h5" variant="h6">
           Properties
         </Typography>
-      </EnvironmentsAccordionSummary>
-      <EnvironmentsAccordionDetails
-        sx={{ paddingTop: (theme) => theme.spacing(2) }}
-      >
+      </AccordionSummary>
+      <AccordionDetails sx={{ paddingTop: (theme) => theme.spacing(2) }}>
         <EditEnvironmentName />
         <EnvironmentImagesRadioGroup />
-      </EnvironmentsAccordionDetails>
-    </EnvironmentsAccordion>
+      </AccordionDetails>
+    </EnvironmentAccordion>
   );
 };

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentSetupScript.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentSetupScript.tsx
@@ -7,7 +7,7 @@ import { isEnvironmentBuilding } from "../common";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 import {
   EnvironmentAccordion,
-  useEnvironmentAccordions,
+  useSetupScriptAccordion,
 } from "./components/EnvironmentAccordion";
 
 type SetupScriptCodeMirrorProps = {
@@ -37,10 +37,7 @@ const SetupScriptCodeMirror = React.memo(function SetupScriptCodeMirror({
 });
 
 export const EnvironmentSetupScript = () => {
-  const {
-    isSetupScriptOpen,
-    setIsSetupScriptOpen,
-  } = useEnvironmentAccordions();
+  const [isSetupScriptOpen, setIsSetupScriptOpen] = useSetupScriptAccordion();
 
   const setupScript = useEditEnvironment(
     (state) => state.environmentChanges?.setup_script

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentSetupScript.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentSetupScript.tsx
@@ -1,3 +1,4 @@
+import { AccordionDetails, AccordionSummary } from "@/components/Accordion";
 import { CodeMirror } from "@/components/common/CodeMirror";
 import Typography from "@mui/material/Typography";
 import "codemirror/theme/dracula.css";
@@ -5,11 +6,9 @@ import React from "react";
 import { isEnvironmentBuilding } from "../common";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 import {
-  EnvironmentsAccordion,
-  EnvironmentsAccordionDetails,
-  EnvironmentsAccordionSummary,
-} from "./components/EnvironmentsAccordion";
-import { useEnvironmentsUiStateStore } from "./stores/useEnvironmentsUiStateStore";
+  EnvironmentAccordion,
+  useEnvironmentAccordions,
+} from "./components/EnvironmentAccordion";
 
 type SetupScriptCodeMirrorProps = {
   value?: string;
@@ -41,8 +40,18 @@ export const EnvironmentSetupScript = () => {
   const {
     isSetupScriptOpen,
     setIsSetupScriptOpen,
-  } = useEnvironmentsUiStateStore();
-  const { environmentChanges, setEnvironmentChanges } = useEditEnvironment();
+  } = useEnvironmentAccordions();
+
+  const setupScript = useEditEnvironment(
+    (state) => state.environmentChanges?.setup_script
+  );
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+
+  const setEnvironmentChanges = useEditEnvironment(
+    (state) => state.setEnvironmentChanges
+  );
 
   const handleChangeSetupScript = React.useCallback(
     (value: string) => {
@@ -59,25 +68,22 @@ export const EnvironmentSetupScript = () => {
   };
 
   return (
-    <EnvironmentsAccordion
+    <EnvironmentAccordion
       expanded={isSetupScriptOpen}
       onChange={handleChangeIsOpen}
     >
-      <EnvironmentsAccordionSummary
-        aria-controls="setup-script"
-        id="setup-script-header"
-      >
+      <AccordionSummary aria-controls="setup-script" id="setup-script-header">
         <Typography component="h5" variant="h6">
           Setup script
         </Typography>
-      </EnvironmentsAccordionSummary>
-      <EnvironmentsAccordionDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <SetupScriptCodeMirror
           onChange={handleChangeSetupScript}
-          value={environmentChanges?.setup_script}
-          isReadOnly={isEnvironmentBuilding(environmentChanges?.latestBuild)}
+          value={setupScript}
+          isReadOnly={isEnvironmentBuilding(latestBuild)}
         />
-      </EnvironmentsAccordionDetails>
-    </EnvironmentsAccordion>
+      </AccordionDetails>
+    </EnvironmentAccordion>
   );
 };

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/components/EnvironmentAccordion.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/components/EnvironmentAccordion.tsx
@@ -1,6 +1,9 @@
+import { Accordion } from "@/components/Accordion";
+import { AccordionProps } from "@mui/material/Accordion";
+import React from "react";
 import create from "zustand";
 
-type EnvironmentsUiState = {
+type EnvironmentAccordions = {
   isPropertiesOpen: boolean;
   isSetupScriptOpen: boolean;
   isLogsOpen: boolean;
@@ -10,7 +13,7 @@ type EnvironmentsUiState = {
   reset: () => void;
 };
 
-export const useEnvironmentsUiStateStore = create<EnvironmentsUiState>(
+export const useEnvironmentAccordions = create<EnvironmentAccordions>(
   (set) => ({
     isPropertiesOpen: true,
     isSetupScriptOpen: true,
@@ -26,3 +29,12 @@ export const useEnvironmentsUiStateStore = create<EnvironmentsUiState>(
       }),
   })
 );
+
+export const EnvironmentAccordion = (props: AccordionProps) => {
+  const { reset } = useEnvironmentAccordions();
+  React.useEffect(() => {
+    return () => reset();
+  }, [reset]);
+
+  return <Accordion {...props} />;
+};

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/components/EnvironmentAccordion.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/components/EnvironmentAccordion.tsx
@@ -38,3 +38,31 @@ export const EnvironmentAccordion = (props: AccordionProps) => {
 
   return <Accordion {...props} />;
 };
+
+export const usePropertiesAccordion = () => {
+  const isPropertiesOpen = useEnvironmentAccordions(
+    (state) => state.isPropertiesOpen
+  );
+  const setIsPropertiesOpen = useEnvironmentAccordions(
+    (state) => state.setIsPropertiesOpen
+  );
+  return [isPropertiesOpen, setIsPropertiesOpen] as const;
+};
+
+export const useLogsAccordion = () => {
+  const isLogsOpen = useEnvironmentAccordions((state) => state.isLogsOpen);
+  const setIsLogsOpen = useEnvironmentAccordions(
+    (state) => state.setIsLogsOpen
+  );
+  return [isLogsOpen, setIsLogsOpen] as const;
+};
+
+export const useSetupScriptAccordion = () => {
+  const isSetupScriptOpen = useEnvironmentAccordions(
+    (state) => state.isSetupScriptOpen
+  );
+  const setIsSetupScriptOpen = useEnvironmentAccordions(
+    (state) => state.setIsSetupScriptOpen
+  );
+  return [isSetupScriptOpen, setIsSetupScriptOpen] as const;
+};

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useLoadSelectedBaseImage.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useLoadSelectedBaseImage.tsx
@@ -2,8 +2,7 @@ import { useAppContext } from "@/contexts/AppContext";
 import { DEFAULT_BASE_IMAGES } from "@/environments-view/common";
 import { useEditEnvironment } from "@/environments-view/stores/useEditEnvironment";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
-import { EnvironmentData } from "@/types";
-import { hasValue } from "@orchest/lib-utils";
+import { CustomImage, EnvironmentData } from "@/types";
 import React from "react";
 import { useBaseImageStore } from "../stores/useBaseImageStore";
 
@@ -29,7 +28,13 @@ export const getDefaultImageFromEnvironment = (
 export const useLoadSelectedBaseImage = () => {
   const { orchestVersion } = useAppContext();
   const { environmentUuid, projectUuid } = useCustomRoute();
-  const { environmentChanges } = useEditEnvironment();
+  const environmentChangesProjectUuid = useEditEnvironment(
+    (state) => state.project_uuid
+  );
+  const uuid = useEditEnvironment((state) => state.uuid);
+  const language = useEditEnvironment((state) => state.language);
+  const gpuSupport = useEditEnvironment((state) => state.gpu_support);
+  const baseImage = useEditEnvironment((state) => state.base_image);
 
   const [setSelectedImage, setCustomImage] = useBaseImageStore((state) => [
     state.setSelectedImage,
@@ -38,37 +43,38 @@ export const useLoadSelectedBaseImage = () => {
 
   const isLoaded = React.useRef(false);
   const hasDataFetched =
-    hasValue(environmentChanges) &&
-    environmentUuid === environmentChanges.uuid &&
-    projectUuid === environmentChanges.project_uuid;
+    environmentUuid === uuid && projectUuid === environmentChangesProjectUuid;
 
   const load = React.useCallback(() => {
-    if (!isLoaded.current && hasDataFetched) {
+    if (!isLoaded.current && hasDataFetched && uuid) {
       isLoaded.current = true;
-      const { base_image, language, gpu_support } = environmentChanges;
-      const savedImage = { base_image, language, gpu_support };
+
+      const savedImage = {
+        base_image: baseImage,
+        gpu_support: gpuSupport,
+        language,
+      } as CustomImage;
       // From the BE perspective, `orchest/base-kernel-py` means latest, equivalent to `orchest/base-kernel-py:${current_orchest_version}`.
       // If the image is, for example, orchest/base-kernel-py, BE will fill the latest matching version of the image, e.g. `orchest/base-kernel-py:v2022.05.3`.
       // User could still choose to use an older version of the Orchest default image, e.g. `orchest/base-kernel-py:v2022.05.1`.
       // Then this is considered as a custom image, because user choose to specify an image themselves, so do the other non-Orchest images.
       const selectedDefaultImage = getDefaultImageFromEnvironment(
-        base_image,
+        baseImage,
         orchestVersion
       );
 
-      setSelectedImage(
-        environmentChanges.uuid,
-        selectedDefaultImage || savedImage
-      );
-      if (!selectedDefaultImage)
-        setCustomImage(environmentChanges.uuid, savedImage);
+      setSelectedImage(uuid, selectedDefaultImage || savedImage);
+      if (!selectedDefaultImage) setCustomImage(uuid, savedImage);
     }
   }, [
-    environmentChanges,
     hasDataFetched,
     orchestVersion,
     setCustomImage,
     setSelectedImage,
+    baseImage,
+    gpuSupport,
+    language,
+    uuid,
   ]);
 
   React.useEffect(() => {

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useSelectBaseImage.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useSelectBaseImage.tsx
@@ -19,9 +19,18 @@ import { getDefaultImageFromEnvironment } from "./useLoadSelectedBaseImage";
  */
 export const useSelectBaseImage = () => {
   const { orchestVersion } = useAppContext();
-  const { environments } = useEnvironmentsApi();
-  const { environmentChanges, setEnvironmentChanges } = useEditEnvironment();
-  const disabled = isEnvironmentBuilding(environmentChanges?.latestBuild);
+  const environments = useEnvironmentsApi((state) => state.environments);
+
+  const setEnvironmentChanges = useEditEnvironment(
+    (state) => state.setEnvironmentChanges
+  );
+  const name = useEditEnvironment((state) => state.environmentChanges?.name);
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const latestBuild = useEditEnvironment(
+    (state) => state.environmentChanges?.latestBuild
+  );
+
+  const disabled = isEnvironmentBuilding(latestBuild);
 
   const [
     selectedImage,
@@ -69,7 +78,7 @@ export const useSelectBaseImage = () => {
 
   const changeEnvironmentPrefixPerLanguage = React.useCallback(
     (selectedImageLanguage: string) => {
-      if (!environmentChanges?.name) {
+      if (!name) {
         setEnvironmentChanges({
           name: generateUniqueEnvironmentName(
             capitalize(selectedImageLanguage),
@@ -79,7 +88,7 @@ export const useSelectBaseImage = () => {
         return;
       }
 
-      const envNameWithoutSerialNumber = environmentChanges.name
+      const envNameWithoutSerialNumber = name
         .replace(/( )+\(\d+\)?$/, "")
         .toLowerCase();
 
@@ -92,19 +101,15 @@ export const useSelectBaseImage = () => {
         });
       }
     },
-    [
-      environmentChanges?.name,
-      setEnvironmentChanges,
-      generateUniqueEnvironmentName,
-    ]
+    [name, setEnvironmentChanges, generateUniqueEnvironmentName]
   );
 
   const selectBaseImage = React.useCallback(
     (baseImage: string) => {
-      if (disabled || !environmentChanges?.uuid) return;
+      if (disabled || !uuid) return;
       isTouched.current = true;
       if (baseImage === customImage.base_image) {
-        setSelectedImage(environmentChanges.uuid, customImage);
+        setSelectedImage(uuid, customImage);
         changeEnvironmentPrefixPerLanguage(customImage.language);
         return;
       }
@@ -115,7 +120,7 @@ export const useSelectBaseImage = () => {
         )
       );
       if (foundDefaultImage) {
-        setSelectedImage(environmentChanges.uuid, foundDefaultImage);
+        setSelectedImage(uuid, foundDefaultImage);
         changeEnvironmentPrefixPerLanguage(foundDefaultImage.language);
       }
     },
@@ -124,7 +129,7 @@ export const useSelectBaseImage = () => {
       disabled,
       orchestVersion,
       setSelectedImage,
-      environmentChanges?.uuid,
+      uuid,
       changeEnvironmentPrefixPerLanguage,
     ]
   );

--- a/services/orchest-webserver/client/src/environments-view/hooks/useBuildEnvironmentImage.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useBuildEnvironmentImage.tsx
@@ -1,14 +1,11 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 
 export const useBuildEnvironmentImage = () => {
-  const [
-    triggerBuilds,
-    cancelBuild,
-    isTriggeringBuild,
-  ] = useEnvironmentsApi((state) => [
-    state.triggerBuilds,
-    state.cancelBuild,
-    state.isTriggeringBuild,
-  ]);
+  const triggerBuilds = useEnvironmentsApi((state) => state.triggerBuilds);
+  const cancelBuild = useEnvironmentsApi((state) => state.cancelBuild);
+  const isTriggeringBuild = useEnvironmentsApi(
+    (state) => state.isTriggeringBuild
+  );
+
   return [triggerBuilds, cancelBuild, isTriggeringBuild] as const;
 };

--- a/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
@@ -7,7 +7,9 @@ import { getNewEnvironmentName } from "../common";
 export const useCreateEnvironment = () => {
   const { config } = useGlobalContext();
 
-  const { environments, post, isPosting } = useEnvironmentsApi();
+  const environments = useEnvironmentsApi((state) => state.environments);
+  const post = useEnvironmentsApi((state) => state.post);
+  const isPosting = useEnvironmentsApi((state) => state.isPosting);
 
   const defaultEnvironment = config?.ENVIRONMENT_DEFAULTS;
   const newEnvironmentName = getNewEnvironmentName(

--- a/services/orchest-webserver/client/src/environments-view/hooks/useFetchBuildStatus.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useFetchBuildStatus.tsx
@@ -8,12 +8,15 @@ import React from "react";
  * Returns the latest environmentImageBuild of the given environment UUID.
  */
 export const useFetchBuildStatus = (environmentUuid?: string) => {
-  const {
-    projectUuid,
-    environments,
-    updateBuildStatus,
-    hasLoadedBuildStatus,
-  } = useEnvironmentsApi();
+  const projectUuid = useEnvironmentsApi((state) => state.projectUuid);
+  const environments = useEnvironmentsApi((state) => state.environments);
+  const updateBuildStatus = useEnvironmentsApi(
+    (state) => state.updateBuildStatus
+  );
+  const hasLoadedBuildStatus = useEnvironmentsApi(
+    (state) => state.hasLoadedBuildStatus
+  );
+
   const isStoreLoaded = hasValue(projectUuid) && hasValue(environments);
 
   const initializeBuildStatus = React.useCallback(async () => {

--- a/services/orchest-webserver/client/src/environments-view/hooks/useFetchEnvironments.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useFetchEnvironments.tsx
@@ -1,7 +1,4 @@
-import {
-  EnvironmentsApi,
-  useEnvironmentsApi,
-} from "@/api/environments/useEnvironmentsApi";
+import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useFocusBrowserTab } from "@/hooks/useFocusBrowserTab";
 import { useHasChanged } from "@/hooks/useHasChanged";
@@ -15,15 +12,12 @@ export const useFetchEnvironments = () => {
   const { projectUuid } = useCustomRoute();
   useReportEnvironmentsError();
 
-  const [
-    shouldFetchOnMount,
-    fetchEnvironments,
-    validate,
-  ] = useEnvironmentsApi((state: EnvironmentsApi) => [
-    !Boolean(state.environments) && !state.isFetchingAll,
-    state.fetch,
-    state.validate,
-  ]);
+  const shouldFetchOnMount = useEnvironmentsApi(
+    (state) => !Boolean(state.environments) && !state.isFetchingAll
+  );
+
+  const fetchEnvironments = useEnvironmentsApi((state) => state.fetch);
+  const validate = useEnvironmentsApi((state) => state.validate);
 
   const isTabFocused = useFocusBrowserTab();
   const hasBrowserFocusChanged = useHasChanged(isTabFocused);

--- a/services/orchest-webserver/client/src/environments-view/hooks/useReportEnvironmentsError.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useReportEnvironmentsError.tsx
@@ -5,7 +5,8 @@ import React from "react";
 export const useReportEnvironmentsError = (heading = "") => {
   const { setAlert } = useGlobalContext();
 
-  const { error, clearError } = useEnvironmentsApi();
+  const error = useEnvironmentsApi((state) => state.error);
+  const clearError = useEnvironmentsApi((state) => state.clearError);
 
   React.useEffect(() => {
     if (error) {

--- a/services/orchest-webserver/client/src/environments-view/hooks/useSyncEnvironmentUuidWithQueryArgs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useSyncEnvironmentUuidWithQueryArgs.tsx
@@ -17,7 +17,7 @@ export const useSyncEnvironmentUuidWithQueryArgs = () => {
     navigateTo,
   } = useCustomRoute();
   const { environmentUuid, setEnvironmentUuid } = useSelectEnvironmentUuid();
-  const { environments } = useEnvironmentsApi();
+  const environments = useEnvironmentsApi((state) => state.environments);
 
   const targetEnvironmentUuid = React.useMemo(() => {
     const foundEnvironment =
@@ -62,7 +62,9 @@ export const useSyncEnvironmentUuidWithQueryArgs = () => {
       : undefined;
   }, [environments, environmentUuid]);
 
-  const { initEnvironmentChanges } = useEditEnvironment();
+  const initEnvironmentChanges = useEditEnvironment(
+    (state) => state.initEnvironmentChanges
+  );
 
   React.useEffect(() => {
     if (environmentChanges) initEnvironmentChanges(environmentChanges);

--- a/services/orchest-webserver/client/src/environments-view/hooks/useUpdateBuildStatusInEnvironmentChanges.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useUpdateBuildStatusInEnvironmentChanges.tsx
@@ -7,12 +7,15 @@ import { useEditEnvironment } from "../stores/useEditEnvironment";
  * Note: should only be used once in a view.
  */
 export const useUpdateBuildStatusInEnvironmentChanges = () => {
-  const { environments } = useEnvironmentsApi();
-  const { environmentChanges, setEnvironmentChanges } = useEditEnvironment();
+  const environments = useEnvironmentsApi((state) => state.environments);
+  const uuid = useEditEnvironment((state) => state.environmentChanges?.uuid);
+  const setEnvironmentChanges = useEditEnvironment(
+    (state) => state.setEnvironmentChanges
+  );
 
   const environmentChangesFromStore = React.useMemo(
-    () => environments?.find((env) => env.uuid === environmentChanges?.uuid),
-    [environments, environmentChanges?.uuid]
+    () => environments?.find((env) => env.uuid === uuid),
+    [environments, uuid]
   );
 
   const latestBuildStatus = React.useMemo(() => {

--- a/services/orchest-webserver/client/src/hooks/useBuildEnvironmentImages.tsx
+++ b/services/orchest-webserver/client/src/hooks/useBuildEnvironmentImages.tsx
@@ -37,7 +37,8 @@ const getInactiveEnvironmentsMessage = (
 
 const usePollBuildStatus = () => {
   const { runUuid } = useCustomRoute();
-  const { validate, status } = useEnvironmentsApi();
+  const validate = useEnvironmentsApi((state) => state.validate);
+  const status = useEnvironmentsApi((state) => state.status);
 
   const isJobRun = hasValue(runUuid);
   const {
@@ -87,7 +88,11 @@ export const useBuildEnvironmentImages = () => {
     dispatch,
   } = useProjectsContext();
 
-  const { validate, environmentsToBeBuilt, status } = useEnvironmentsApi();
+  const validate = useEnvironmentsApi((state) => state.validate);
+  const status = useEnvironmentsApi((state) => state.status);
+  const environmentsToBeBuilt = useEnvironmentsApi(
+    (state) => state.environmentsToBeBuilt
+  );
 
   const cancel = React.useCallback(() => {
     buildRequest?.onCancel();

--- a/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
@@ -65,7 +65,9 @@ const ServiceForm: React.FC<{
   const { projectUuid, pipelineUuid, runUuid } = useCustomRoute();
   const environmentPrefix = "environment@";
 
-  const { environments: environmentOptions = [] } = useEnvironmentsApi();
+  const environmentOptions = useEnvironmentsApi(
+    (state) => state.environments || []
+  );
 
   let [showImageDialog, setShowImageDialog] = React.useState(false);
   let [editImageName, setEditImageName] = React.useState(

--- a/services/orchest-webserver/client/src/pipeline-view/CreateStepButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/CreateStepButton.tsx
@@ -13,7 +13,8 @@ import { STEP_HEIGHT, STEP_WIDTH } from "./PipelineStep";
 
 export const CreateStepButton = () => {
   const { setAlert } = useGlobalContext();
-  const { environments = [] } = useEnvironmentsApi();
+  const environments = useEnvironmentsApi((state) => state.environments || []);
+
   const {
     state: { pipelineReadOnlyReason },
   } = useProjectsContext();

--- a/services/orchest-webserver/client/src/pipeline-view/ReadOnlyBanner.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/ReadOnlyBanner.tsx
@@ -49,7 +49,13 @@ const ReadOnlyBannerContainer: React.FC = ({ children }) => {
 
 export const ReadOnlyBanner = () => {
   const { navigateTo } = useCustomRoute();
-  const { buildingEnvironments, environmentsToBeBuilt } = useEnvironmentsApi();
+  const buildingEnvironments = useEnvironmentsApi(
+    (state) => state.buildingEnvironments
+  );
+  const environmentsToBeBuilt = useEnvironmentsApi(
+    (state) => state.environmentsToBeBuilt
+  );
+
   const {
     state: { pipelineReadOnlyReason },
     dispatch,

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
@@ -24,7 +24,7 @@ const relativeToPipeline = (pipelinePath?: string, path?: string) =>
 export type StepCreator = (filePath?: string) => void;
 
 export const useCreateStep = (): StepCreator => {
-  const { environments = [] } = useEnvironmentsApi();
+  const environments = useEnvironmentsApi((state) => state.environments || []);
   const { pipelineCwd } = usePipelineDataContext();
   const { uiStateDispatch } = usePipelineUiStateContext();
   const { pipelineViewportRef } = usePipelineRefs();

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useIsReadOnly.tsx
@@ -10,7 +10,7 @@ export const useIsReadOnly = () => {
   const { jobUuid, runUuid } = useCustomRoute();
   const { dispatch } = useProjectsContext();
 
-  const { status } = useEnvironmentsApi();
+  const status = useEnvironmentsApi((state) => state.status);
 
   const isJobRun = Boolean(runUuid && jobUuid);
 

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -59,7 +59,8 @@ const PipelineViewportComponent = React.forwardRef<
     pipelineCwd,
     isFetchingPipelineJson,
   } = usePipelineDataContext();
-  const { environments = [] } = useEnvironmentsApi();
+
+  const environments = useEnvironmentsApi((state) => state.environments || []);
 
   const { scaleFactor, canvasPointAtPointer } = useCanvasScaling();
   const { pipelineCanvasRef, newConnection } = usePipelineRefs();

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewportContextMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewportContextMenu.tsx
@@ -24,7 +24,7 @@ export const usePipelineViewportContextMenu = useContextMenuContext;
 export const PipelineViewportContextMenu = () => {
   const { position, ...props } = usePipelineViewportContextMenu(); // eslint-disable-line @typescript-eslint/no-unused-vars
   const { isReadOnly } = usePipelineDataContext();
-  const { environments = [] } = useEnvironmentsApi();
+  const environments = useEnvironmentsApi((state) => state.environments || []);
 
   const { canvasPointAtPointer } = useCanvasScaling();
   const {

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/SelectEnvironment.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/SelectEnvironment.tsx
@@ -28,7 +28,9 @@ export const SelectEnvironment = ({
   disabled,
   language,
 }: SelectEnvironmentProps) => {
-  const { environments: allEnvironments = [] } = useEnvironmentsApi();
+  const allEnvironments = useEnvironmentsApi(
+    (state) => state.environments || []
+  );
 
   const environments = React.useMemo(() => {
     return allEnvironments.filter(


### PR DESCRIPTION


## Description

The return value of the selector shouldn't be wrapped in an array or an
object, as they are new instances, which will always cause re-render.
Selector should return the value as-is for zustand to shallow compare.

Also extract Accordion from EnvironmentAccordion, as we'd also need to
use Accordion in other places.



## Checklist

- [x] I have manually tested my changes and I am happy with the result.
