### PR TITLE
Fix/remove nginx if annotation is present

### DIFF
--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -558,7 +558,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 			copy.Spec.Applications = applications
 			changed = true
 		}
-	} else if isIngressAddonRequired(ctx, occ.Client()) {
+	} else if isIngressAddonRequired(ctx, occ.k8sDistro, occ.Client()) {
 		ingressEnabled := false
 		for _, app := range copy.Spec.Applications {
 			if app.Name == addons.IngressNginx {

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -544,7 +544,21 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 		copy.Spec.Applications = occ.config.DefaultApplications
 	}
 
-	if !isIngressDisabled(copy) && isIngressAddonRequired(ctx, occ.Client()) {
+	if isIngressDisabled(copy) {
+		ingressEnabled := false
+		applications := make([]orchestv1alpha1.ApplicationSpec, 0, 0)
+		for _, app := range copy.Spec.Applications {
+			if app.Name != addons.IngressNginx {
+				ingressEnabled = true
+				continue
+			}
+			applications = append(applications, app)
+		}
+		if ingressEnabled {
+			copy.Spec.Applications = applications
+			changed = true
+		}
+	} else if isIngressAddonRequired(ctx, occ.Client()) {
 		ingressEnabled := false
 		for _, app := range copy.Spec.Applications {
 			if app.Name == addons.IngressNginx {

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -554,6 +554,9 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 			}
 			applications = append(applications, app)
 		}
+
+		// If ingress is enabled, it has to be removed from the .Spec.Applications,
+		// k8s ensures we are using the latest object version.
 		if ingressEnabled {
 			copy.Spec.Applications = applications
 			changed = true

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -548,7 +548,7 @@ func (occ *OrchestClusterController) setDefaultIfNotSpecified(ctx context.Contex
 		ingressEnabled := false
 		applications := make([]orchestv1alpha1.ApplicationSpec, 0, 0)
 		for _, app := range copy.Spec.Applications {
-			if app.Name != addons.IngressNginx {
+			if app.Name == addons.IngressNginx {
 				ingressEnabled = true
 				continue
 			}

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -507,14 +507,9 @@ func isCustomImage(orchest *orchestv1alpha1.OrchestCluster, component, imageName
 	return false
 }
 
-func isIngressAddonRequired(ctx context.Context, client kubernetes.Interface) bool {
-
-	if isNginxIngressInstalled(ctx, client) {
-		return false
-	}
+func isIngressAddonRequired(ctx context.Context, k8sDistro utils.KubernetesDistros, client kubernetes.Interface) bool {
 
 	// we first need to detect the k8s distribution
-	k8sDistro := utils.DetectK8sDistribution(client)
 	if k8sDistro == utils.NotDetected {
 		klog.Error("Failed to detect k8s distribution")
 		return false
@@ -523,7 +518,7 @@ func isIngressAddonRequired(ctx context.Context, client kubernetes.Interface) bo
 	// In k3s ingress addon can be installed by us
 	switch k8sDistro {
 	case utils.K3s, utils.EKS, utils.GKE:
-		return true
+		return !isNginxIngressInstalled(ctx, client)
 	default:
 		return false
 	}

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -515,7 +515,6 @@ func isIngressAddonRequired(ctx context.Context, k8sDistro utils.KubernetesDistr
 		return false
 	}
 
-	// In k3s ingress addon can be installed by us
 	switch k8sDistro {
 	case utils.K3s, utils.EKS, utils.GKE:
 		return !isNginxIngressInstalled(ctx, client)


### PR DESCRIPTION
## Description

The controller has to remove the `Nginx` from the list of applications if present in `OrchestCluster` CRD. also the detection logic of whether the `Nginx` is required or not, is simplified a bit.

Fixes: #issue

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
