### PR TITLE
Dynamically update the pipeline of a job draft

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -159,7 +159,7 @@ class Job(Resource):
         return job
 
     @api.expect(schema.job_parameters_update)
-    @api.doc("update_job")
+    @api.doc("update_job_parameters")
     def put(self, job_uuid):
         """Updates a job parameters.
 

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -417,6 +417,16 @@ job_parameters_update = Model(
     },
 )
 
+draft_job_pipeline_update = Model(
+    "DraftJobPipelineUpdate",
+    {
+        "pipeline_uuid": fields.String(
+            required=True,
+            description="UUID of the pipeline to use.",
+        ),
+    },
+)
+
 # Namespace: Jobs.
 non_interactive_run_config = pipeline_run_config.inherit(
     "NonInteractiveRunConfig",

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -495,20 +495,9 @@ job_spec = Model(
         "name": fields.String(required=True, description="Name for job"),
         "project_uuid": fields.String(required=True, description="UUID of project"),
         "pipeline_uuid": fields.String(required=True, description="UUID of pipeline"),
-        "pipeline_definitions": fields.List(
-            fields.Raw(description="Pipeline definition in JSON"),
+        "pipeline_definition": fields.Raw(
             required=True,
-            description="Collection of pipeline definitions",
-        ),
-        "pipeline_run_ids": fields.List(
-            fields.Integer(
-                description=(
-                    "Pipeline index corresponding to respective "
-                    "list entries in pipeline_definitions."
-                )
-            ),
-            required=True,
-            description="Collection of pipeline definition indices.",
+            description="Pipeline definition in JSON",
         ),
         "pipeline_run_spec": fields.Nested(
             non_interactive_run_spec,

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -381,8 +381,8 @@ status_update = Model(
     },
 )
 
-job_update = Model(
-    "JobUpdate",
+job_parameters_update = Model(
+    "JobParametersUpdate",
     {
         "cron_schedule": fields.String(
             required=False,

--- a/services/orchest-webserver/app/app/core/jobs.py
+++ b/services/orchest-webserver/app/app/core/jobs.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import os
+import subprocess
 import uuid
 from collections import defaultdict
 
@@ -11,6 +12,7 @@ import app.utils as utils
 from _orchest.internals import config as _config
 from _orchest.internals import utils as _utils
 from app import error
+from app.config import CONFIG_CLASS as config
 from app.models import Pipeline, Project
 
 
@@ -382,3 +384,78 @@ def _create_snapshot_record_for_job(
         remove_job_directory(job_uuid, pipeline_uuid, project_uuid)
         raise error.OrchestApiRequestError(response=resp)
     return resp.json()["uuid"]
+
+
+def _move_job_directory(
+    job_uuid: str, old_pipeline_uuid: str, new_pipeline_uuid: str, project_uuid: str
+) -> str:
+    """Moves a job directory to account for a pipeline change.
+
+
+    Raises:
+        UnexpectedFileSystemState: if the destination directory already
+        exists.
+        OSError: If the move operation failed.
+
+    """
+    if old_pipeline_uuid == new_pipeline_uuid:
+        return
+
+    old_path = utils.get_job_directory(old_pipeline_uuid, project_uuid, job_uuid)
+    new_path = utils.get_job_directory(new_pipeline_uuid, project_uuid, job_uuid)
+
+    if os.path.exists(new_path):
+        raise error.UnexpectedFileSystemState(f"Directory {new_path} already exists.")
+
+    # The pipeline directory might not exist.
+    os.makedirs(os.path.split(new_path)[0], exist_ok=True)
+
+    exit_code = subprocess.call(["mv", old_path, new_path], stderr=subprocess.STDOUT)
+    if exit_code != 0:
+        raise OSError(f"Failed to mv {old_path} to {new_path}, :{exit_code}.")
+
+
+def change_draft_job_pipeline(
+    job_uuid: str,
+    new_pipeline_uuid: str,
+) -> requests.Response:
+
+    resp = requests.get(f"http://{config.ORCHEST_API_ADDRESS}/api/jobs/{job_uuid}")
+    if resp.status_code != 200:
+        return resp
+
+    job = resp.json()
+    old_pipeline_uuid = job["pipeline_uuid"]
+    project_uuid = job["project_uuid"]
+
+    resp = requests.put(
+        f"http://{config.ORCHEST_API_ADDRESS}/api/jobs/{job_uuid}/pipeline",
+        json={"pipeline_uuid": new_pipeline_uuid},
+    )
+
+    if resp.status_code != 200:
+        return resp
+
+    try:
+        _move_job_directory(
+            job_uuid, old_pipeline_uuid, new_pipeline_uuid, project_uuid
+        )
+    except Exception as e:
+        current_app.logger.error(
+            "Failed to move the job directory, reverting job pipeline change."
+        )
+        current_app.logger.error(e)
+        resp = requests.put(
+            f"http://{config.ORCHEST_API_ADDRESS}/api/jobs/{job_uuid}/pipeline",
+            json={"pipeline_uuid": old_pipeline_uuid},
+        )
+        if resp.status_code != 200:
+            current_app.logger.error(
+                (
+                    "Failed to revert the job pipeline change.\n"
+                    f"{resp.status_code}: {resp.text}"
+                )
+            )
+        raise e
+
+    return resp

--- a/services/orchest-webserver/app/app/error.py
+++ b/services/orchest-webserver/app/app/error.py
@@ -74,6 +74,10 @@ class JobDoesNotExist(Exception):
     pass
 
 
+class UnexpectedFileSystemState(Exception):
+    pass
+
+
 class EnvironmentsDoNotExist(Exception):
     def __init__(self, environment_uuids=List[str]):
         self.environment_uuids = environment_uuids

--- a/services/orchest-webserver/app/app/views/orchest_api.py
+++ b/services/orchest-webserver/app/app/views/orchest_api.py
@@ -465,6 +465,12 @@ def register_orchest_api_views(app, db):
 
         return resp.content, resp.status_code, resp.headers.items()
 
+    @app.route("/catch/api-proxy/api/jobs/<job_uuid>/pipeline", methods=["PUT"])
+    def catch_api_proxy_job_pipeline_put(job_uuid):
+
+        resp = jobs.change_draft_job_pipeline(job_uuid, request.json["pipeline_uuid"])
+        return resp.content, resp.status_code, resp.headers.items()
+
     @app.route("/catch/api-proxy/api/jobs/<job_uuid>/<run_uuid>", methods=["GET"])
     def catch_api_proxy_job_runs_single(job_uuid, run_uuid):
 


### PR DESCRIPTION
## Description

Allows altering the pipeline of a job which is still in the `DRAFT` status. Environment variables are resolved using the snapshotted state contained in the snapshot in use by the job. See the docstring of `_resolve_environment_variables` for more details.

@iannbing 
The functionality is exposed to the client through a new `orchest-webserver` endpoint, `/catch/api-proxy/api/jobs/<job_uuid>/pipeline` (PUT), which requires a json of the form `{"pipeline_uuid": "<uuid>"}` which indicates
which pipeline the job should be using. From the client POV the endpoint is a proxy to the `orchest-api` endpoint `/jobs/<job_uuid>/pipeline`, see the `orchest-api` swagger docs for the dos and don'ts.

Note that the `orchest-webserver` now also exposes the endpoint `/catch/api-proxy/api/snapshots/<snapshot_uuid>`, which allows retrieving details about a snapshot. This information is what should be used when it comes to the pipelines (uuids, names, paths)  within the job: e.g.:
- get the job 
- the job has a `snapshot_uuid` field
- retrieve the snapshot through its uuid
- the snapshot contains information about what pipelines are contained within the job's snapshot, which are the pipelines between which the job can switch while in draft mode


## Checklist

- [X] I have manually tested my changes and I am happy with the result.

