### PR TITLE
Fix: You get navigated back into JupyterLab on load

### DIFF
--- a/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
+++ b/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
@@ -246,7 +246,7 @@ class Jupyter {
   }
 
   hasRenderingProblem() {
-    const shellNode = this.iframe?.contentWindow?._orchest_app.shell.node;
+    const shellNode = this.getApp()?.shell?.node;
     const contentPanel = shellNode?.querySelector("#jp-main-content-panel");
 
     if (!contentPanel) return true;

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -120,7 +120,7 @@ const JupyterLabView = () => {
     if (session?.status === "RUNNING") {
       if (!window.orchest.jupyter?.isShowing()) {
         window.orchest.jupyter?.show();
-        if (filePath) window.orchest.jupyter?.navigateTo(filePath);
+        if (filePath) window.orchest.jupyter?.openFile(filePath);
       }
     } else {
       window.orchest.jupyter?.hide();
@@ -160,7 +160,7 @@ const JupyterLabView = () => {
 
   useInterval(
     () => {
-      if (window.orchest.jupyter?.isRendered() && pipelineJson) {
+      if (window.orchest.jupyter?.hasRendered() && pipelineJson) {
         for (let stepUUID in pipelineJson.steps) {
           let step = pipelineJson.steps[stepUUID];
 
@@ -187,7 +187,7 @@ const JupyterLabView = () => {
       <ProjectBasedView
         sx={{ padding: (theme) => theme.spacing(4), height: "100%" }}
       >
-        {!window.orchest.jupyter?.isLoaded() && (
+        {!window.orchest.jupyter?.hasLoaded() && (
           <Stack
             justifyContent="center"
             alignItems="center"

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -94,13 +94,9 @@ const JupyterLabView = () => {
       startSession(pipelineUuid, BUILD_IMAGE_SOLUTION_VIEW.JUPYTER_LAB)
         .then((result) => {
           if (result === true) {
-            // Force reloading the view.
             dispatch({
               type: "SET_PIPELINE_READONLY_REASON",
               payload: undefined,
-            });
-            navigateTo(siteMap.jupyterLab.path, {
-              query: { projectUuid, pipelineUuid },
             });
           } else if (
             ![

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -160,7 +160,7 @@ const JupyterLabView = () => {
 
   useInterval(
     () => {
-      if (window.orchest.jupyter?.isJupyterLoaded() && pipelineJson) {
+      if (window.orchest.jupyter?.isRendered() && pipelineJson) {
         for (let stepUUID in pipelineJson.steps) {
           let step = pipelineJson.steps[stepUUID];
 
@@ -187,24 +187,26 @@ const JupyterLabView = () => {
       <ProjectBasedView
         sx={{ padding: (theme) => theme.spacing(4), height: "100%" }}
       >
-        <Stack
-          justifyContent="center"
-          alignItems="center"
-          sx={{ height: "100%" }}
-        >
-          <Box
-            sx={{
-              textAlign: "center",
-              width: "100%",
-              maxWidth: "400px",
-            }}
+        {!window.orchest.jupyter?.isLoaded() && (
+          <Stack
+            justifyContent="center"
+            alignItems="center"
+            sx={{ height: "100%" }}
           >
-            <Typography component="h2" variant="h6" sx={{ marginBottom: 3 }}>
-              Setting up JupyterLab…
-            </Typography>
-            <LinearProgress />
-          </Box>
-        </Stack>
+            <Box
+              sx={{
+                textAlign: "center",
+                width: "100%",
+                maxWidth: "400px",
+              }}
+            >
+              <Typography component="h2" variant="h6" sx={{ marginBottom: 3 }}>
+                Setting up JupyterLab…
+              </Typography>
+              <LinearProgress />
+            </Box>
+          </Stack>
+        )}
       </ProjectBasedView>
       <BuildPendingDialog
         onCancel={() => {


### PR DESCRIPTION
This PR fixes:
- The user gets "sucked back" into the JupyterLab view if the reload the page but quickly navigate away from it.
- "Setting up JupyterLab" flashes for a brief second if opening a file when JupyterLab has already been loaded

Additionally:
- Break out common functionality (like getting `_orchest_app`,  `_orchest_docmanager` and widgets) into shared functions
- Removes some unecessary `try`/`catch` blocks and instead doing using `?.` for dot-operations which they protected against.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

## Tested:

Before JupyterLab has been initialized (first page load):
- [x] Opening JupyterLab by double-clicking steps, the right tab opens.
- [x] Opening JupyterLab by double-clicking files in the file manager, the right tab opens.
- [x] Opening the JupyterLab from the menu resumes the last viewed tab.
- [x] Refreshing the page in the JupyterLab view resumes the last viewed tab.

After JupyterLab has been initialized:
- [x] Opening JupyterLab by double-clicking steps, the right tab opens.
- [x] Opening JupyterLab by double-clicking files in the file manager, the right tab opens.
- [x] Opening the JupyterLab from the menu resumes the last viewed tab