### PR TITLE
Shift responsibility of kernels pod creation to `orchest-api`

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -73,16 +73,6 @@ KERNELSPECS_PATH = ".orchest/kernels/{project_uuid}"
 
 # Environments
 ENVIRONMENT_IMAGE_NAME = "orchest-env-{project_uuid}-{environment_uuid}"
-# NOTE: the build_uuid is rather important, since it allows us to
-# differentiate between builds of the same environment. Without that,
-# different env builds would contend for the same tag (the same
-# environment image removal name), leading to issues in the case of
-# multiple environment images "versions" surviving through multiple
-# updates because of jobs.
-ENVIRONMENT_IMAGE_REMOVAL_NAME = (
-    "removed-orchest-env-{project_uuid}-{environment_uuid}-{build_uuid}"
-)
-
 # Orchest environments that are passed as services, i.e. the image will
 # be used to start a service, have a form of "environment@<env-uuid>".
 ENVIRONMENT_AS_SERVICE_PREFIX = "environment@"

--- a/services/node-agent/app/image_puller.py
+++ b/services/node-agent/app/image_puller.py
@@ -173,10 +173,11 @@ class ImagePuller(object):
                     self.logger.warning(f"Image '{image_name}' was not downloaded!")
                 except Exception as ex:
                     self.logger.warning(
-                        f"Attempt {retry} to pull image "
-                        f"'{image_name}' failed with "
-                        f"exception - retrying. Exception was: {ex}."
+                        f"Attempt {retry} to pull image '{image_name}' and notify the "
+                        "orchest-api failed with exception - retrying. "
+                        f"Exception was: {ex}."
                     )
+
             queue.task_done()
 
     async def run(self):

--- a/services/node-agent/app/image_puller.py
+++ b/services/node-agent/app/image_puller.py
@@ -87,7 +87,69 @@ class ImagePuller(object):
         # pulled are not pulled concurrently again.
         self._curr_pulling_imgs = set()
 
-    async def get_image_names(self, queue: asyncio.Queue):
+    async def _enqueue_pre_pull_orchest_images(
+        self, session: aiohttp.ClientSession, queue: asyncio.Queue
+    ):
+        endpoint = f"{self.orchest_api_host}/api/ctl/orchest-images-to-pre-pull"
+        async with session.get(endpoint) as response:
+            response_json = await response.json()
+            for image_name in response_json["pre_pull_images"]:
+                await queue.put((image_name, False))
+
+    async def _enqueue_active_environment_images(
+        self, session: aiohttp.ClientSession, queue: asyncio.Queue
+    ):
+        endpoint = (
+            f"{self.orchest_api_host}/api/environment-images/active"
+            "?stored_in_registry=true"
+        )
+        async with session.get(endpoint) as response:
+            response_json = await response.json()
+            active_images = response_json["active_environment_images"]
+
+        # Since k8s GC could delete the image from the node we want the
+        # image puller to continuously try to pull all active images, at
+        # the same time, we don't want to have it notify the orchest-api
+        # for every image it (attempts to) pull, but only about the ones
+        # the orchest-api believe are not on the node.
+        endpoint = (
+            f"{self.orchest_api_host}/api/environment-images/active"
+            f"?stored_in_registry=true&not_in_node={CONFIG_CLASS.CLUSTER_NODE}"
+        )
+        async with session.get(endpoint) as response:
+            response_json = await response.json()
+            images_to_notify_api_about_pull = set(
+                response_json["active_environment_images"]
+            )
+
+        for image in active_images:
+            await queue.put((image, image in images_to_notify_api_about_pull))
+
+    async def _enqueue_active_jupyter_images(
+        self, session: aiohttp.ClientSession, queue: asyncio.Queue
+    ):
+        endpoint = (
+            f"{self.orchest_api_host}/api/ctl/active-custom-jupyter-images"
+            "?stored_in_registry=true"
+        )
+        async with session.get(endpoint) as response:
+            response_json = await response.json()
+            active_images = response_json["active_custom_jupyter_images"]
+
+        endpoint = (
+            f"{self.orchest_api_host}/api/ctl/active-custom-jupyter-images"
+            f"?stored_in_registry=true&not_in_node={CONFIG_CLASS.CLUSTER_NODE}"
+        )
+        async with session.get(endpoint) as response:
+            response_json = await response.json()
+            images_to_notify_api_about_pull = set(
+                response_json["active_custom_jupyter_images"]
+            )
+
+        for image in active_images:
+            await queue.put((image, image in images_to_notify_api_about_pull))
+
+    async def get_active_images_to_pull(self, queue: asyncio.Queue):
         """Fetches the image names by calling following endpoints
         of the orchest-api.
             1. /ctl/orchest-images-to-pre-pull
@@ -101,36 +163,13 @@ class ImagePuller(object):
         async with aiohttp.ClientSession(trust_env=True) as session:
             while True:
                 try:
-                    endpoint = (
-                        f"{self.orchest_api_host}/api/ctl/orchest-images-to-pre-pull"
-                    )
-                    async with session.get(endpoint) as response:
-                        response_json = await response.json()
-                        for image_name in response_json["pre_pull_images"]:
-                            await queue.put(image_name)
-
-                    endpoint = (
-                        f"{self.orchest_api_host}/api/environment-images/active"
-                        "?stored_in_registry=true"
-                    )
-                    async with session.get(endpoint) as response:
-                        response_json = await response.json()
-                        for image_name in response_json["active_environment_images"]:
-                            await queue.put(image_name)
-
-                    endpoint = (
-                        f"{self.orchest_api_host}/api/ctl/active-custom-jupyter-images"
-                        "?stored_in_registry=true"
-                    )
-                    async with session.get(endpoint) as response:
-                        response_json = await response.json()
-                        for image_name in response_json["active_custom_jupyter_images"]:
-                            await queue.put(image_name)
-
+                    await self._enqueue_pre_pull_orchest_images(session, queue)
+                    await self._enqueue_active_environment_images(session, queue)
+                    await self._enqueue_active_jupyter_images(session, queue)
                 except Exception as ex:
                     self.logger.error(
-                        f"Attempt to get image name from '{self.interval}' "
-                        f"encountered exception. Exception was: {ex}."
+                        f"Attempt '{self.interval}' to get active images"
+                        f"encountered an exception. Exception was: {ex}."
                     )
                 await asyncio.sleep(self.interval)
 
@@ -148,29 +187,47 @@ class ImagePuller(object):
         """
 
         while True:
