### PR TITLE
More empty state actions

### DIFF
--- a/services/orchest-webserver/client/src/components/common/EmptyState.tsx
+++ b/services/orchest-webserver/client/src/components/common/EmptyState.tsx
@@ -4,7 +4,7 @@ import Stack, { StackProps } from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
 
-type ViewportCenterMessageProps = StackProps & {
+type EmptyStateProps = StackProps & {
   imgSrc: string;
   title: string;
   description: string;
@@ -12,7 +12,7 @@ type ViewportCenterMessageProps = StackProps & {
   actions?: React.ReactNode;
 };
 
-export const ViewportCenterMessage = ({
+export const EmptyState = ({
   imgSrc,
   title,
   description,
@@ -20,7 +20,7 @@ export const ViewportCenterMessage = ({
   sx,
   actions,
   ...props
-}: ViewportCenterMessageProps) => {
+}: EmptyStateProps) => {
   return (
     <Stack
       direction="column"

--- a/services/orchest-webserver/client/src/environments-view/CreateEnvironmentButton.tsx
+++ b/services/orchest-webserver/client/src/environments-view/CreateEnvironmentButton.tsx
@@ -16,7 +16,7 @@ export const CreateEnvironmentButton = ({
   onCreated,
   ...props
 }: CreateEnvironmentButtonProps) => {
-  const { createEnvironment, isAllowedToCreate } = useCreateEnvironment();
+  const { createEnvironment, canCreateEnvironment } = useCreateEnvironment();
   const onCreate = async () => {
     const newEnvironment = await createEnvironment();
     if (newEnvironment) onCreated(newEnvironment.uuid);
@@ -25,7 +25,7 @@ export const CreateEnvironmentButton = ({
   return (
     <CreateEntityButton
       onClick={onCreate}
-      disabled={!isAllowedToCreate}
+      disabled={!canCreateEnvironment}
       {...props}
     >
       New environment

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
@@ -20,7 +20,7 @@ export const EnvironmentMenuList = () => {
 
   const setEnvironment = useEnvironmentsApi((state) => state.setEnvironment);
   const environments = useEnvironmentsApi((state) => state.environments);
-  const { selectEnvironment } = useSelectEnvironment();
+  const selectEnvironment = useSelectEnvironment();
 
   const updateStoreAndRedirect = (uuid: string) => {
     const environment = environmentDataFromState(environmentChanges);
@@ -43,7 +43,7 @@ export const EnvironmentMenuList = () => {
     >
       <CreateEnvironmentButton
         sx={{ flexShrink: 0 }}
-        onCreated={updateStoreAndRedirect}
+        onCreated={selectEnvironment}
       />
       <MenuList
         sx={{

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMoreOptions.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMoreOptions.tsx
@@ -33,8 +33,7 @@ export const EnvironmentMoreOptions = () => {
     (state) => state.environmentChanges?.action
   );
 
-  const { selectEnvironment } = useSelectEnvironment();
-
+  const selectEnvironment = useSelectEnvironment();
   const deleteEnvironment = useEnvironmentsApi((state) => state.delete);
   const environments = useEnvironmentsApi((state) => state.environments);
   const isUsedByJobs = useEnvironmentsApi((state) => state.isUsedByJobs);

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
@@ -22,7 +22,7 @@ export const EditEnvironmentContainer = ({
 
   const environments = useEnvironmentsApi((state) => state.environments);
   const isLoading = !hasValue(environments);
-  const hasNoEnvironments = !isLoading && environments.length > 0;
+  const hasNoEnvironments = !isLoading && environments.length === 0;
 
   if (isLoading) {
     return null;

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentContainer.tsx
@@ -20,20 +20,23 @@ export const EditEnvironmentContainer = ({
   useSaveEnvironmentChanges();
   useUpdateBuildStatusInEnvironmentChanges();
 
-  const hasNoEnvironment = useEnvironmentsApi((state) =>
-    !hasValue(state.environments) ? undefined : state.environments.length === 0
-  );
+  const environments = useEnvironmentsApi((state) => state.environments);
+  const isLoading = !hasValue(environments);
+  const hasNoEnvironments = !isLoading && environments.length > 0;
 
-  if (!hasValue(hasNoEnvironment)) return null;
-  return hasNoEnvironment ? (
-    <NoEnvironment />
-  ) : (
-    <Stack
-      direction="column"
-      spacing={3}
-      sx={{ paddingBottom: (theme) => theme.spacing(6) }}
-    >
-      {children}
-    </Stack>
-  );
+  if (isLoading) {
+    return null;
+  } else if (hasNoEnvironments) {
+    return <NoEnvironment />;
+  } else {
+    return (
+      <Stack
+        direction="column"
+        spacing={3}
+        sx={{ paddingBottom: (theme) => theme.spacing(6) }}
+      >
+        {children}
+      </Stack>
+    );
+  }
 };

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/NoEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/NoEnvironment.tsx
@@ -1,4 +1,4 @@
-import { ViewportCenterMessage } from "@/pipeline-view/pipeline-viewport/components/ViewportCenterMessage";
+import { EmptyState } from "@/components/common/EmptyState";
 import AddOutlined from "@mui/icons-material/AddOutlined";
 import Button from "@mui/material/Button";
 import Stack, { StackProps } from "@mui/material/Stack";
@@ -17,7 +17,7 @@ export const NoEnvironment = (props: StackProps) => {
 
   return (
     <Stack justifyContent="center" alignItems="center" sx={{ height: "100%" }}>
-      <ViewportCenterMessage
+      <EmptyState
         imgSrc="/image/no-environment.svg"
         title="No Environments"
         description={`Environments define the conditions in which Pipeline steps execute scripts and kernels.`}

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/NoEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/NoEnvironment.tsx
@@ -1,8 +1,20 @@
 import { ViewportCenterMessage } from "@/pipeline-view/pipeline-viewport/components/ViewportCenterMessage";
+import AddOutlined from "@mui/icons-material/AddOutlined";
+import Button from "@mui/material/Button";
 import Stack, { StackProps } from "@mui/material/Stack";
 import React from "react";
+import { useCreateEnvironment } from "../hooks/useCreateEnvironment";
+import { useSelectEnvironment } from "../hooks/useSelectEnvironment";
 
 export const NoEnvironment = (props: StackProps) => {
+  const { createEnvironment, canCreateEnvironment } = useCreateEnvironment();
+  const selectEnvironment = useSelectEnvironment();
+
+  const create = () =>
+    createEnvironment().then(
+      (environment) => environment && selectEnvironment(environment.uuid)
+    );
+
   return (
     <Stack justifyContent="center" alignItems="center" sx={{ height: "100%" }}>
       <ViewportCenterMessage
@@ -10,6 +22,16 @@ export const NoEnvironment = (props: StackProps) => {
         title="No Environments"
         description={`Environments define the conditions in which Pipeline steps execute scripts and kernels.`}
         docPath="/fundamentals/environments.html"
+        actions={
+          <Button
+            variant="contained"
+            onClick={create}
+            disabled={!canCreateEnvironment}
+            startIcon={<AddOutlined />}
+          >
+            New environment
+          </Button>
+        }
         {...props}
       />
     </Stack>

--- a/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
@@ -18,7 +18,7 @@ export const useCreateEnvironment = () => {
     defaultEnvironment?.name || "New environment",
     environments
   );
-  const isAllowedToCreate =
+  const canCreateEnvironment =
     hasValue(newEnvironmentName) && hasValue(defaultEnvironment);
 
   const createEnvironment = React.useCallback(
@@ -32,18 +32,18 @@ export const useCreateEnvironment = () => {
         base_image: baseImage,
         language: language || defaultEnvironment?.language,
       } as EnvironmentSpec;
-      if (status !== "PENDING" && isAllowedToCreate) {
+      if (status !== "PENDING" && canCreateEnvironment) {
         return run(
           post(customEnvironmentName ?? newEnvironmentName, environmentSpec)
         );
       }
     },
     [
-      post,
-      run,
-      status,
       defaultEnvironment,
-      isAllowedToCreate,
+      status,
+      canCreateEnvironment,
+      run,
+      post,
       newEnvironmentName,
     ]
   );
@@ -51,6 +51,6 @@ export const useCreateEnvironment = () => {
   return {
     createEnvironment,
     isCreating: status === "PENDING",
-    isAllowedToCreate,
+    canCreateEnvironment,
   };
 };

--- a/services/orchest-webserver/client/src/environments-view/hooks/useSelectEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useSelectEnvironment.tsx
@@ -19,5 +19,5 @@ export const useSelectEnvironment = () => {
     [navigateTo, projectUuid]
   );
 
-  return { selectEnvironment };
+  return selectEnvironment;
 };

--- a/services/orchest-webserver/client/src/jobs-view/CreateJobButton.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/CreateJobButton.tsx
@@ -2,7 +2,6 @@ import {
   CreateEntityButton,
   CreateEntityButtonProps,
 } from "@/blocks/CreateEntityButton";
-import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import React from "react";
 import { pickJobChanges } from "./common";
@@ -16,27 +15,12 @@ type CreateJobButtonProps = Omit<
   onCreated: (uuids: string) => void;
 };
 
-// TODO: replace this with usePipelinesApi using zustand.
-const useGetValidPipeline = () => {
-  const {
-    state: { pipelines = [], pipeline },
-  } = useProjectsContext();
-
-  const validPipeline = React.useMemo(() => {
-    return pipeline || pipelines[0];
-  }, [pipelines, pipeline]);
-
-  return validPipeline;
-};
-
 export const CreateJobButton = ({
   onCreated,
   ...props
 }: CreateJobButtonProps) => {
   const { projectUuid } = useCustomRoute();
-
-  const pipeline = useGetValidPipeline();
-  const { createJob, isAllowedToCreateJob } = useCreateJob(pipeline);
+  const { createJob, canCreateJob, pipeline } = useCreateJob();
 
   const { withConfirmation } = useUnsavedChangesWarning();
 
@@ -52,7 +36,7 @@ export const CreateJobButton = ({
   return (
     <CreateEntityButton
       onClick={() => withConfirmation(onCreate)}
-      disabled={!isAllowedToCreateJob}
+      disabled={!canCreateJob}
       {...props}
     >
       New job

--- a/services/orchest-webserver/client/src/jobs-view/job-view/NoJob.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/NoJob.tsx
@@ -1,4 +1,4 @@
-import { ViewportCenterMessage } from "@/pipeline-view/pipeline-viewport/components/ViewportCenterMessage";
+import { EmptyState } from "@/components/common/EmptyState";
 import AddOutlined from "@mui/icons-material/AddOutlined";
 import Button from "@mui/material/Button";
 import Stack, { StackProps } from "@mui/material/Stack";
@@ -10,7 +10,7 @@ export const NoJob = (props: StackProps) => {
 
   return (
     <Stack justifyContent="center" alignItems="center" sx={{ height: "100%" }}>
-      <ViewportCenterMessage
+      <EmptyState
         imgSrc="/image/no-job.svg"
         title="No Jobs"
         description={`Jobs are a way to schedule one-off or recurring Pipelines runs. Jobs can run multiple iterations of the same Pipeline; taking different parameters as inputs.`}

--- a/services/orchest-webserver/client/src/jobs-view/job-view/NoJob.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/NoJob.tsx
@@ -1,8 +1,13 @@
 import { ViewportCenterMessage } from "@/pipeline-view/pipeline-viewport/components/ViewportCenterMessage";
+import AddOutlined from "@mui/icons-material/AddOutlined";
+import Button from "@mui/material/Button";
 import Stack, { StackProps } from "@mui/material/Stack";
 import React from "react";
+import { useCreateJob } from "../hooks/useCreateJob";
 
 export const NoJob = (props: StackProps) => {
+  const { createJob, canCreateJob } = useCreateJob();
+
   return (
     <Stack justifyContent="center" alignItems="center" sx={{ height: "100%" }}>
       <ViewportCenterMessage
@@ -10,6 +15,16 @@ export const NoJob = (props: StackProps) => {
         title="No Jobs"
         description={`Jobs are a way to schedule one-off or recurring Pipelines runs. Jobs can run multiple iterations of the same Pipeline; taking different parameters as inputs.`}
         docPath="/fundamentals/jobs.html"
+        actions={
+          <Button
+            variant="contained"
+            disabled={!canCreateJob}
+            onClick={createJob}
+            startIcon={<AddOutlined />}
+          >
+            New Job
+          </Button>
+        }
         {...props}
       />
     </Stack>

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/usePipelineActions.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/primary-action/usePipelineActions.tsx
@@ -65,10 +65,10 @@ export const usePipelineActions = () => {
     doRunSteps(selectedSteps, "incoming");
   }, [doRunSteps, selectedSteps]);
 
-  const { createJob, isAllowedToCreateJob } = useCreateJob(pipeline);
+  const { createJob, canCreateJob } = useCreateJob(pipeline);
 
   const createDraftJob = React.useCallback(async () => {
-    if (!isAllowedToCreateJob) return;
+    if (!canCreateJob) return;
     const jobData = await createJob();
     const jobChanges = pickJobChanges(jobData);
     if (jobChanges) {
@@ -77,13 +77,7 @@ export const usePipelineActions = () => {
     }
     if (jobChanges)
       uiStateDispatch({ type: "SET_DRAFT_JOB", payload: jobChanges.uuid });
-  }, [
-    createJob,
-    uiStateDispatch,
-    isAllowedToCreateJob,
-    initJobChanges,
-    startEditing,
-  ]);
+  }, [canCreateJob, createJob, uiStateDispatch, initJobChanges, startEditing]);
 
   // No operation is allowed when read-only.
   if (isReadOnly) return {};

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/NoPipeline.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/NoPipeline.tsx
@@ -1,12 +1,12 @@
+import { EmptyState } from "@/components/common/EmptyState";
 import AddOutlined from "@mui/icons-material/AddOutlined";
 import Button from "@mui/material/Button";
 import React from "react";
 import { CreatePipelineDialog } from "../CreatePipelineDialog";
-import { ViewportCenterMessage } from "./components/ViewportCenterMessage";
 
 export const NoPipeline = () => {
   return (
-    <ViewportCenterMessage
+    <EmptyState
       imgSrc="/image/no-pipeline.svg"
       title="No Pipelines in Project"
       description="Pipelines are an interactive tool for creating and experimenting with
@@ -15,15 +15,13 @@ export const NoPipeline = () => {
       actions={
         <CreatePipelineDialog>
           {(createPipeline) => (
-            <>
-              <Button
-                startIcon={<AddOutlined />}
-                variant="contained"
-                onClick={createPipeline}
-              >
-                New pipeline
-              </Button>
-            </>
+            <Button
+              startIcon={<AddOutlined />}
+              variant="contained"
+              onClick={createPipeline}
+            >
+              New pipeline
+            </Button>
           )}
         </CreatePipelineDialog>
       }

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/NoStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/NoStep.tsx
@@ -1,3 +1,4 @@
+import { EmptyState } from "@/components/common/EmptyState";
 import { UploadFilesForm } from "@/components/UploadFilesForm";
 import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useUploader } from "@/hooks/useUploader";
@@ -9,7 +10,6 @@ import { lastSelectedFolderPath } from "../file-manager/common";
 import { CreateFileDialog } from "../file-manager/CreateFileDialog";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useCreateStep } from "../hooks/useCreateStep";
-import { ViewportCenterMessage } from "./components/ViewportCenterMessage";
 
 export const NoStep = () => {
   const { selectedFiles, fetchFileTrees } = useFileManagerContext();
@@ -30,7 +30,7 @@ export const NoStep = () => {
 
   return (
     <>
-      <ViewportCenterMessage
+      <EmptyState
         imgSrc="/image/files.svg"
         title="No scripts or notebooks"
         description={`There are no files in this Project yet. Create or upload a file to get started.`}

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepCreateEnvironmentButton.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepCreateEnvironmentButton.tsx
@@ -20,7 +20,7 @@ export const StepCreateEnvironmentButton = ({
 }: StepCreateEnvironmentButtonProps) => {
   const { navigateTo, projectUuid } = useCustomRoute();
   const { setAlert } = useGlobalContext();
-  const { createEnvironment, isAllowedToCreate } = useCreateEnvironment();
+  const { createEnvironment, canCreateEnvironment } = useCreateEnvironment();
   const createEnvironmentAndRedirect = async () => {
     try {
       const environment = await createEnvironment(
@@ -41,7 +41,7 @@ export const StepCreateEnvironmentButton = ({
     <FormControl fullWidth>
       <Button
         startIcon={<AddIcon />}
-        disabled={!isAllowedToCreate}
+        disabled={!canCreateEnvironment}
         sx={{ height: (theme) => theme.spacing(7) }}
         onClick={createEnvironmentAndRedirect}
       >

--- a/services/orchest-webserver/client/src/projects-view/NoProject.tsx
+++ b/services/orchest-webserver/client/src/projects-view/NoProject.tsx
@@ -1,4 +1,4 @@
-import { ViewportCenterMessage } from "@/pipeline-view/pipeline-viewport/components/ViewportCenterMessage";
+import { EmptyState } from "@/components/common/EmptyState";
 import { AddOutlined, DownloadOutlined } from "@mui/icons-material";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
@@ -16,7 +16,7 @@ export const NoProject = ({ importProject, createProject }: NoProjectProps) => {
       alignItems="center"
       sx={{ marginTop: (theme) => theme.spacing(6) }}
     >
-      <ViewportCenterMessage
+      <EmptyState
         imgSrc="/image/no-project.svg"
         title="No Projects"
         description="Projects are the main container for organizing related Pipelines, Jobs, Environments and code."


### PR DESCRIPTION
## Description

This PR adds empty state actions to the Jobs & environments view, and moves the common empty state components to `@/components/common/EmptyState.tsx`.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.