### PR TITLE
fix: Ensure websocket connections are closed correctly.

### DIFF
--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -46,13 +46,10 @@ export const ImageBuildLog = ({
       // ignore terminal outputs from other builds
       if (data.identity === streamIdentity) {
         if (data.action === "sio_streamed_task_output") {
-          let lines = (data.output || "").split("\n");
+          const lines = (data.output || "").split("\n");
           for (let x = 0; x < lines.length; x++) {
-            if (x === lines.length - 1) {
-              xtermRef.current?.terminal.write(lines[x]);
-            } else {
-              xtermRef.current?.terminal.write(lines[x] + "\n\r");
-            }
+            if (x > 0) xtermRef.current?.terminal.write("\n\r");
+            xtermRef.current?.terminal.write(lines[x]);
           }
         } else if (data["action"] == "sio_streamed_task_started") {
           // This blocking mechanism makes sure old build logs are

--- a/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
@@ -122,11 +122,8 @@ export const LegacyImageBuildLog = ({
             ) {
               let lines = (data.output || "").split("\n");
               for (let x = 0; x < lines.length; x++) {
-                if (x == lines.length - 1) {
-                  xtermRef.current?.terminal.write(lines[x]);
-                } else {
-                  xtermRef.current?.terminal.write(lines[x] + "\n\r");
-                }
+                if (x > 0) xtermRef.current?.terminal.write("\n\r");
+                xtermRef.current?.terminal.write(lines[x]);
               }
             } else if (data["action"] == "sio_streamed_task_started") {
               // This blocking mechanism makes sure old build logs are

--- a/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
@@ -110,7 +110,7 @@ export const LegacyImageBuildLog = ({
   React.useEffect(() => {
     if (!hasRegisteredSocketIO.current) {
       hasRegisteredSocketIO.current = true;
-      socket.on(
+      socket?.on(
         "sio_streamed_task_data",
         (data: { action: string; identity: string; output?: string }) => {
           // ignore terminal outputs from other builds

--- a/services/orchest-webserver/client/src/pipeline-view/LogViewer.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/LogViewer.tsx
@@ -64,8 +64,8 @@ export const LogViewer = ({
   );
 
   const initializeSocketIOListener = React.useCallback(() => {
-    socket.on("pty-output", onPtyOutputHandler);
-    socket.on("pty-reset", onPtyReset);
+    socket?.on("pty-output", onPtyOutputHandler);
+    socket?.on("pty-reset", onPtyReset);
 
     setHeartbeatInterval(HEARTBEAT_INTERVAL);
   }, [onPtyOutputHandler, onPtyReset, socket]);
@@ -105,7 +105,7 @@ export const LogViewer = ({
       data["job_uuid"] = jobUuid;
     }
 
-    socket.emit("pty-log-manager", data);
+    socket?.emit("pty-log-manager", data);
   }, [
     jobUuid,
     logId,
@@ -119,7 +119,7 @@ export const LogViewer = ({
 
   useInterval(() => {
     if (sessionUuid) {
-      socket.emit("pty-log-manager", {
+      socket?.emit("pty-log-manager", {
         action: "heartbeat",
         session_uuid: sessionUuid,
       });
@@ -138,13 +138,13 @@ export const LogViewer = ({
 
     return () => {
       // stop logging
-      socket.emit("pty-log-manager", {
+      socket?.emit("pty-log-manager", {
         action: "stop-logs",
         session_uuid: sessionUuid,
       });
 
-      socket.off("pty-output", onPtyOutputHandler);
-      socket.off("pty-reset", onPtyReset);
+      socket?.off("pty-output", onPtyOutputHandler);
+      socket?.off("pty-reset", onPtyReset);
 
       window.removeEventListener("resize", fitTerminal);
     };

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
@@ -15,10 +15,12 @@ const useSocketIOStore = create<SocketIO>((set) => ({
     set((state) => {
       const currentSocket = state.sockets[namespace];
       if (currentSocket) return {};
+      // Socket, by default, will attempt to connect automatically upon creation.
+      // Therefore, no need to call `socket.connect(...)` manually.
       const socket = io(namespace, {
         transports: ["websocket"],
         upgrade: false,
-        reconnection: false,
+        reconnection: false, // Prevent automatically attempting to reconnect when being disconnected.
         closeOnBeforeunload: true,
       });
       return { sockets: { ...state.sockets, [namespace]: socket } };

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
@@ -1,17 +1,53 @@
 import React from "react";
-import io from "socket.io-client";
+import { io, Socket } from "socket.io-client";
+import create from "zustand";
 
-export const useSocketIO = (namespace: string) => {
-  const socket = React.useMemo(
-    () => io(namespace, { transports: ["websocket"] }),
-    [namespace]
+type SocketIO = {
+  sockets: Record<string, Socket>;
+  init: (namespace: string | undefined) => void;
+  disconnect: (namespace: string | undefined) => void;
+};
+
+const useSocketIOStore = create<SocketIO>((set) => ({
+  sockets: {},
+  init: (namespace) => {
+    if (!namespace) return;
+    set((state) => {
+      const currentSocket = state.sockets[namespace];
+      if (currentSocket) return {};
+      const socket = io(namespace, {
+        transports: ["websocket"],
+        upgrade: false,
+        reconnection: false,
+        closeOnBeforeunload: true,
+      });
+      return { sockets: { ...state.sockets, [namespace]: socket } };
+    });
+  },
+  disconnect: (namespace) => {
+    if (!namespace) return;
+    set((state) => {
+      const { [namespace]: socket, ...sockets } = state.sockets;
+      if (socket) {
+        socket.removeAllListeners();
+        socket.disconnect();
+      }
+      return { sockets };
+    });
+  },
+}));
+
+export const useSocketIO = (namespace: string | undefined) => {
+  const init = useSocketIOStore((state) => state.init);
+  const disconnect = useSocketIOStore((state) => state.disconnect);
+  const socket = useSocketIOStore((state) =>
+    namespace ? state.sockets[namespace] : undefined
   );
 
   React.useEffect(() => {
-    return () => {
-      socket.disconnect();
-    };
-  }, [socket]);
+    init(namespace);
+    return () => disconnect(namespace);
+  }, [init, namespace, disconnect]);
 
   return socket;
 };


### PR DESCRIPTION
## Description

This PR adds `@socketio.on("disconnect", ...)` event handlers to `orchest-webserver` backend, and also creates a zustand store for socketio's to manage connections globally.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