-            image_name = await queue.get()
-            if self.policy == Policy.IfNotPresent:
-                if (
+            image_name, should_notify_orchest_api = await queue.get()
+
+            should_pull = self.policy == Policy.Always or (
+                self.policy == Policy.IfNotPresent
+                and not (
                     image_name in self._curr_pulling_imgs
                     or await self.container_runtime.image_exists(image_name)
-                ):
-                    queue.task_done()
-                    continue
-
-            self.logger.info(
-                f"Image '{image_name}' " "is not found - attempting pull..."
+                )
             )
 
             for retry in range(self.num_retries):
                 try:
-                    self.logger.info(f"Pulling image '{image_name}'...")
-                    if await self.container_runtime.download_image(image_name):
+                    if should_pull:
+                        self.logger.info(f"Pulling image '{image_name}'...")
+                        pulled_successfully = (
+                            await self.container_runtime.download_image(image_name)
+                        )
+
+                    # We might need to notify the orchest-api without
+                    # having pulled the image if, for example, the image
+                    # has already been pulled by other means, e.g. by a
+                    # pod using the image which was started on this
+                    # node.
+                    should_notify_orchest_api = should_notify_orchest_api and (
+                        not should_pull or pulled_successfully
+                    )
+                    if should_notify_orchest_api:
                         async with aiohttp.ClientSession(trust_env=True) as session:
                             await self.notify_orchest_api_of_image_pull(
                                 session, image_name
                             )
+                        self.logger.info(
+                            f"Notified orchest-api of pull of '{image_name}'"
+                        )
+                    if should_pull:
+                        if pulled_successfully:
+                            self.logger.info(f"Image '{image_name}' was pulled.")
+                        else:
+                            self.logger.warning(f"Image '{image_name}' was not pulled!")
+                    else:
                         break
-                    self.logger.warning(f"Image '{image_name}' was not downloaded!")
                 except Exception as ex:
                     self.logger.warning(
                         f"Attempt {retry} to pull image '{image_name}' and notify the "
@@ -179,20 +236,6 @@ class ImagePuller(object):
                     )
 
             queue.task_done()
-
-    async def run(self):
-        try:
-            self.logger.info("Starting image puller.")
-            queue = asyncio.Queue()
-
-            get_images_task = asyncio.create_task(self.get_image_names(queue))
-            pullers = [
-                asyncio.create_task(self.pull_image(queue))
-                for _ in range(self.threadiness)
-            ]
-            await asyncio.gather(*pullers, get_images_task)
-        finally:
-            await self.container_runtime.close()
 
     async def notify_orchest_api_of_image_pull(
         self, session: aiohttp.ClientSession, image: str
@@ -205,3 +248,17 @@ class ImagePuller(object):
             self.logger.info(
                 "Not an environment or jupyter image, not notifying the orchest-api."
             )
+
+    async def run(self):
+        try:
+            self.logger.info("Starting image puller.")
+            queue = asyncio.Queue()
+
+            get_images_task = asyncio.create_task(self.get_active_images_to_pull(queue))
+            pullers = [
+                asyncio.create_task(self.pull_image(queue))
+                for _ in range(self.threadiness)
+            ]
+            await asyncio.gather(*pullers, get_images_task)
+        finally:
+            await self.container_runtime.close()

--- a/services/node-agent/app/image_pusher.py
+++ b/services/node-agent/app/image_pusher.py
@@ -69,7 +69,10 @@ async def _notify_orchest_api_of_env_image_registry_push(
     proj_uuid, env_uuid, tag = _utils.env_image_name_to_proj_uuid_env_uuid_tag(image)
     if tag is None:
         raise ValueError(f"Unexpected image without tag: {image}.")
-    endpoint = f"http://orchest-api/api/environment-images/{proj_uuid}/{env_uuid}/{tag}"
+    endpoint = (
+        f"http://orchest-api/api/environment-images/{proj_uuid}/{env_uuid}/{tag}/"
+        "registry"
+    )
     async with session.put(endpoint) as response:
         if response.status != 200:
             raise Exception(
@@ -80,12 +83,12 @@ async def _notify_orchest_api_of_env_image_registry_push(
 async def _notify_orchest_api_of_jupyter_image_registry_push(
     session: aiohttp.ClientSession, image: str
 ) -> None:
-    endpoint = "http://orchest-api/api/ctl/set-jupyter-image-as-pushed"
     tag = _utils.jupyter_image_name_to_tag(image)
+    endpoint = f"http://orchest-api/api/ctl/jupyter-images/{tag}/registry"
     if tag is None:
         raise ValueError(f"Unexpected image without tag: {image}.")
 
-    async with session.put(endpoint, json={"tag": tag}) as response:
+    async with session.put(endpoint) as response:
         if response.status != 200:
             raise Exception(
                 f"Failed to PUT registry push of {image} to the orchest-api."

--- a/services/node-agent/app/image_pusher.py
+++ b/services/node-agent/app/image_pusher.py
@@ -102,6 +102,7 @@ async def notify_orchest_api_of_registry_push(
         await _notify_orchest_api_of_env_image_registry_push(session, image)
     elif _config.JUPYTER_IMAGE_NAME in image:
         await _notify_orchest_api_of_jupyter_image_registry_push(session, image)
+    raise ValueError(f"Invalid image to push: {image}.")
 
 
 async def _queue_images_to_push(queue: asyncio.Queue, interval: int) -> None:

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -281,12 +281,11 @@ def _run_update_in_venv(namespace: str, cluster_name: str, dev_mode: bool):
         run_cmds(args=shlex.split(update_cmd))
 
 
-@api.route("/set-jupyter-image-as-pushed")
-class SetJupyterImageAsPushed(Resource):
-    @api.doc("put_set_jupyter_image_as_pushed")
-    def put(self):
+@api.route("/jupyter-images/<string:tag>/registry")
+class JupyterImage(Resource):
+    @api.doc("put_jupyter_image_as_pushed")
+    def put(self, tag: str):
         """Notifies that the image has been pushed to the registry."""
-        tag = request.get_json()["tag"]
         image = models.JupyterImage.query.get_or_404(
             ident=int(tag),
             description="Jupyter image not found.",

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -83,10 +83,10 @@ class OrchestImagesToPrePull(Resource):
 
 
 def _get_formatted_active_jupyter_imgs(
-    stored_in_registry=None, in_node=None
+    stored_in_registry=None, in_node=None, not_in_node=None
 ) -> List[str]:
     active_custom_jupyter_images = utils.get_active_custom_jupyter_images(
-        stored_in_registry=stored_in_registry, in_node=in_node
+        stored_in_registry=stored_in_registry, in_node=in_node, not_in_node=not_in_node
     )
 
     active_custom_jupyter_image_names = []
@@ -99,6 +99,9 @@ def _get_formatted_active_jupyter_imgs(
 
 
 @api.route("/active-custom-jupyter-images")
+@api.param("stored_in_registry")
+@api.param("in_node")
+@api.param("not_in_node")
 class ActiveCustomJupyterImages(Resource):
     @api.doc("active_custom_jupyter_images")
     def get(self):
@@ -107,12 +110,14 @@ class ActiveCustomJupyterImages(Resource):
                 "stored_in_registry", default=None, type=lambda v: v in ["True", "true"]
             ),
             in_node=request.args.get("in_node"),
+            not_in_node=request.args.get("not_in_node"),
         )
 
         return {"active_custom_jupyter_images": active_custom_jupyter_images}, 200
 
 
 @api.route("/active-custom-jupyter-images-to-push")
+@api.param("in_node")
 class ActiveCustomJupyterImagesToPush(Resource):
     @api.doc("active_custom_jupyter_images-to-push")
     def get(self):

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -297,7 +297,7 @@ class JupyterImageRegistryStatus(Resource):
         return {}, 200
 
 
-@api.route("/jupyter-images/<string:tag>/node/<string:node_name>")
+@api.route("/jupyter-images/<string:tag>/node/<string:node>")
 @api.param("tag", "Tag of the image")
 @api.param("node", "Node on which the image was pulled")
 class JupyterImageNodeStatus(Resource):

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -98,10 +98,10 @@ class LatestEnvironmentImage(Resource):
 
 
 def _get_formatted_active_environment_imgs(
-    stored_in_registry=None, in_node=None
+    stored_in_registry=None, in_node=None, not_in_node=None
 ) -> List[str]:
     active_env_images = environments.get_active_environment_images(
-        stored_in_registry=stored_in_registry, in_node=in_node
+        stored_in_registry=stored_in_registry, in_node=in_node, not_in_node=not_in_node
     )
 
     active_env_images_names = []
@@ -119,6 +119,9 @@ def _get_formatted_active_environment_imgs(
 
 
 @api.route("/active")
+@api.param("stored_in_registry")
+@api.param("in_node")
+@api.param("not_in_node")
 class ActiveEnvironmentImages(Resource):
     @api.doc("get_active_environment_images")
     @api.marshal_with(schema.active_environment_images, code=200)
@@ -130,12 +133,14 @@ class ActiveEnvironmentImages(Resource):
                 "stored_in_registry", default=None, type=lambda v: v in ["True", "true"]
             ),
             in_node=request.args.get("in_node"),
+            not_in_node=request.args.get("not_in_node"),
         )
 
         return {"active_environment_images": active_env_images}, 200
 
 
 @api.route("/to-push")
+@api.param("in_node")
 class ActiveEnvironmentImagesToPush(Resource):
     @api.doc("get_environment_images_to_push")
     @api.marshal_with(schema.active_environment_images, code=200)

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -39,7 +39,7 @@ class LatestProjectEnvironmentEnvironmentImage(Resource):
         return env_image
 
 
-@api.route("/<string:project_uuid>/<string:environment_uuid>/<string:tag>")
+@api.route("/<string:project_uuid>/<string:environment_uuid>/<string:tag>/registry")
 @api.param("project_uuid", "uuid of the project")
 @api.param("environment_uuid", "uuid of the environment")
 @api.param("tag", "Tag of the image")

--- a/services/orchest-api/app/app/apis/namespace_sessions.py
+++ b/services/orchest-api/app/app/apis/namespace_sessions.py
@@ -1,3 +1,6 @@
+import os
+from typing import Any, Dict
+
 from flask import request
 from flask.globals import current_app
 from flask_restx import Namespace, Resource, marshal
@@ -5,11 +8,12 @@ from sqlalchemy import desc
 
 import app.models as models
 from _orchest.internals import config as _config
+from _orchest.internals import utils as _utils
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import errors as self_errors
-from app import schema
+from app import schema, utils
 from app.apis.namespace_runs import AbortPipelineRun
-from app.connections import db
+from app.connections import db, k8s_core_api
 from app.core import environments, events, sessions
 from app.errors import JupyterEnvironmentBuildInProgressException
 from app.types import InteractiveSessionConfig, SessionType
@@ -116,33 +120,25 @@ class Session(Resource):
             return {"message": "Session not found."}, 404
 
 
-@api.route(
-    "/kernels/lock-image/<string:project_uuid>/<string:pipeline_uuid>/"
-    "<string:environment_uuid>"
-)
+@api.route("/<string:project_uuid>/<string:pipeline_uuid>/kernels")
 @api.param("project_uuid", "UUID of project")
 @api.param("pipeline_uuid", "UUID of pipeline")
-@api.param("environment_uuid", "UUID of the environment")
 @api.response(404, "Session not found")
-class SessionKernelImageLock(Resource):
-    """For kernels to request which image to use for an environment.
+class SessionKernelList(Resource):
+    """To create kernels to be used by Jupyter EG in a session."""
 
-    The environment image that is returned will be considered as in use
-    by the session until the session is stopped.
-    """
-
-    @api.doc("get_kernel_image")
-    @api.marshal_with(schema.environment_image)
-    def get(self, project_uuid, pipeline_uuid, environment_uuid):
+    @api.doc("create_kernel")
+    @api.marshal_with(schema.kernel_spec)
+    def post(self, project_uuid, pipeline_uuid):
         """Lock and get the environment image to use for the kernel."""
-        models.InteractiveSession.query.get_or_404(
-            ident=(project_uuid, pipeline_uuid), description="Session not found."
-        )
-        images = environments.lock_environment_images_for_interactive_session(
-            project_uuid, pipeline_uuid, set([environment_uuid])
-        )
-        db.session.commit()
-        return images[environment_uuid]
+        try:
+            with TwoPhaseExecutor(db.session) as tpe:
+                CreateKernel(tpe).transaction(project_uuid, pipeline_uuid)
+        except Exception as e:
+            current_app.logger.error(e)
+            return {"message": str(e)}, 500
+
+        return {}, 201
 
 
 class CreateInteractiveSession(TwoPhaseFunction):
@@ -395,3 +391,134 @@ class StopInteractiveSession(TwoPhaseFunction):
                 project_uuid,
                 pipeline_uuid,
             )
+
+
+class CreateKernel(TwoPhaseFunction):
+    def _transaction(
+        self, project_uuid: str, pipeline_uuid: str, kernel_spec: Dict[str, Any]
+    ) -> None:
+        models.InteractiveSession.query.get_or_404(
+            ident=(project_uuid, pipeline_uuid), description="Session not found."
+        )
+        _, env_uuid, _ = _utils.env_image_name_to_proj_uuid_env_uuid_tag(
+            kernel_spec["kernel_image"]
+        )
+        env_image = environments.lock_environment_images_for_interactive_session(
+            project_uuid, pipeline_uuid, set([env_uuid])
+        )[env_uuid]
+        registry_ip = k8s_core_api.read_namespaced_service(
+            _config.REGISTRY, _config.ORCHEST_NAMESPACE
+        ).spec.cluster_ip
+        image_name = (
+            registry_ip
+            + _config.ENVIRONMENT_IMAGE_NAME.format(
+                project_uuid=project_uuid, environment_uuid=pipeline_uuid
+            )
+            + f":{env_image.tag}"
+        )
+
+        pod_manifest = {}
+        kernel_id = kernel_spec["kernel_id"]
+        if kernel_spec.get("kernel_username") is None:
+            name = f"kernel-{kernel_id}"
+        else:
+            kernel_username = kernel_spec["kernel_username"]
+            name = f"kernel-{kernel_username}-{kernel_id}"
+
+        session_uuid = project_uuid[:18] + pipeline_uuid[:18]
+        metadata = {
+            "name": name,
+            "labels": {
+                "project_uuid": project_uuid,
+                "session_uuid": session_uuid,
+                "kernel_id": kernel_id,
+                "component": "kernel",
+                "app": "enterprise-gateway",
+            },
+        }
+
+        vols, vol_mounts = _utils.get_step_and_kernel_volumes_and_volume_mounts(
+            userdir_pvc="userdir-pvc",
+            project_dir=kernel_spec["project_dir"],
+            pipeline_file=kernel_spec["pipeline_file"],
+            container_project_dir=_config.PROJECT_DIR,
+            container_pipeline_file=_config.PIPELINE_FILE,
+            container_runtime_socket=_config.CONTAINER_RUNTIME_SOCKET,
+        )
+
+        environment = {
+            "ORCHEST_PROJECT_UUID": project_uuid,
+            "ORCHEST_PROJECT_DIR": kernel_spec["project_dir"],
+            "ORCHEST_PIPELINE_UUID": pipeline_uuid,
+            "ORCHEST_PIPELINE_FILE": kernel_spec["pipeline_file"],
+            "ORCHEST_PIPELINE_PATH": kernel_spec["pipeline_path"],
+            "ORCHEST_HOST_GID": os.environ.get("ORCHEST_HOST_GID"),
+            "ORCHEST_SESSION_UUID": session_uuid,
+            "ORCHEST_SESSION_TYPE": "interactive",
+            "ORCHEST_GPU_ENABLED_INSTANCE": False,
+            "ORCHEST_CLUSTER": _config.ORCHEST_CLUSTER,
+            "ORCHEST_NAMESPACE": _config.ORCHEST_NAMESPACE,
+        }
+        environment["EG_RESPONSE_ADDRESS"] = kernel_spec["eg_response_address"]
+        if kernel_spec.get("spark_context_init_mode") is not None:
+            environment["KERNEL_SPARK_CONTEXT_INIT_MODE"] = kernel_spec[
+                "spark_context_init_mode"
+            ]
+
+        environment.update(
+            utils.get_proj_pip_env_variables(project_uuid, pipeline_uuid)
+        )
+        # No "PATH" changes, could break code execution.
+        environment.pop("PATH", None)
+        env = [{"name": k, "value": v} for k, v in environment.items()]
+
+        image_puller_manifest = _utils.get_init_container_manifest(
+            image_name,
+            _config.CONTAINER_RUNTIME,
+            _config.CONTAINER_RUNTIME_IMAGE,
+        )
+
+        pod_manifest = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": metadata,
+            "spec": {
+                "securityContext": {
+                    "runAsUser": 0,
+                    "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                    "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
+                },
+                # "Kernel pods have restart policies of Never. This is
+                # because the Jupyter framework already has built-in
+                # logic for auto-restarting failed kernels and any other
+                # restart policy would likely interfere with the
+                # built-in behaviors."
+                "restartPolicy": "Never",
+                "volumes": vols,
+                "initContainers": [
+                    image_puller_manifest,
+                ],
+                "containers": [
+                    {
+                        "name": name,
+                        "image": image_name,
+                        "env": env,
+                        "ports": [
+                            {"name": "web", "containerPort": 80, "protocol": "TCP"}
+                        ],
+                        "volumeMounts": vol_mounts,
+                    }
+                ],
+                "resources": {"requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}},
+            },
+        }
+        if kernel_spec["kernel_working_dir"] is not None:
+            pod_manifest["spec"]["containers"][0]["workingDir"] = kernel_spec[
+                "kernel_working_dir"
+            ]
+
+        self.collateral_kwargs["pod_manifest"] = pod_manifest
+
+    def _collateral(self, pod_manifest: Dict[str, Any]):
+        ns = _config.ORCHEST_NAMESPACE
+        k8s_core_api.create_namespaced_pod(ns, pod_manifest)

--- a/services/orchest-api/app/app/apis/namespace_sessions.py
+++ b/services/orchest-api/app/app/apis/namespace_sessions.py
@@ -408,9 +408,7 @@ class LaunchKernel(TwoPhaseFunction):
         env_image = environments.lock_environment_images_for_interactive_session(
             project_uuid, pipeline_uuid, set([env_uuid])
         )[env_uuid]
-        registry_ip = k8s_core_api.read_namespaced_service(
-            _config.REGISTRY, _config.ORCHEST_NAMESPACE
-        ).spec.cluster_ip
+        registry_ip = utils.get_registry_ip()
         image_name = (
             f"{registry_ip}/"
             + _config.ENVIRONMENT_IMAGE_NAME.format(

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -707,44 +707,15 @@ def _get_jupyter_enterprise_gateway_deployment_service_manifest(
         },
     }
 
-    # Get user environment variables to pass to Jupyter kernels.
-    try:
-        user_defined_env_vars = utils.get_proj_pip_env_variables(
-            project_uuid, pipeline_uuid
-        )
-
-        # NOTE: Don't allow users to specify change the `PATH` as it
-        # could break user code execution. The `PATH` var is removed
-        # when starting kernels through the jupyter-EG as well.
-        user_defined_env_vars.pop("PATH", None)
-    except Exception:
-        user_defined_env_vars = {}
-
     process_env_whitelist = [
         "ORCHEST_PIPELINE_UUID",
         "ORCHEST_PIPELINE_PATH",
         "ORCHEST_PROJECT_UUID",
-        "ORCHEST_USERDIR_PVC",
         "ORCHEST_PROJECT_DIR",
         "ORCHEST_PIPELINE_FILE",
-        "ORCHEST_HOST_GID",
-        "ORCHEST_SESSION_UUID",
-        "ORCHEST_SESSION_TYPE",
-        "ORCHEST_GPU_ENABLED_INSTANCE",
-        "ORCHEST_REGISTRY",
-        "ORCHEST_CLUSTER",
-        "ORCHEST_NAMESPACE",
     ]
-    process_env_whitelist.extend(list(user_defined_env_vars.keys()))
     process_env_whitelist = ",".join(process_env_whitelist)
 
-    # Need to reference the ip because the local docker engine will
-    # run the container, and if the image is missing it will prompt
-    # a pull which will fail because the FQDN can't be resolved by
-    # the local engine on the node. K8S_TODO: fix this.
-    registry_ip = k8s_core_api.read_namespaced_service(
-        _config.REGISTRY, _config.ORCHEST_NAMESPACE
-    ).spec.cluster_ip
     environment = {
         "EG_MIRROR_WORKING_DIRS": "True",
         "EG_LIST_KERNELS": "True",
@@ -767,23 +738,10 @@ def _get_jupyter_enterprise_gateway_deployment_service_manifest(
         # each kernel."
         "EG_NAMESPACE": _config.ORCHEST_NAMESPACE,
         "EG_SHARED_NAMESPACE": "True",
-        "ORCHEST_USERDIR_PVC": userdir_pvc,
         "ORCHEST_PROJECT_DIR": project_dir,
         "ORCHEST_PIPELINE_FILE": pipeline_path,
-        "ORCHEST_HOST_GID": os.environ.get("ORCHEST_HOST_GID"),
-        "ORCHEST_GPU_ENABLED_INSTANCE": str(CONFIG_CLASS.GPU_ENABLED_INSTANCE),
-        "ORCHEST_REGISTRY": registry_ip,
-        "ORCHEST_NAMESPACE": _config.ORCHEST_NAMESPACE,
-        "ORCHEST_CLUSTER": _config.ORCHEST_CLUSTER,
-        "CONTAINER_RUNTIME_SOCKET": _config.CONTAINER_RUNTIME_SOCKET,
-        "CONTAINER_RUNTIME": _config.CONTAINER_RUNTIME,
-        "CONTAINER_RUNTIME_IMAGE": _config.CONTAINER_RUNTIME_IMAGE,
     }
     environment = [{"name": k, "value": v} for k, v in environment.items()]
-    user_defined_env_vars = [
-        {"name": key, "value": value} for key, value in user_defined_env_vars.items()
-    ]
-    environment.extend(user_defined_env_vars)
     environment.extend(
         _get_orchest_sdk_vars(
             project_uuid,

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Optional, Tuple
 from _orchest.internals import config as _config
 from _orchest.internals.utils import add_image_puller_if_needed, get_userdir_relpath
 from app import utils
-from app.connections import k8s_core_api
 from app.types import SessionConfig, SessionType
 from config import CONFIG_CLASS
 
@@ -921,9 +920,7 @@ def _get_user_service_deployment_service_manifest(
         # run the container, and if the image is missing it will prompt
         # a pull which will fail because the FQDN can't be resolved by
         # the local engine on the node. K8S_TODO: fix this.
-        registry_ip = k8s_core_api.read_namespaced_service(
-            _config.REGISTRY, _config.ORCHEST_NAMESPACE
-        ).spec.cluster_ip
+        registry_ip = utils.get_registry_ip()
 
         image = image.replace(prefix, "")
         image = img_mappings[image]

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -1066,6 +1066,23 @@ event = Model(
     },
 )
 
+kernel_spec = Model(
+    "KernelRequest",
+    {
+        "kernel_working_dir": fields.String(required=False),
+        "kernel_username": fields.String(required=False),
+        "kernel_id": fields.String(required=True),
+        "kernel_image": fields.String(required=True),
+        "eg_response_address": fields.String(required=True),
+        "spark_context_init_mode": fields.Boolean(required=False),
+        # TODO: store this data at the interactive session db record
+        # level instead of passing it from jupyter EG.
+        "pipeline_file": fields.String(required=True),
+        "pipeline_path": fields.String(required=True),
+        "project_dir": fields.String(required=True),
+    },
+)
+
 
 def register_schema(api: Namespace) -> Namespace:
     current_module = sys.modules[__name__]

--- a/services/orchest-api/app/app/schema.py
+++ b/services/orchest-api/app/app/schema.py
@@ -1074,7 +1074,7 @@ kernel_spec = Model(
         "kernel_id": fields.String(required=True),
         "kernel_image": fields.String(required=True),
         "eg_response_address": fields.String(required=True),
-        "spark_context_init_mode": fields.Boolean(required=False),
+        "spark_context_init_mode": fields.String(required=False),
         # TODO: store this data at the interactive session db record
         # level instead of passing it from jupyter EG.
         "pipeline_file": fields.String(required=True),

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -13,7 +13,7 @@ from flask import current_app
 from flask_restx import Model
 from flask_sqlalchemy import Pagination
 from kubernetes import client as k8s_client
-from sqlalchemy import desc, or_, text
+from sqlalchemy import desc, or_, text, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import query, undefer
 
@@ -212,7 +212,9 @@ def fuzzy_filter_non_interactive_pipeline_runs(
 
 
 def get_active_custom_jupyter_images(
-    stored_in_registry: Optional[bool] = None, in_node: Optional[str] = None
+    stored_in_registry: Optional[bool] = None,
+    in_node: Optional[str] = None,
+    not_in_node: Optional[str] = None,
 ) -> List[models.JupyterImage]:
     """Returns the list of active jupyter images, sorted by tag DESC.
 
@@ -220,10 +222,18 @@ def get_active_custom_jupyter_images(
         stored_in_registry: If not none, it will be applied as a filter
             to the images. For example, if True, only active images
             which are already stored in the registry will be returned.
-        in_nodes: If not none, it will be applied as a filter so that
+        in_node: If not none, it will be applied as a filter so that
             only active images that are known by the orchest-api to
-            be on the given node will be returned.
+            be on the given node will be returned. Can't be used along
+            "not_in_node".
+        not_in_node: If not none, it will be applied as a filter so that
+            only active images that are known by the orchest-api to
+            *not* be on the given node will be returned. Can't be used
+            along "in_node". Can't be used along "in_node".
     """
+    if in_node is not None and not_in_node is not None:
+        raise ValueError("Can't use both 'in_node' and 'not_in_node' at the same time.")
+
     query = db.session.query(models.JupyterImage).filter(
         models.JupyterImage.marked_for_removal.is_(False),
         # Only allow an image that matches this orchest cluster
@@ -236,10 +246,22 @@ def get_active_custom_jupyter_images(
             models.JupyterImage.stored_in_registry.is_(stored_in_registry)
         )
 
-    # TODO: allow filtering with not_in_node.
     if in_node is not None:
         query = query.join(models.JupyterImageOnNode).filter(
             models.JupyterImageOnNode.node_name == in_node
+        )
+    elif not_in_node is not None:
+        images_on_node = (
+            db.session.query(models.JupyterImageOnNode)
+            .filter(models.JupyterImageOnNode.node_name == not_in_node)
+            .with_entities(
+                models.JupyterImageOnNode.jupyter_image_tag,
+            )
+        ).subquery()
+        query = query.filter(
+            tuple_(
+                models.JupyterImage.tag,
+            ).not_in(images_on_node),
         )
 
     return query.all()

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -798,3 +798,47 @@ def upsert_cluster_node(name: str) -> None:
     )
     stmt = stmt.on_conflict_do_nothing(index_elements=[models.ClusterNode.name])
     db.session.execute(stmt)
+
+
+def upsert_jupyter_image_on_node(tag: Union[str, int], node: str) -> None:
+    upsert_cluster_node(node)
+    stmt = insert(models.JupyterImageOnNode).values(
+        [
+            dict(
+                jupyter_image_tag=int(tag),
+                node_name=node,
+            )
+        ]
+    )
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=[
+            models.JupyterImageOnNode.jupyter_image_tag,
+            models.JupyterImageOnNode.node_name,
+        ]
+    )
+    db.session.execute(stmt)
+
+
+def upsert_environment_image_on_node(
+    project_uuid: str, environment_uuid: str, tag: Union[str, int], node: str
+) -> None:
+    upsert_cluster_node(node)
+    stmt = insert(models.EnvironmentImageOnNode).values(
+        [
+            dict(
+                project_uuid=project_uuid,
+                environment_uuid=environment_uuid,
+                environment_image_tag=int(tag),
+                node_name=node,
+            )
+        ]
+    )
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=[
+            models.EnvironmentImageOnNode.project_uuid,
+            models.EnvironmentImageOnNode.environment_uuid,
+            models.EnvironmentImageOnNode.environment_image_tag,
+            models.EnvironmentImageOnNode.node_name,
+        ]
+    )
+    db.session.execute(stmt)

--- a/services/orchest-webserver/app/app/res/kernels/launch_kubernetes.py
+++ b/services/orchest-webserver/app/app/res/kernels/launch_kubernetes.py
@@ -3,11 +3,12 @@
 This script is meant to be used by jupyter-enterprise-gateway (EG), so
 it's not something we call directly, instead, we place it in
 userdir/.orchest/kernels/<project uuid> and mount this file to the EG
-pod. It will launch a pod with the required env variables and specs.
+pod. It will request the creation of a kernel pod to the orchest-api.
 Pod deletion is handled by EG.
 
 Calls:
-    browser client -> jupyter server -> jupyter EG -> this script -> k8s
+    browser client -> jupyter server -> jupyter EG -> this script ->
+    orchest-api -> k8s
 
 Related docs:
     https://jupyter-enterprise-gateway.readthedocs.io/en/latest/kernel-kubernetes.html#kubernetes
@@ -16,186 +17,35 @@ Related docs:
 import argparse
 import os
 import sys
-import uuid
-from typing import Tuple
 
 import requests
-from kubernetes import client as k8s_client
-from kubernetes import config
 
 from _orchest.internals import config as _config
-from _orchest.internals.utils import (
-    get_init_container_manifest,
-    get_step_and_kernel_volumes_and_volume_mounts,
-)
-
-
-def _env_image_name_to_project_environment_uuid(image_name: str) -> Tuple[str, str]:
-    """Extracts a project/env uuid from an environment image name.
-
-    See ENVIRONMENT_IMAGE_NAME for the expected format, example:
-    orchest-env-ae400269-642f-42db-9db4-3be9e46ed344-61a86adf-7709-413b
-    -a449-86990e77f13f
-    """
-    prefix = "orchest-env-"
-    if not image_name.startswith(prefix):
-        raise ValueError()
-
-    image_name = image_name[len(prefix) :]
-    uuid4_length = 36
-    proj_uuid = image_name[:uuid4_length]
-    # Make sure it's a valid UUID.
-    uuid.UUID(proj_uuid)
-
-    image_name = image_name[uuid4_length + 1 :]
-    env_uuid = image_name[:uuid4_length]
-    uuid.UUID(env_uuid)
-    return proj_uuid, env_uuid
-
-
-def _get_user_env_vars(proj_uuid: str, pipe_uuid: str) -> dict:
-    project_resp = requests.get(
-        "http://" + _config.ORCHEST_API_ADDRESS + f"/api/projects/{proj_uuid}"
-    )
-    pipeline_resp = requests.get(
-        "http://"
-        + _config.ORCHEST_API_ADDRESS
-        + f"/api/pipelines/{proj_uuid}/{pipe_uuid}"
-    )
-
-    if project_resp.status_code != 200 or pipeline_resp.status_code != 200:
-        raise RuntimeError("Failed to retrieve user environment variables.")
-
-    project, pipeline = project_resp.json(), pipeline_resp.json()
-    return {**project["env_variables"], **pipeline["env_variables"]}
-
-
-def _get_kernel_pod_manifest(
-    kernel_id: str, response_addr: str, spark_context_init_mode: str
-) -> dict:
-    image_name = os.environ.get("KERNEL_IMAGE", None)
-    if image_name is None:
-        sys.exit(
-            "ERROR - KERNEL_IMAGE not found in environment - kernel launch terminating!"
-        )
-    proj_uuid, env_uuid = _env_image_name_to_project_environment_uuid(image_name)
-    pipeline_uuid = os.environ["ORCHEST_PIPELINE_UUID"]
-
-    resp = requests.get(
-        "http://"
-        + _config.ORCHEST_API_ADDRESS
-        + f"/api/sessions/kernels/lock-image/{proj_uuid}/{pipeline_uuid}/{env_uuid}"
-    )
-    if resp.status_code != 200:
-        sys.exit("Failed to get environment image version to use.")
-    tag = resp.json()["tag"]
-    image_name = f'{os.environ["ORCHEST_REGISTRY"]}/{image_name}:{tag}'
-
-    kernel_username = os.environ.get("KERNEL_USERNAME")
-    if kernel_username is None:
-        name = f"kernel-{kernel_id}"
-    else:
-        name = f"kernel-{kernel_username}-{kernel_id}"
-
-    metadata = {
-        "name": name,
-        "labels": {
-            "project_uuid": os.environ["ORCHEST_PROJECT_UUID"],
-            "session_uuid": os.environ["ORCHEST_SESSION_UUID"],
-            "kernel_id": kernel_id,
-            "component": "kernel",
-            "app": "enterprise-gateway",
-        },
-    }
-
-    vols, vol_mounts = get_step_and_kernel_volumes_and_volume_mounts(
-        userdir_pvc=os.environ.get("ORCHEST_USERDIR_PVC"),
-        project_dir=os.environ.get("ORCHEST_PROJECT_DIR"),
-        pipeline_file=os.environ.get("ORCHEST_PIPELINE_FILE"),
-        container_project_dir=_config.PROJECT_DIR,
-        container_pipeline_file=_config.PIPELINE_FILE,
-        container_runtime_socket=_config.CONTAINER_RUNTIME_SOCKET,
-    )
-
-    environment = dict()
-    environment["EG_RESPONSE_ADDRESS"] = response_addr
-    environment["KERNEL_SPARK_CONTEXT_INIT_MODE"] = spark_context_init_mode
-    # Since the environment is specific to the kernel (per env stanza of
-    # kernelspec, KERNEL_ and ENV_WHITELIST) just add the env here.
-    environment.update(os.environ)
-    try:
-        user_env_vars = _get_user_env_vars(
-            os.environ["ORCHEST_PROJECT_UUID"],
-            pipeline_uuid,
-        )
-    except RuntimeError as e:
-        sys.exit(e)
-    else:
-        # NOTE: This update needs to happen after adding `os.environ`.
-        # Otherwise old env var values (that are present in the
-        # environment of the EG) will overwrite updated values.
-        environment.update(user_env_vars)
-    # Let the image PATH be used. Since this is relative to images,
-    # we're probably safe.
-    environment.pop("PATH")
-    env = [{"name": k, "value": v} for k, v in environment.items()]
-
-    image_puller_manifest = get_init_container_manifest(
-        image_name,
-        _config.CONTAINER_RUNTIME,
-        _config.CONTAINER_RUNTIME_IMAGE,
-    )
-
-    # K8S_TODO: device requests/gpus.
-    pod_manifest = {
-        "apiVersion": "v1",
-        "kind": "Pod",
-        "metadata": metadata,
-        "spec": {
-            "securityContext": {
-                "runAsUser": 0,
-                "runAsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-                "fsGroup": int(os.environ.get("ORCHEST_HOST_GID")),
-            },
-            # "Kernel pods have restart policies of Never. This is
-            # because the Jupyter framework already has built-in logic
-            # for auto-restarting failed kernels and any other restart
-            # policy would likely interfere with the built-in
-            # behaviors."
-            "restartPolicy": "Never",
-            "volumes": vols,
-            "initContainers": [
-                image_puller_manifest,
-            ],
-            "containers": [
-                {
-                    "name": name,
-                    "image": image_name,
-                    "env": env,
-                    "ports": [{"name": "web", "containerPort": 80, "protocol": "TCP"}],
-                    "volumeMounts": vol_mounts,
-                }
-            ],
-            "resources": {"requests": {"cpu": _config.USER_CONTAINERS_CPU_SHARES}},
-        },
-    }
-    if os.environ.get("KERNEL_WORKING_DIR") is not None:
-        pod_manifest["spec"]["containers"][0]["workingDir"] = os.environ[
-            "KERNEL_WORKING_DIR"
-        ]
-
-    return pod_manifest
 
 
 def launch_kernel(kernel_id, response_addr, spark_context_init_mode):
-    manifest = _get_kernel_pod_manifest(
-        kernel_id, response_addr, spark_context_init_mode
+    project_uuid = os.environ["ORCHEST_PROJECT_UUID"]
+    pipeline_uuid = os.environ["ORCHEST_PIPELINE_UUID"]
+    kernel_spec = {
+        "kernel_working_dir": os.environ.get("KERNEL_WORKING_DIR"),
+        "kernel_username": os.environ.get("KERNEL_USERNAME"),
+        "kernel_image": os.environ["KERNEL_IMAGE"],
+        "kernel_id": kernel_id,
+        "eg_response_address": response_addr,
+        "spark_context_init_mode": spark_context_init_mode,
+        "pipeline_file": os.environ["ORCHEST_PIPELINE_FILE"],
+        "pipeline_path": os.environ["ORCHEST_PIPELINE_PATH"],
+        "project_dir": os.environ["ORCHEST_PROJECT_DIR"],
+    }
+    resp = requests.post(
+        url=(
+            f"http://{_config.ORCHEST_API_ADDRESS}/api/sessions/"
+            f"{project_uuid}/{pipeline_uuid}/kernels"
+        ),
+        data=kernel_spec,
     )
-
-    config.load_incluster_config()
-    k8s_core_api = k8s_client.CoreV1Api()
-    ns = _config.ORCHEST_NAMESPACE
-    k8s_core_api.create_namespaced_pod(ns, manifest)
+    if resp.status_code != 201:
+        sys.exit(f"Kernel pod request failed: {resp.status_code}, {resp.json()}.")
 
 
 if __name__ == "__main__":

--- a/services/orchest-webserver/app/app/res/kernels/launch_kubernetes.py
+++ b/services/orchest-webserver/app/app/res/kernels/launch_kubernetes.py
@@ -42,7 +42,7 @@ def launch_kernel(kernel_id, response_addr, spark_context_init_mode):
             f"http://{_config.ORCHEST_API_ADDRESS}/api/sessions/"
             f"{project_uuid}/{pipeline_uuid}/kernels"
         ),
-        data=kernel_spec,
+        json=kernel_spec,
     )
     if resp.status_code != 201:
         sys.exit(f"Kernel pod request failed: {resp.status_code}, {resp.json()}.")


### PR DESCRIPTION
## Description

Preliminary work needed for pod scheduling at the `orchest-api` level:
- have the `orchest-api` be notified of an image having been pulled to a node
- shift responsibility of kernels pod creation to orchest-api
