### PR TITLE
fix: App crashed when creating an environment from PipelineEditor

### DIFF
--- a/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
@@ -25,6 +25,7 @@ export const useCreateEnvironment = () => {
     async (language?: Language, customEnvironmentName?: string) => {
       const baseImage = language
         ? DEFAULT_BASE_IMAGES.find((image) => image.language === language)
+            ?.base_image
         : defaultEnvironment?.base_image;
       const environmentSpec = {
         ...defaultEnvironment,


### PR DESCRIPTION
## Description

In the new UI, user could click "New environment" if there is no image with the matching language. However, currently, clicking on this button will crash the app.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.