### PR TITLE
Fix unable to save pipeline parameters when clicking outside of the field.

### DIFF
--- a/services/orchest-webserver/client/src/components/ParameterEditorWithJsonForm.tsx
+++ b/services/orchest-webserver/client/src/components/ParameterEditorWithJsonForm.tsx
@@ -30,7 +30,7 @@ import {
 type ParameterEditorWithJsonFormProps = {
   initialValue: Json;
   isReadOnly: boolean;
-  onSave: (parameters: Json) => void;
+  onSave: (parameters: Record<string, Json>) => void;
   parameterSchema: JsonSchema | undefined;
   parameterUiSchema: UISchemaElement | undefined;
   openSchemaFile: (e: React.MouseEvent, type: JsonSchemaType) => void;
@@ -114,14 +114,15 @@ export const ParameterEditorWithJsonForm = ({
     Object.keys(parameterSchema?.properties).length > 0;
 
   const prettifyInputParameters = () => {
-    if (!hasValue(editableParameters)) return;
-    let newValue: string | undefined;
-    try {
-      const parsedValue = JSON.stringify(JSON.parse(editableParameters));
-      newValue = parsedValue !== editableParameters ? parsedValue : undefined;
-    } catch (error) {}
+    setEditableParameters((value) => {
+      if (!hasValue(value)) return value;
 
-    if (newValue) onChangeParameterJSON(newValue);
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2);
+      } catch (error) {
+        return value;
+      }
+    });
   };
 
   const isUiSchemaDefined =

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepParameters.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepParameters.tsx
@@ -18,7 +18,7 @@ export const StepParameters = ({ isReadOnly, onSave }: StepParametersProps) => {
   const { openStepSchemaFile } = useOpenStepSchemaFile();
 
   const onSaveParameters = React.useCallback(
-    (parameters: Json) => {
+    (parameters: Record<string, Json>) => {
       onSave({ parameters }, step.uuid, true);
     },
     [step.uuid, onSave]


### PR DESCRIPTION
## Description

`editableParameters` in `prettifyInputParameters` is not in sync with the latest value of editableParameters. Use setState callback to get the latest value. Also removed the unnecessary saving, as the value was already formatted and saved while typing. `onBlur` should only update the client-side state only.

Fixes: #1233 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
