### PR TITLE
Update file tree when pipeline is deleted

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/PipelineMoreOptionsMenu.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-canvas-header-bar/PipelineMoreOptionsMenu.tsx
@@ -12,6 +12,7 @@ import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 import { usePipelineCanvasContext } from "../contexts/PipelineCanvasContext";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
+import { useFileManagerContext } from "../file-manager/FileManagerContext";
 
 const deletePipeline = (projectUuid: string, pipelineUuid: string) => {
   return fetcher(`/async/pipelines/${projectUuid}/${pipelineUuid}`, {
@@ -20,6 +21,7 @@ const deletePipeline = (projectUuid: string, pipelineUuid: string) => {
 };
 
 export const PipelineMoreOptionsMenu = () => {
+  const { fetchFileTrees } = useFileManagerContext();
   const { setConfirm } = useGlobalContext();
   const { isReadOnly } = usePipelineDataContext();
   const {
@@ -52,6 +54,7 @@ export const PipelineMoreOptionsMenu = () => {
               ),
             };
           });
+          fetchFileTrees();
           resolve(true);
           return true;
         },


### PR DESCRIPTION
## Description

I wasn't able to reproduce this issue before, because I didn't know that you could delete a pipeline from this location.
This PR ensures that the file tree is updated when the pipeline is deleted from the "more actions" context menu.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.