### PR TITLE
UI Overhaul: Add cancel button to pipeline editor for job runs + zustand store

### DIFF
--- a/services/orchest-webserver/client/src/api/job-runs/jobRunsApi.ts
+++ b/services/orchest-webserver/client/src/api/job-runs/jobRunsApi.ts
@@ -1,0 +1,49 @@
+import { PipelineRun } from "@/types";
+import { join } from "@/utils/path";
+import { fetcher } from "@orchest/lib-utils";
+
+const BASE_URL = "/catch/api-proxy/api/jobs/";
+
+export type StatusUpdate = {
+  jobUuid: string;
+  runUuid: string;
+  status: "PENDING" | "STARTED" | "SUCCESS" | "FAILURE" | "ABORTED";
+};
+
+export type StepStatusUpdate = StatusUpdate & { stepUuid: string };
+
+export const fetchOne = (jobUuid: string, runUuid: string) =>
+  fetcher<PipelineRun>(join(BASE_URL, jobUuid, runUuid));
+
+export const fetchAll = (jobUuid: string) =>
+  fetcher<PipelineRun[]>(join(BASE_URL, jobUuid, "pipeline_runs"));
+
+export const setStatus = ({ jobUuid, runUuid, status }: StatusUpdate) =>
+  fetcher<void>(join(BASE_URL, jobUuid, runUuid), {
+    method: "PUT",
+    body: JSON.stringify({ status }),
+  });
+
+export const setStepStatus = ({
+  jobUuid,
+  runUuid,
+  stepUuid,
+  status,
+}: StepStatusUpdate) =>
+  fetcher<void>(join(BASE_URL, jobUuid, runUuid, stepUuid), {
+    method: "PUT",
+    body: JSON.stringify({ status }),
+  });
+
+export const cancel = (jobUuid: string, runUuid: string) =>
+  fetcher<void>(join(BASE_URL, jobUuid, runUuid), {
+    method: "DELETE",
+  });
+
+export const jobRunsApi = {
+  cancel,
+  fetch: fetchOne,
+  fetchAll,
+  setStatus,
+  setStepStatus,
+};

--- a/services/orchest-webserver/client/src/api/job-runs/useJobRunsApi.ts
+++ b/services/orchest-webserver/client/src/api/job-runs/useJobRunsApi.ts
@@ -1,0 +1,98 @@
+import { PipelineRun, PipelineRunStep } from "@/types";
+import { deduplicates, replaces } from "@/utils/array";
+import { equates } from "@/utils/record";
+import create from "zustand";
+import { jobRunsApi, StatusUpdate, StepStatusUpdate } from "./jobRunsApi";
+
+export type JobRunsApi = {
+  /** A list of all the currently fetched runs, in no particular order. */
+  runs: PipelineRun[];
+  /** Fetches all runs for a given job and adds it to `runs`. */
+  fetchAll: (jobUuid: string) => Promise<void>;
+  /** Fetches a single run and adds it to `runs`. */
+  fetch: (jobUuid: string, runUuid: string) => Promise<void>;
+  /** Cancels a job run and updates the  it in `runs` (if it includes it). */
+  cancel: (jobUuid: string, runUuid: string) => Promise<void>;
+  /** Updates the status of a job run and updates it in `runs` (if it includes it). */
+  setStatus: (update: StatusUpdate) => Promise<void>;
+  /** Updates the status of a job run step and updates it in `runs` (if it includes it). */
+  setStepStatus: (update: StepStatusUpdate) => Promise<void>;
+};
+
+export const useJobRunsApi = create<JobRunsApi>((set, get) => {
+  return {
+    runs: [],
+    fetch: async (jobUuid, runUuid) => {
+      const run = await jobRunsApi.fetch(jobUuid, runUuid).catch(onFetchError);
+
+      if (!run) return;
+
+      set((state) => ({ ...state, runs: replaceRun(state.runs, run) }));
+    },
+    fetchAll: async (jobUuid) => {
+      const runs = await jobRunsApi.fetchAll(jobUuid).catch(onFetchError);
+
+      if (!runs?.length) return;
+
+      set((state) => ({ ...state, runs: deduplicateRuns(runs, state.runs) }));
+    },
+    cancel: async (jobUuid, runUuid) => {
+      await jobRunsApi.cancel(jobUuid, runUuid).catch(onFetchError);
+      const run = get().runs.find(equates("uuid", runUuid));
+
+      if (!run) return;
+
+      const updated: PipelineRun = { ...run, status: "ABORTED" };
+
+      set((state) => ({ ...state, runs: replaceRun(state.runs, updated) }));
+    },
+    setStatus: async (update) => {
+      await jobRunsApi.setStatus(update).catch(onFetchError);
+      const run = get().runs.find(equates("uuid", update.runUuid));
+
+      if (!run) return;
+
+      const updated: PipelineRun = { ...run, status: update.status };
+
+      set((state) => ({ ...state, runs: replaceRun(state.runs, updated) }));
+    },
+    setStepStatus: async (update) => {
+      await jobRunsApi.setStepStatus(update).catch(onFetchError);
+      const run = get().runs.find(equates("uuid", update.runUuid));
+      const step = run?.pipeline_steps.find(
+        equates("step_uuid", update.stepUuid)
+      );
+
+      if (!run || !step) return;
+
+      const updatedStep: PipelineRunStep = { ...step, status: update.status };
+      const updatedRun: PipelineRun = {
+        ...run,
+        pipeline_steps: replaceStep(run.pipeline_steps, updatedStep),
+      };
+
+      set((state) => ({ ...state, runs: replaceRun(state.runs, updatedRun) }));
+    },
+  };
+});
+
+const replacesByRunUuid = (uuid: string) =>
+  replaces<PipelineRun>(equates("uuid", uuid), "unshift");
+
+const replacesByStepUuid = (uuid: string) =>
+  replaces<PipelineRunStep>(equates("step_uuid", uuid), "ignore");
+
+const replaceStep = (
+  steps: readonly PipelineRunStep[],
+  step: PipelineRunStep
+) => replacesByStepUuid(step.step_uuid)(steps, step);
+
+const replaceRun = (runs: readonly PipelineRun[], run: PipelineRun) =>
+  replacesByRunUuid(run.uuid)(runs, run);
+
+const deduplicateRuns = deduplicates<PipelineRun>((run) => run.uuid);
+
+const onFetchError = (error: unknown) => {
+  console.error(error);
+  return null;
+};

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
@@ -3,7 +3,7 @@ import MenuList from "@mui/material/MenuList";
 import Stack from "@mui/material/Stack";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
