### PR TITLE
Fix k3s support

### DIFF
--- a/docs/source/_static/js/installer_widget.js
+++ b/docs/source/_static/js/installer_widget.js
@@ -70,7 +70,8 @@ class="pre">orchest-cli</span></code>:</p>
 <div class="highlight">
 <pre>
 pip install --upgrade orchest-cli
-orchest install
+# Omit the socket path if you pointed k3s to use the system containerd.
+orchest install --socket-path=/run/k3s/containerd/containerd.sock
 </pre>
 </div>
 <p>Now that Orchest is installed, it can be reached on the IP address returned by:</p>

--- a/services/orchest-controller/pkg/controller/orchestcomponent/buildkit_daemon.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/buildkit_daemon.go
@@ -72,6 +72,9 @@ func getBuildKitDaemonDaemonset(metadata metav1.ObjectMeta,
 	if strings.Contains(socketPath, "microk8s") {
 		runContainerdPath = "/var/snap/microk8s/common/run/containerd"
 		varLibContainerdPath = "/var/snap/microk8s/common/var/lib/containerd"
+	} else if strings.Contains(socketPath, "k3s") {
+		runContainerdPath = "/var/run/k3s/containerd"
+		varLibContainerdPath = "/var/lib/rancher/k3s/agent/containerd"
 	}
 
 	volumes := []corev1.Volume{
@@ -149,7 +152,7 @@ func getBuildKitDaemonDaemonset(metadata metav1.ObjectMeta,
 		},
 	}
 
-	if strings.Contains(socketPath, "microk8s") {
+	if strings.Contains(socketPath, "microk8s") || strings.Contains(socketPath, "k3s") {
 		volumes = append(volumes, corev1.Volume{
 			Name: "run-containerd-fifo",
 			VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
## Description

Required fix for Orchest `k3s` installations due to `k3s` using a dedicated `containerd` socket and storage by default.

## Checklist

- [X] I have manually tested my changes and I am happy with the result.
