### PR TITLE
Don't autostart sessions for job runs

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineDataContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineDataContext.tsx
@@ -24,8 +24,12 @@ export type PipelineDataContextType = {
   pipelineJson?: PipelineJson;
   setPipelineJson: StateDispatcher<PipelineJson>;
   isFetchingPipelineJson: boolean;
+  /** Whether this is a pipeline from a job run. */
   isJobRun: boolean;
+  /** Whether this is a snapshot of a pipeline run. */
   isSnapshot: boolean;
+  /** Whether this is an interactive pipeline: not a job run nor snapshot. */
+  isInteractive: boolean;
   pipeline?: PipelineMetaData;
   job?: JobData;
 };
@@ -112,6 +116,8 @@ export const PipelineDataContextProvider: React.FC = ({ children }) => {
 
   const isJobRun = hasValue(jobUuid) && hasValue(runUuidFromRoute);
   const isSnapshot = hasValue(jobUuid) && hasValue(snapshotUuid);
+  const isInteractive = !isJobRun && !isSnapshot;
+
   const { job } = useFetchJob({
     jobUuid: isJobRun || isSnapshot ? jobUuid : undefined,
   });
@@ -128,6 +134,7 @@ export const PipelineDataContextProvider: React.FC = ({ children }) => {
         runUuid,
         setRunUuid,
         isReadOnly,
+        isInteractive,
         pipelineJson,
         setPipelineJson,
         isFetchingPipelineJson,

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineDataContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/PipelineDataContext.tsx
@@ -24,11 +24,11 @@ export type PipelineDataContextType = {
   pipelineJson?: PipelineJson;
   setPipelineJson: StateDispatcher<PipelineJson>;
   isFetchingPipelineJson: boolean;
-  /** Whether this is a pipeline from a job run. */
+  /** If true, this pipeline is from a job run. */
   isJobRun: boolean;
-  /** Whether this is a snapshot of a pipeline run. */
+  /** If true, this pipeline is a snapshot for a job. */
   isSnapshot: boolean;
-  /** Whether this is an interactive pipeline: not a job run nor snapshot. */
+  /** If true, this pipeline is interactive: it is not a job snapshot or from a job run. */
   isInteractive: boolean;
   pipeline?: PipelineMetaData;
   job?: JobData;

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -21,7 +21,7 @@ export const useAutoStartSession = () => {
     dispatch,
   } = useProjectsContext();
   const { setAlert, setConfirm } = useGlobalContext();
-  const { isJobRun } = usePipelineDataContext();
+  const { isInteractive } = usePipelineDataContext();
   const { pipelineUuid: pipelineUuidFromRoute, navigateTo } = useCustomRoute();
 
   const session = React.useMemo(() => getSession(pipeline?.uuid), [
@@ -30,7 +30,7 @@ export const useAutoStartSession = () => {
   ]);
 
   const shouldCheckIfAutoStartIsNeeded =
-    !isJobRun && // This is not a job run
+    isInteractive && // This is an interactive pipeline
     hasValue(sessions) && // `sessions` is available to look up
     hasValue(pipeline?.uuid) && // `pipeline` is loaded.
     pipelineUuidFromRoute === pipeline?.uuid && // Only auto-start the pipeline that user is viewing.

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -8,6 +8,7 @@ import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { siteMap } from "@/routingConfig";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
+import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 
 export const useAutoStartSession = () => {
   const {
@@ -20,6 +21,7 @@ export const useAutoStartSession = () => {
     dispatch,
   } = useProjectsContext();
   const { setAlert, setConfirm } = useGlobalContext();
+  const { isJobRun } = usePipelineDataContext();
   const { pipelineUuid: pipelineUuidFromRoute, navigateTo } = useCustomRoute();
 
   const session = React.useMemo(() => getSession(pipeline?.uuid), [
@@ -28,6 +30,7 @@ export const useAutoStartSession = () => {
   ]);
 
   const shouldCheckIfAutoStartIsNeeded =
+    !isJobRun && // This is not a job run
     hasValue(sessions) && // `sessions` is available to look up
     hasValue(pipeline?.uuid) && // `pipeline` is loaded.
     pipelineUuidFromRoute === pipeline?.uuid && // Only auto-start the pipeline that user is viewing.


### PR DESCRIPTION
## Description

@fruttasecca noticed that sometimes interactive sessions may get autostarted for job runs. This is not intended.

This PR changes so that sessions are never autostarted for job runs.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.(https://github.com/orchest/orchest/blob/master/orchest
