### PR TITLE
Cap `ipywidgets` to avoid breakage

### DIFF
--- a/services/base-images/runnable-shared/runner/requirements-user.txt
+++ b/services/base-images/runnable-shared/runner/requirements-user.txt
@@ -2,5 +2,5 @@
 # see https://ipywidgets.readthedocs.io/en/stable/user_install.html#installing-in-jupyterlab-3-x
 # Pin version to avoid breaking coupling with jupyterlab_widgets,
 # see https://github.com/jupyter-widgets/ipywidgets/issues/3577
-ipywidgets~=8.0
+ipywidgets>=7.0,<8
 -e ../../../../orchest-sdk/python/

--- a/services/base-images/runnable-shared/runner/requirements-user.txt
+++ b/services/base-images/runnable-shared/runner/requirements-user.txt
@@ -1,3 +1,6 @@
-# Required by `jupyterlab-widgets` extension
-ipywidgets
+# Required by `jupyterlab-widgets` extension,
+# see https://ipywidgets.readthedocs.io/en/stable/user_install.html#installing-in-jupyterlab-3-x
+# Pin version to avoid breaking coupling with jupyterlab_widgets,
+# see https://github.com/jupyter-widgets/ipywidgets/issues/3577
+ipywidgets~=8.0
 -e ../../../../orchest-sdk/python/

--- a/services/jupyter-server/requirements.txt
+++ b/services/jupyter-server/requirements.txt
@@ -110,7 +110,7 @@ jupyterlab-pygments==0.1.2
     # via nbconvert
 jupyterlab-server==2.12.0
     # via jupyterlab
-jupyterlab-widgets==3.0.2
+jupyterlab-widgets==1.0.2
     # via -r requirements.in
 lxml==4.9.1
     # via nbconvert

--- a/services/jupyter-server/requirements.txt
+++ b/services/jupyter-server/requirements.txt
@@ -110,7 +110,7 @@ jupyterlab-pygments==0.1.2
     # via nbconvert
 jupyterlab-server==2.12.0
     # via jupyterlab
-jupyterlab-widgets==1.0.2
+jupyterlab-widgets==3.0.2
     # via -r requirements.in
 lxml==4.9.1
     # via nbconvert


### PR DESCRIPTION
## Description

Upgrade `jupyterlab_widgets` and future-proof ipywidgets for a working default experience.

Fixes: #1235.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
