### PR TITLE
Bust cache when manually checking for updates

### DIFF
--- a/services/orchest-webserver/app/app/utils.py
+++ b/services/orchest-webserver/app/app/utils.py
@@ -16,6 +16,7 @@ from _orchest.internals import utils as _utils
 from _orchest.internals.utils import copytree, is_services_definition_valid, rmtree
 from app import error
 from app.config import CONFIG_CLASS as StaticConfig
+from app.core import scheduler
 from app.models import Environment, Pipeline, Project
 from app.schemas import EnvironmentSchema
 
@@ -858,13 +859,19 @@ def get_orchest_examples_json() -> dict:
 _DEFAULT_ORCHEST_UPDATE_INFO_JSON = {"latest_version": None}
 
 
-def get_orchest_update_info_json() -> dict:
+def get_orchest_update_info_json(cache: bool = True) -> dict:
     """Get orchest update info.
+
+    Args:
+        cache: If cache is `False` then refresh cache.
 
     Returns:
         A dictionary mapping latest_version to the latest Orchest
         version.
     """
+    if not cache:
+        jobs = scheduler.Jobs()
+        jobs.handle_orchest_update_info(current_app, interval=0)
 
     path = current_app.config["ORCHEST_UPDATE_INFO_JSON_PATH"]
     if not os.path.exists(path):

--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -178,7 +178,8 @@ def register_views(app, db):
 
     @app.route("/async/orchest-update-info", methods=["GET"])
     def orchest_update_info():
-        return get_orchest_update_info_json()
+        cache = request.args.get("cache", "") == "true"
+        return get_orchest_update_info_json(cache=cache)
 
     @app.route("/async/server-config", methods=["GET"])
     def server_config():

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -41,15 +41,19 @@ const fetchOrchestVersion = () =>
     (response) => response.version
   );
 
-const fetchLatestVersion = () =>
-  fetcher<UpdateInfo>("/async/orchest-update-info").then(
+const fetchLatestVersion = (cache?: boolean) => {
+  const endpoint = `/async/orchest-update-info?cache=${
+    cache ? "true" : "false"
+  }`;
+  return fetcher<UpdateInfo>(endpoint).then(
     (response) => response.latest_version
   );
+};
 
-const requestToCheckVersions = async () => {
+const requestToCheckVersions = async (cache?: boolean) => {
   const [orchestVersion, latestVersion] = await Promise.all([
     fetchOrchestVersion(),
-    fetchLatestVersion(),
+    fetchLatestVersion(cache),
   ]);
 
   return [orchestVersion, latestVersion] as const;
@@ -178,7 +182,7 @@ export const useCheckUpdate = () => {
     // we want to be able to tell the user that no update is available
     // if this function is invoked.
     const [fetchedOrchestVersion, fetchedLatestVersion] = await makeCancelable(
-      requestToCheckVersions()
+      requestToCheckVersions(false)
     );
 
     if (fetchedOrchestVersion && fetchedLatestVersion) {


### PR DESCRIPTION
## Description

When clicking the "check for updates" in the settings, then we should not use the cached orchest update info JSON and instead query it again.
