### PR TITLE
Disable builder cache

### DIFF
--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -198,11 +198,6 @@ def _get_buildah_image_build_workflow_manifest(
                                 "readOnly": True,
                             },
                             {
-                                "name": "image-builder-cache-pvc",
-                                "subPath": "containers",
-                                "mountPath": "/var/lib/containers",
-                            },
-                            {
                                 "name": "tls-secret",
                                 "mountPath": "/etc/ssl/certs/additional-ca-cert-bundle.crt",  # noqa
                                 "subPath": "additional-ca-cert-bundle.crt",
@@ -229,12 +224,6 @@ def _get_buildah_image_build_workflow_manifest(
                     "name": "userdir-pvc",
                     "persistentVolumeClaim": {
                         "claimName": "userdir-pvc",
-                    },
-                },
-                {
-                    "name": "image-builder-cache-pvc",
-                    "persistentVolumeClaim": {
-                        "claimName": "image-builder-cache-pvc",
                     },
                 },
                 {


### PR DESCRIPTION
## Description

This PR disables the builder cache entirely as an attempt to circumvent https://github.com/orchest/orchest/issues/1171 for the time being, this is going to make image builds slower until https://github.com/orchest/orchest/pull/1198 is released, which will both speedup builds and fix #1171 by changing how images are built entirely.

Note: the pvc backing the builder cache will be removed in https://github.com/orchest/orchest/pull/1225