### PR TITLE
Write to JupyterLab user settings during custom Jupyter server build

### DIFF
--- a/services/jupyter-server/Dockerfile
+++ b/services/jupyter-server/Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 RUN apt-get update \
     # Refresh SSL certificates
     && update-ca-certificates --fresh \
-    && apt-get install -yq --no-install-recommends curl git jq ca-certificates \
+    && apt-get install -yq --no-install-recommends curl git jq ca-certificates rsync \
     # Install nodejs for Jupyter extensions.
-    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    ssh sshpass && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -yq --no-install-recommends nodejs \
     # Swap dash for bash to get more full fledged shell by default in
     # JupyterLab terminal.

--- a/services/jupyter-server/Dockerfile
+++ b/services/jupyter-server/Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 RUN apt-get update \
     # Refresh SSL certificates
     && update-ca-certificates --fresh \
-    && apt-get install -yq --no-install-recommends curl git jq ca-certificates rsync \
+    && apt-get install -yq --no-install-recommends curl git jq ca-certificates rsync ssh sshpass \
     # Install nodejs for Jupyter extensions.
-    ssh sshpass && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -yq --no-install-recommends nodejs \
     # Swap dash for bash to get more full fledged shell by default in
     # JupyterLab terminal.

--- a/utility-containers/image-builder-buildkit/Dockerfile
+++ b/utility-containers/image-builder-buildkit/Dockerfile
@@ -1,8 +1,10 @@
 FROM moby/buildkit:latest
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
-RUN	buildkitd --version && buildctl --version && \
-	apk add rsync openssh-server && ssh-keygen -A && \
-	# To ssh from the jupyter server container while building to be
-	# able to write to jupyter settings.
-	echo -e "root\nroot" | passwd root && \
-	echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+RUN buildkitd --version \
+    && buildctl --version \
+    && apk add rsync openssh-server \
+    && ssh-keygen -A \
+    # To ssh from the jupyter server container while building to be
+    # able to write to jupyter settings.
+    && echo -e "root\nroot" | passwd root \
+    && echo "PermitRootLogin yes" >> /etc/ssh/sshd_config

--- a/utility-containers/image-builder-buildkit/Dockerfile
+++ b/utility-containers/image-builder-buildkit/Dockerfile
@@ -1,3 +1,8 @@
 FROM moby/buildkit:latest
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
-RUN buildkitd --version
+RUN	buildkitd --version && buildctl --version && \
+	apk add rsync openssh-server && ssh-keygen -A && \
+	# To ssh from the jupyter server container while building to be
+	# able to write to jupyter settings.
+	echo -e "root\nroot" | passwd root && \
+	echo "PermitRootLogin yes" >> /etc/ssh/sshd_config

--- a/utility-containers/image-builder-buildx/Dockerfile
+++ b/utility-containers/image-builder-buildx/Dockerfile
@@ -1,4 +1,9 @@
 FROM docker
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
-RUN docker buildx version
+RUN	docker buildx version && \
+	apk add rsync openssh-server && ssh-keygen -A && \
+	# To ssh from the jupyter server container while building to be
+	# able to write to jupyter settings.
+	echo -e "root\nroot" | passwd root && \
+	echo "PermitRootLogin yes" >> /etc/ssh/sshd_config


### PR DESCRIPTION
## Description

When using `buildah` to build images we could mount (RW) the jupyterlab settings from the builder to the container in which the build takes place, this is not possible anymore with `buildkit`. To circumvent that, the user settings are `rsync`'d from the container where the build takes place to the builder pod, which mounts the jupyter settings. 

To do that, a ssh server is started on the builder pod when building jupyter.