-import { extractEnvironmentFromState } from "./common";
+import { environmentDataFromState } from "./common";
 import { CreateEnvironmentButton } from "./CreateEnvironmentButton";
 import { EnvironmentMenuItem } from "./EnvironmentMenuItem";
 import { useFetchBuildStatus } from "./hooks/useFetchBuildStatus";
@@ -22,7 +22,7 @@ export const EnvironmentMenuList = () => {
   const { selectEnvironment } = useSelectEnvironment();
 
   const updateStoreAndRedirect = (uuid: string) => {
-    const environment = extractEnvironmentFromState(environmentChanges);
+    const environment = environmentDataFromState(environmentChanges);
     if (environment) {
       setEnvironment(environment.uuid, environment);
     }

--- a/services/orchest-webserver/client/src/environments-view/common.tsx
+++ b/services/orchest-webserver/client/src/environments-view/common.tsx
@@ -8,7 +8,7 @@ import {
   OrchestSession,
 } from "@/types";
 import { getUniqueName } from "@/utils/getUniqueName";
-import { prune } from "@/utils/record";
+import { omit } from "@/utils/record";
 import { fetcher, hasValue, HEADER } from "@orchest/lib-utils";
 
 export const isEnvironmentBuilding = (build?: EnvironmentImageBuild) =>
@@ -92,15 +92,12 @@ export const postEnvironment = (
     }),
   });
 
