### PR TITLE
Fix - k8s for docker for desktop support

### DIFF
--- a/services/node-agent/Dockerfile
+++ b/services/node-agent/Dockerfile
@@ -8,12 +8,20 @@ WORKDIR /tmp/download
 ARG CONTAINERD_VERSION="1.6.4"
 ENV CONTAINERD_DOWNLOAD_URL="https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION-linux-amd64.tar.gz"
 
-# install containerd
+# Install Buildah. This is needed to pull and push images without ssl
+# verification for container runtimes which don't allow interacting with
+# insecure registries by default and for which the ssl certificates
+# injection did not fix the issue, like in kubernetes for docker for
+# desktop.
+RUN apt-get update && apt-get install -y buildah && buildah version && \
+    apt-get clean
+
+# Install containerd.
 RUN curl -L $CONTAINERD_DOWNLOAD_URL --output containerd-$CONTAINERD_VERSION-linux-amd64.tar.gz \
     && tar zxvf containerd-$CONTAINERD_VERSION-linux-amd64.tar.gz -C /tmp/download \
     && mv /tmp/download/bin/ctr /usr/local/bin
 
-# install crictl
+# Install crictl.
 ARG CRICTL_VERSION="v1.24.1"
 ENV CRICTL_DOWNLOAD_URL=https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
 RUN curl -L $CRICTL_DOWNLOAD_URL --output crictl-$CRICTL_VERSION-linux-amd64.tar.gz \

--- a/services/node-agent/app/image_puller.py
+++ b/services/node-agent/app/image_puller.py
@@ -153,7 +153,8 @@ class ImagePuller(object):
         """Fetches the image names by calling following endpoints
         of the orchest-api.
             1. /ctl/orchest-images-to-pre-pull
-            2. /environment-images/active
+            2. /ctl/active-custom-jupyter-images
+            3. /environment-images/active
         Args:
             queue: The queue to put the image names to, the queue will
             be consumed by puller tasks.


### PR DESCRIPTION
## Description

Makes it so that the `node-agent` will be able to push and pull images when the container runtime is docker and the runtime refuses to interact with the internally deployed registry, which currently happens only in k8s for docker for desktop.
