### PR TITLE
Fix/disable "Pause Job" and "Trigger a new Run now" for one-off jobs

### DIFF
--- a/services/orchest-webserver/client/src/api/jobs/jobsApi.ts
+++ b/services/orchest-webserver/client/src/api/jobs/jobsApi.ts
@@ -52,6 +52,7 @@ const post = (
         uuids: [],
       },
       parameters: [],
+      max_retained_pipeline_runs: 250,
     }),
   });
 

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
@@ -34,18 +34,22 @@ export const useJobActionMenu = () => {
               action: startEditingActiveCronJob,
             }
           : undefined,
-        {
-          label: hasPaused ? "Resume job" : "Pause job",
-          icon: hasPaused ? "resume" : "pause",
-          disabled: !isCronJob || !isRunning,
-          action: hasPaused ? resumeJob : pauseJob,
-        },
-        {
-          label: "Trigger job now",
-          icon: "run",
-          disabled: !isAllowedToTriggerScheduledRuns,
-          action: triggerJobNow,
-        },
+        isCronJob
+          ? {
+              label: hasPaused ? "Resume job" : "Pause job",
+              icon: hasPaused ? "resume" : "pause",
+              disabled: !isCronJob || !isRunning,
+              action: hasPaused ? resumeJob : pauseJob,
+            }
+          : undefined,
+        isCronJob
+          ? {
+              label: "Trigger job now",
+              icon: "run",
+              disabled: !isAllowedToTriggerScheduledRuns,
+              action: triggerJobNow,
+            }
+          : undefined,
         {
           label: "Copy job configuration",
           icon: "duplicate",

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
@@ -38,7 +38,7 @@ export const useJobActionMenu = () => {
           ? {
               label: hasPaused ? "Resume job" : "Pause job",
               icon: hasPaused ? "resume" : "pause",
-              disabled: !isCronJob || !isRunning,
+              disabled: !isRunning,
               action: hasPaused ? resumeJob : pauseJob,
             }
           : undefined,

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActionMenu.tsx
@@ -9,18 +9,12 @@ import { useJobActions } from "./useJobActions";
 export const useJobActionMenu = () => {
   const status = useEditJob((state) => state.jobChanges?.status);
   const schedule = useEditJob((state) => state.jobChanges?.schedule);
-  const nextScheduledTime = useEditJob(
-    (state) => state.jobChanges?.next_scheduled_time
-  );
   const { resumeJob, pauseJob, duplicateJob, triggerJobNow } = useJobActions();
 
   const isCronJob = hasValue(schedule);
-  const isOneOffJob = !schedule && hasValue(nextScheduledTime);
-  const isScheduledJob = isCronJob || isOneOffJob;
 
   const isAllowedToTriggerScheduledRuns =
-    (isCronJob && ["PAUSED", "STARTED"].includes(status || "")) ||
-    (isOneOffJob && status === "PENDING");
+    isCronJob && ["PAUSED", "STARTED"].includes(status || "");
 
   const isRunning = ["PAUSED", "STARTED", "PENDING"].includes(status || "");
   const hasPaused = status === "PAUSED";
@@ -43,7 +37,7 @@ export const useJobActionMenu = () => {
         {
           label: hasPaused ? "Resume job" : "Pause job",
           icon: hasPaused ? "resume" : "pause",
-          disabled: !isScheduledJob || !isRunning,
+          disabled: !isCronJob || !isRunning,
           action: hasPaused ? resumeJob : pauseJob,
         },
         {
@@ -67,7 +61,7 @@ export const useJobActionMenu = () => {
       duplicateJob,
       hasPaused,
       isRunning,
-      isScheduledJob,
+      isCronJob,
       pauseJob,
       resumeJob,
       triggerJobNow,


### PR DESCRIPTION
## Description

Hide "Pause Job" and "Trigger a new Run now" options for a recurring job, as they are recurring-jobs-only features. This PR also set default `max_retained_pipeline_runs` to 250.


- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