-export const extractEnvironmentFromState = (
+export const environmentDataFromState = (
   environmentState?: EnvironmentState
 ): EnvironmentData | undefined => {
   if (!environmentState) return undefined;
 
-  return prune<EnvironmentData>(
-    environmentState,
-    ([key]) => !["action", "latestBuild"].includes(key)
-  );
+  return omit(environmentState, "action", "latestBuild");
 };
 
 /**

--- a/services/orchest-webserver/client/src/environments-view/hooks/useSaveEnvironmentChanges.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useSaveEnvironmentChanges.tsx
@@ -1,7 +1,7 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import { useAutoSaveEnvironment } from "@/environments-view/edit-environment/hooks/useAutoSaveEnvironment";
 import React from "react";
-import { extractEnvironmentFromState } from "../common";
+import { environmentDataFromState } from "../common";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 
 /**
@@ -13,7 +13,7 @@ export const useSaveEnvironmentChanges = () => {
   const { environmentChanges } = useEditEnvironment();
 
   const save = React.useCallback(() => {
-    const environmentData = extractEnvironmentFromState(environmentChanges);
+    const environmentData = environmentDataFromState(environmentChanges);
     if (environmentData) {
       // Saving an environment will invalidate the Jupyter <iframe>
       // TODO: perhaps this can be fixed with coordination between JLab +

--- a/services/orchest-webserver/client/src/environments-view/hooks/useUpdateEnvironmentOnUnmount.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useUpdateEnvironmentOnUnmount.tsx
@@ -1,6 +1,6 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import React from "react";
-import { extractEnvironmentFromState } from "../common";
+import { environmentDataFromState } from "../common";
 import { useEditEnvironment } from "../stores/useEditEnvironment";
 
 /**
@@ -25,7 +25,7 @@ export const useUpdateEnvironmentOnUnmount = () => {
   const updateEnvironment = React.useCallback(() => {
     const environment =
       environmentChangesRef.current &&
-      extractEnvironmentFromState(environmentChangesRef.current);
+      environmentDataFromState(environmentChangesRef.current);
     if (environment) {
       setEnvironment(environment.uuid, environment);
     }

--- a/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
+++ b/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
@@ -31,6 +31,6 @@ export const useCurrentJobRun = () => {
   return {
     run,
     cancelRun,
-    isCancellable: run?.status === "STARTED" || run?.status === "PENDING",
+    isCancelable: run?.status === "STARTED" || run?.status === "PENDING",
   };
 };

--- a/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
+++ b/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
@@ -5,7 +5,7 @@ import { useCustomRoute } from "./useCustomRoute";
 
 /**
  * Extracts the current job_uuid and run_uuid from the route
- * and fetches said job run from it from the back-end.
+ * and fetches said job run from the back-end.
  *
  * It also provides helpers to interface with this run.
  */

--- a/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
+++ b/services/orchest-webserver/client/src/hooks/useCurrentJobRun.ts
@@ -1,0 +1,36 @@
+import { useJobRunsApi } from "@/api/job-runs/useJobRunsApi";
+import { equates } from "@/utils/record";
+import React from "react";
+import { useCustomRoute } from "./useCustomRoute";
+
+/**
+ * Extracts the current job_uuid and run_uuid from the route
+ * and fetches said job run from it from the back-end.
+ *
+ * It also provides helpers to interface with this run.
+ */
+export const useCurrentJobRun = () => {
+  const { jobUuid, runUuid } = useCustomRoute();
+  const cancel = useJobRunsApi((api) => api.cancel);
+  const fetchRun = useJobRunsApi((api) => api.fetch);
+  const runs = useJobRunsApi((api) => api.runs);
+
+  const run = React.useMemo(
+    () => (runUuid ? runs.find(equates("uuid", runUuid)) : undefined),
+    [runUuid, runs]
+  );
+
+  const cancelRun = React.useCallback(() => {
+    if (jobUuid && runUuid) cancel(jobUuid, runUuid);
+  }, [cancel, jobUuid, runUuid]);
+
+  React.useEffect(() => {
+    if (jobUuid && runUuid && !run) fetchRun(jobUuid, runUuid);
+  }, [fetchRun, jobUuid, runUuid, run]);
+
+  return {
+    run,
+    cancelRun,
+    isCancellable: run?.status === "STARTED" || run?.status === "PENDING",
+  };
+};

--- a/services/orchest-webserver/client/src/legacy-job-view/PipelineRunTable.tsx
+++ b/services/orchest-webserver/client/src/legacy-job-view/PipelineRunTable.tsx
@@ -1,3 +1,4 @@
+import { jobRunsApi } from "@/api/job-runs/jobRunsApi";
 import {
   DataTable,
   DataTableColumn,
@@ -94,9 +95,8 @@ export const PipelineRunTable: React.FC<{
         "Are you sure that you want to cancel this job run?",
         async (resolve) => {
           try {
-            await fetcher(`/catch/api-proxy/api/jobs/${jobUuid}/${runUuid}`, {
-              method: "DELETE",
-            });
+            await jobRunsApi.cancel(jobUuid, runUuid);
+
             setData((current) => {
               if (!current) return current;
               const newRows = [...current.rows];

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/InteractiveRunsContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/InteractiveRunsContext.tsx
@@ -1,3 +1,4 @@
+import { jobRunsApi } from "@/api/job-runs/jobRunsApi";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { BUILD_IMAGE_SOLUTION_VIEW } from "@/contexts/ProjectsContext";
 import { OrchestSession } from "@/types";
@@ -66,9 +67,7 @@ export const InteractiveRunsContextProvider: React.FC = ({ children }) => {
           async (resolve) => {
             setDisplayedPipelineStatus("CANCELING");
             try {
-              await fetcher(`/catch/api-proxy/api/jobs/${jobUuid}/${runUuid}`, {
-                method: "DELETE",
-              });
+              await jobRunsApi.cancel(jobUuid, runUuid);
               resolve(true);
             } catch (error) {
               setAlert("Error", `Failed to cancel this job run.`);

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/PipelineCanvasHeaderBar.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/PipelineCanvasHeaderBar.tsx
@@ -43,16 +43,13 @@ export const PipelineCanvasHeaderBar = () => {
           Logs
         </Button>
         <ServicesMenu />
-        {!isJobRun && (
-          <>
-            <Divider
-              orientation="vertical"
-              sx={{ height: (theme) => theme.spacing(3) }}
-            />
-            <CreateStepButton />
-            <PrimaryPipelineButton />
-          </>
-        )}
+
+        <Divider
+          orientation="vertical"
+          sx={{ height: (theme) => theme.spacing(3) }}
+        />
+        {!isJobRun && <CreateStepButton />}
+        <PrimaryPipelineButton />
         <PipelineMoreOptionsMenu />
       </Stack>
     </Stack>

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/CancelJobRunButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/CancelJobRunButton.tsx
@@ -5,15 +5,15 @@ import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 
 export const CancelJobRunButton = () => {
-  const { cancelRun, isCancellable } = useCurrentJobRun();
-  const title = isCancellable ? "Cancel the job run" : "The job is not running";
+  const { cancelRun, isCancelable } = useCurrentJobRun();
+  const title = isCancelable ? "Cancel the job run" : "The job is not running";
 
   return (
     <Tooltip title={title}>
       {/* This span is needed because disabled elements cannot have tooltips. */}
       <span>
         <Button
-          disabled={!isCancellable}
+          disabled={!isCancelable}
           startIcon={<CancelOutlined />}
           onClick={cancelRun}
           variant="contained"

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/CancelJobRunButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/CancelJobRunButton.tsx
@@ -1,0 +1,26 @@
+import { useCurrentJobRun } from "@/hooks/useCurrentJobRun";
+import CancelOutlined from "@mui/icons-material/CancelOutlined";
+import Button from "@mui/material/Button";
+import Tooltip from "@mui/material/Tooltip";
+import React from "react";
+
+export const CancelJobRunButton = () => {
+  const { cancelRun, isCancellable } = useCurrentJobRun();
+  const title = isCancellable ? "Cancel the job run" : "The job is not running";
+
+  return (
+    <Tooltip title={title}>
+      {/* This span is needed because disabled elements cannot have tooltips. */}
+      <span>
+        <Button
+          disabled={!isCancellable}
+          startIcon={<CancelOutlined />}
+          onClick={cancelRun}
+          variant="contained"
+        >
+          Cancel run
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/PrimaryPipelineButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/PrimaryPipelineButton.tsx
@@ -1,97 +1,14 @@
-import { useProjectsContext } from "@/contexts/ProjectsContext";
-import { useThrottle } from "@/hooks/useThrottle";
-import { usePipelineUiStateContext } from "@/pipeline-view/contexts/PipelineUiStateContext";
-import ArrowDropDownOutlinedIcon from "@mui/icons-material/ArrowDropDownOutlined";
-import Button from "@mui/material/Button";
-import ButtonGroup from "@mui/material/ButtonGroup";
+import { usePipelineDataContext } from "@/pipeline-view/contexts/PipelineDataContext";
 import React from "react";
-import { PrimaryPipelineActionIcon } from "./PipelineOperationButtonIcon";
-import { PrimaryPipelineActionMenu } from "./PrimaryPipelineActionMenu";
-import { useRunSteps } from "./useRunSteps";
+import { CancelJobRunButton } from "./CancelJobRunButton";
+import { RunPipelineButton } from "./RunPipelineButton";
 
 export const PrimaryPipelineButton = () => {
-  const {
-    state: { pipelineReadOnlyReason },
-  } = useProjectsContext();
-  const {
-    uiState: { steps },
-  } = usePipelineUiStateContext();
-  const hasNoStep = Object.keys(steps).length === 0;
-  const buttonRef = React.useRef<HTMLDivElement>(null);
-  const [anchor, setAnchor] = React.useState<Element>();
-  const openMenu = () => setAnchor(buttonRef.current ?? undefined);
-  const closeMenu = () => setAnchor(undefined);
+  const { isJobRun } = usePipelineDataContext();
 
-  const {
-    displayedPipelineStatus,
-    runSelectedSteps,
-    runAllSteps,
-    shouldRunAll,
-    cancelRun,
-  } = useRunSteps();
-
-  const { withThrottle, reset } = useThrottle();
-
-  const [buttonLabel, executeOperation] = React.useMemo(() => {
-    if (pipelineReadOnlyReason) {
-      return ["Run all", undefined];
-    } else if (displayedPipelineStatus === "RUNNING") {
-      return ["Cancel run", cancelRun];
-    } else if (displayedPipelineStatus === "CANCELING") {
-      return ["Cancelling...", undefined];
-    } else if (shouldRunAll) {
-      return ["Run all", runAllSteps];
-    } else {
-      return ["Run selected", runSelectedSteps];
-    }
-  }, [
-    pipelineReadOnlyReason,
-    cancelRun,
-    displayedPipelineStatus,
-    runAllSteps,
-    runSelectedSteps,
-    shouldRunAll,
-  ]);
-
-  // Prevent the unintentional second click.
-  const handleClick = executeOperation
-    ? withThrottle(executeOperation)
-    : undefined;
-
-  React.useEffect(() => reset(), [displayedPipelineStatus, reset]);
-
-  const disabled = Boolean(pipelineReadOnlyReason) || hasNoStep;
-  const isIdling = displayedPipelineStatus === "IDLING";
-  const isRunning = displayedPipelineStatus === "RUNNING";
-
-  return (
-    <>
-      <ButtonGroup
-        ref={buttonRef}
-        disabled={disabled}
-        variant={isRunning ? "outlined" : "contained"}
-        color="primary"
-        size="small"
-      >
-        <Button
-          startIcon={
-            <PrimaryPipelineActionIcon status={displayedPipelineStatus} />
-          }
-          onClick={handleClick}
-        >
-          {buttonLabel}
-        </Button>
-        {isIdling ? (
-          <Button
-            sx={{ backgroundColor: (theme) => theme.palette.primary.dark }}
-            size="small"
-            onClick={openMenu}
-          >
-            <ArrowDropDownOutlinedIcon fontSize="small" />
-          </Button>
-        ) : null}
-      </ButtonGroup>
-      <PrimaryPipelineActionMenu anchor={anchor} onClose={closeMenu} />
-    </>
-  );
+  if (isJobRun) {
+    return <CancelJobRunButton />;
+  } else {
+    return <RunPipelineButton />;
+  }
 };

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/RunPipelineButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/RunPipelineButton.tsx
@@ -1,0 +1,97 @@
+import { useProjectsContext } from "@/contexts/ProjectsContext";
+import { useThrottle } from "@/hooks/useThrottle";
+import { usePipelineUiStateContext } from "@/pipeline-view/contexts/PipelineUiStateContext";
+import ArrowDropDownOutlinedIcon from "@mui/icons-material/ArrowDropDownOutlined";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import React from "react";
+import { PrimaryPipelineActionIcon } from "./PipelineOperationButtonIcon";
+import { PrimaryPipelineActionMenu } from "./PrimaryPipelineActionMenu";
+import { useRunSteps } from "./useRunSteps";
+
+export const RunPipelineButton = () => {
+  const {
+    state: { pipelineReadOnlyReason },
+  } = useProjectsContext();
+  const {
+    uiState: { steps },
+  } = usePipelineUiStateContext();
+  const hasNoStep = Object.keys(steps).length === 0;
+  const buttonRef = React.useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = React.useState<Element>();
+  const openMenu = () => setAnchor(buttonRef.current ?? undefined);
+  const closeMenu = () => setAnchor(undefined);
+
+  const {
+    displayedPipelineStatus,
+    runSelectedSteps,
+    runAllSteps,
+    shouldRunAll,
+    cancelRun,
+  } = useRunSteps();
+
+  const { withThrottle, reset } = useThrottle();
+
+  const [buttonLabel, executeOperation] = React.useMemo(() => {
+    if (pipelineReadOnlyReason) {
+      return ["Run all", undefined];
+    } else if (displayedPipelineStatus === "RUNNING") {
+      return ["Cancel run", cancelRun];
+    } else if (displayedPipelineStatus === "CANCELING") {
+      return ["Cancelling...", undefined];
+    } else if (shouldRunAll) {
+      return ["Run all", runAllSteps];
+    } else {
+      return ["Run selected", runSelectedSteps];
+    }
+  }, [
+    pipelineReadOnlyReason,
+    cancelRun,
+    displayedPipelineStatus,
+    runAllSteps,
+    runSelectedSteps,
+    shouldRunAll,
+  ]);
+
+  // Prevent the unintentional second click.
+  const handleClick = executeOperation
+    ? withThrottle(executeOperation)
+    : undefined;
+
+  React.useEffect(() => reset(), [displayedPipelineStatus, reset]);
+
+  const disabled = Boolean(pipelineReadOnlyReason) || hasNoStep;
+  const isIdling = displayedPipelineStatus === "IDLING";
+  const isRunning = displayedPipelineStatus === "RUNNING";
+
+  return (
+    <>
+      <ButtonGroup
+        ref={buttonRef}
+        disabled={disabled}
+        variant={isRunning ? "outlined" : "contained"}
+        color="primary"
+        size="small"
+      >
+        <Button
+          startIcon={
+            <PrimaryPipelineActionIcon status={displayedPipelineStatus} />
+          }
+          onClick={handleClick}
+        >
+          {buttonLabel}
+        </Button>
+        {isIdling ? (
+          <Button
+            sx={{ backgroundColor: (theme) => theme.palette.primary.dark }}
+            size="small"
+            onClick={openMenu}
+          >
+            <ArrowDropDownOutlinedIcon fontSize="small" />
+          </Button>
+        ) : null}
+      </ButtonGroup>
+      <PrimaryPipelineActionMenu anchor={anchor} onClose={closeMenu} />
+    </>
+  );
+};

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -199,6 +199,14 @@ export type JobStatus =
   | "FAILURE"
   | "DRAFT";
 
+export type PipelineRunStep = {
+  run_uuid: string;
+  step_uuid: string;
+  status: PipelineStepStatus;
+  started_time: string;
+  finished_time: string;
+};
+
 export type PipelineRun = {
   uuid: string;
   project_uuid: string;
@@ -206,13 +214,7 @@ export type PipelineRun = {
   status: TStatus;
   started_time: string;
   finished_time: string;
-  pipeline_steps: {
-    run_uuid: string;
-    step_uuid: string;
-    status: PipelineStepStatus;
-    started_time: string;
-    finished_time: string;
-  }[];
+  pipeline_steps: PipelineRunStep[];
   env_variables: Record<string, string>;
   job_uuid: string;
   job_run_index: number;

--- a/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
+++ b/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
@@ -1,69 +1,69 @@
 import { deduplicates, replaces } from "../array";
 
-describe("replacing array entries", () => {
-  it("replaces the first entry that matches the predicate", () => {
-    const replace = replaces((entry) => entry === "x", "ignore");
+describe("replacing array items", () => {
+  it("replaces the first item that matches the predicate", () => {
+    const replace = replaces((item) => item === "x", "ignore");
 
     expect(replace(["a", "x", "c", "x"], "r")).toEqual(["a", "r", "c", "x"]);
   });
 
-  it("calls the predicate for each entry when none match", () => {
-    const entries = ["a", "b", "c"];
+  it("calls the predicate for each item when none match", () => {
+    const items = ["a", "b", "c"];
     const predicate = jest.fn(() => false);
     const replace = replaces<string>(predicate, "ignore");
 
-    replace(entries, "_");
+    replace(items, "_");
 
-    expect(predicate).toHaveBeenCalledTimes(entries.length);
+    items.forEach((item, i) =>
+      expect(predicate).toHaveBeenNthCalledWith(i + 1, item, i, items)
+    );
+    expect(predicate).toHaveBeenCalledTimes(items.length);
   });
 
   it("does not modify the source array", () => {
-    const entries = ["a", "b", "c"];
-    const replace = replaces<string>((entry) => entry === "b", "ignore");
+    const source = ["a", "b", "c"];
+    const replace = replaces<string>((item) => item === "b", "ignore");
 
-    expect(replace(entries, "r")).toEqual(["a", "r", "c"]);
-    expect(entries).toEqual(["a", "b", "c"]);
+    expect(replace(source, "r")).toEqual(["a", "r", "c"]);
+    expect(source).toEqual(["a", "b", "c"]);
   });
 });
 
 describe("replacement fallback strategies", () => {
   it("does nothing when set to 'ignore'", () => {
-    const replace = replaces<string>((entry) => entry === null, "ignore");
+    const replace = replaces<string>((item) => item === null, "ignore");
 
     expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c"]);
   });
 
   it("uses 'ignore' by default", () => {
-    const replace = replaces<string>((entry) => entry === null, "x" as any);
+    const replace = replaces<string>((item) => item === null, "x" as any);
 
     expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c"]);
   });
 
   it("adds the item in the back when set to 'push'", () => {
-    const replace = replaces<string>((entry) => entry === null, "push");
+    const replace = replaces<string>((item) => item === null, "push");
 
     expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c", "r"]);
   });
 
   it("adds the item in the front when set to 'unshift'", () => {
-    const replace = replaces<string>((entry) => entry === null, "unshift");
+    const replace = replaces<string>((item) => item === null, "unshift");
 
     expect(replace(["a", "b", "c"], "r")).toEqual(["r", "a", "b", "c"]);
   });
 });
 
 describe("deduplicating arrays", () => {
-  it("removes entries that share the same key", () => {
-    const deduplicate = deduplicates<string>((s) => s);
-    const input = ["a", "b", "c", "b", "c", "a", "b", "c"];
+  it("it merges arrays and omits items that share the same key", () => {
+    const deduplicate = deduplicates<string>((key) => key);
+    const input = [
+      ["a", "b", "c", "b"],
+      ["c", "a", "b", "c"],
+    ];
     const expected = ["a", "b", "c"];
 
-    expect(deduplicate(input)).toEqual(expected);
-  });
-
-  it("merges multiple arrays", () => {
-    const deduplicate = deduplicates<string>((s) => s);
-
-    expect(deduplicate(["a", "b"], ["c", "d"])).toEqual(["a", "b", "c", "d"]);
+    expect(deduplicate(...input)).toEqual(expected);
   });
 });

--- a/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
+++ b/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
@@ -1,0 +1,69 @@
+import { deduplicates, replaces } from "../array";
+
+describe("replacing array entries", () => {
+  it("replaces the first entry that matches the predicate", () => {
+    const replace = replaces((entry) => entry === "x", "ignore");
+
+    expect(replace(["a", "x", "c", "x"], "r")).toEqual(["a", "r", "c", "x"]);
+  });
+
+  it("calls the predicate for each entry", () => {
+    const entries = ["a", "b", "c"];
+    const predicate = jest.fn(() => false);
+    const replace = replaces<string>(predicate, "ignore");
+
+    replace(entries, "_");
+
+    expect(predicate).toHaveBeenCalledTimes(entries.length);
+  });
+
+  it("does not modify the source array", () => {
+    const entries = ["a", "b", "c"];
+    const replace = replaces<string>((entry) => entry === "b", "ignore");
+
+    expect(replace(entries, "r")).toEqual(["a", "r", "c"]);
+    expect(entries).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("replacement fallback strategies", () => {
+  it("does nothing when set to 'ignore'", () => {
+    const replace = replaces<string>((entry) => entry === null, "ignore");
+
+    expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c"]);
+  });
+
+  it("uses 'ignore' by default", () => {
+    const replace = replaces<string>((entry) => entry === null, "x" as any);
+
+    expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c"]);
+  });
+
+  it("adds the item in the back when set to 'push'", () => {
+    const replace = replaces<string>((entry) => entry === null, "push");
+
+    expect(replace(["a", "b", "c"], "r")).toEqual(["a", "b", "c", "r"]);
+  });
+
+  it("adds the item in the front when set to 'unshift'", () => {
+    const replace = replaces<string>((entry) => entry === null, "unshift");
+
+    expect(replace(["a", "b", "c"], "r")).toEqual(["r", "a", "b", "c"]);
+  });
+});
+
+describe("deduplicating arrays", () => {
+  it("removes entries that share the same key", () => {
+    const deduplicate = deduplicates<string>((s) => s);
+    const input = ["a", "b", "c", "b", "c", "a", "b", "c"];
+    const expected = ["a", "b", "c"];
+
+    expect(deduplicate(input)).toEqual(expected);
+  });
+
+  it("merges multiple arrays", () => {
+    const deduplicate = deduplicates<string>((s) => s);
+
+    expect(deduplicate(["a", "b"], ["c", "d"])).toEqual(["a", "b", "c", "d"]);
+  });
+});

--- a/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
+++ b/services/orchest-webserver/client/src/utils/__tests__/array.test.ts
@@ -7,7 +7,7 @@ describe("replacing array entries", () => {
     expect(replace(["a", "x", "c", "x"], "r")).toEqual(["a", "r", "c", "x"]);
   });
 
-  it("calls the predicate for each entry", () => {
+  it("calls the predicate for each entry when none match", () => {
     const entries = ["a", "b", "c"];
     const predicate = jest.fn(() => false);
     const replace = replaces<string>(predicate, "ignore");

--- a/services/orchest-webserver/client/src/utils/array.ts
+++ b/services/orchest-webserver/client/src/utils/array.ts
@@ -1,5 +1,9 @@
-/** Determines whether some condition is true for the given item. */
-export type Predicate<T> = (item: T) => boolean;
+/** Determines whether some condition is true for a given item. */
+export type FindPredicate<T> = (
+  item: T,
+  index: number,
+  items: readonly T[]
+) => boolean;
 /** Replaces an item in an array with a new one. */
 export type ArrayReplacer<T> = (items: readonly T[], item: T) => T[];
 /** Selects a key from the given item. */
@@ -13,7 +17,7 @@ export type ArrayMerger<T> = (...arrays: readonly (readonly T[])[]) => T[];
  * @param fallback The strategy to use if an item is not found
  */
 export const replaces = <T>(
-  predicate: Predicate<T>,
+  predicate: FindPredicate<T>,
   fallback: "ignore" | "push" | "unshift"
 ): ArrayReplacer<T> => (items, item) => {
   const index = items.findIndex(predicate);

--- a/services/orchest-webserver/client/src/utils/array.ts
+++ b/services/orchest-webserver/client/src/utils/array.ts
@@ -1,0 +1,62 @@
+/** Determines whether some condition is true for the given item. */
+export type Predicate<T> = (item: T) => boolean;
+/** Replaces an item in an array with a new one. */
+export type ArrayReplacer<T> = (items: readonly T[], item: T) => T[];
+/** Selects a key from the given item. */
+export type KeySelector<T> = (item: T) => string | number;
+/** Merges multiple arrays into one. */
+export type ArrayMerger<T> = (...arrays: readonly (readonly T[])[]) => T[];
+
+/**
+ * Returns a function which replaces the first item in an array that matches the predicate.
+ * @param predicate Determines which item should be replaced with a new item.
+ * @param fallback The strategy to use if an item is not found
+ */
+export const replaces = <T>(
+  predicate: Predicate<T>,
+  fallback: "ignore" | "push" | "unshift"
+): ArrayReplacer<T> => (items, item) => {
+  const index = items.findIndex(predicate);
+
+  if (index === -1) {
+    switch (fallback) {
+      default:
+        return [...items];
+      case "push":
+        return [...items, item];
+      case "unshift":
+        return [item, ...items];
+    }
+  }
+
+  return [...items.slice(0, index), item, ...items.slice(index + 1)];
+};
+
+/**
+ * Returns a function which merges multiple arrays and deduplicates items based on some shared key.
+ * @param selectKey Selects the key which is used to determine uniqueness.
+ */
+export const deduplicates = <T>(selectKey: KeySelector<T>): ArrayMerger<T> => (
+  ...arrays
+) => {
+  const result: T[] = [];
+  const keys = new Set<string | number>();
+
+  const isDuplicate = (item: T) => {
+    const key = selectKey(item);
+    const seen = keys.has(key);
+    if (!seen) keys.add(key);
+
+    return seen;
+  };
+
+  for (const array of arrays) {
+    for (const item of array) {
+      if (isDuplicate(item)) continue;
+
+      result.push(item);
+    }
+  }
+
+  return result;
+};

--- a/services/orchest-webserver/client/src/utils/record.ts
+++ b/services/orchest-webserver/client/src/utils/record.ts
@@ -2,6 +2,9 @@ import { hasValue } from "@orchest/lib-utils";
 
 export type AnyRecord = Record<string, unknown>;
 export type PropsOf<T extends AnyRecord> = readonly (keyof T)[];
+export type EntryPredicate = ([string, unknown]) => boolean;
+
+const entryHasValue: EntryPredicate = ([, value]) => !hasValue(value);
 
 /**
  * Returns the properties of the record T as a typed array.
@@ -42,12 +45,20 @@ export const pick = <T extends AnyRecord, P extends PropsOf<T>>(
   return result as Pick<T, P[number]>;
 };
 
-/** Remove unwanted properties from the record R.
- * By default, it removes all properties with value `null` and `undefined`. */
-export const prune = <R extends Record<string, unknown>>(
-  record: Record<string, unknown>,
-  predicate: (args: [string, unknown]) => boolean = ([, value]) =>
-    hasValue(value)
-): R => {
-  return Object.fromEntries(Object.entries(record).filter(predicate)) as R;
-};
+/**
+ * Removes some undesired properties from the record R.
+ * By default, it removes all properties with nullish values.
+ */
+export const prune = <T extends AnyRecord, R extends AnyRecord = T>(
+  record: T,
+  predicate: EntryPredicate = entryHasValue
+) => Object.fromEntries(Object.entries(record).filter(predicate)) as R;
+
+/**
+ * Returns a predicate which returns true when a property of a record is strictly equal to a provided value.
+ * This is useful in for instance, `Array.find` or `replaces`.
+ */
+export const equates = <T extends AnyRecord, P extends keyof T>(
+  prop: P,
+  value: unknown
+) => (item: T) => item[prop] === value;


### PR DESCRIPTION
## Description

The primary purpose of this PR is to add a "Cancel Job Run" button to the pipeline editor when viewing a job run.

![image](https://user-images.githubusercontent.com/8259221/187879676-c1f1a157-4c29-47e8-8fd8-d5f9eb2ad956.png)

But I have also taken some time to create abstractions for the "job runs api" and a zustand store for it.
While doing so, I learned a lot about zustand, and because I found a lot of boilerplate code for array manipulation in other stores, I decided to create some helpers to reduce said boilerplate in this one.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
