### PR TITLE
fix: Hide job status alert when isEditing is true

### DIFF
--- a/services/orchest-webserver/client/src/jobs-view/job-view/JobStatusAlert.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/JobStatusAlert.tsx
@@ -30,10 +30,11 @@ const alertMessageMapping: Record<
 };
 
 export const JobStatusAlert = () => {
+  const isEditing = useEditJob((state) => state.isEditing);
   const jobStatus = useEditJob((state) => state.jobChanges?.status);
   const { resumeJob } = useJobActions();
 
-  const alert = alertMessageMapping[jobStatus || ""];
+  const alert = isEditing ? undefined : alertMessageMapping[jobStatus || ""];
   return (
     <Collapse in={Boolean(alert)}>
       {hasValue(alert) && (


### PR DESCRIPTION
## Description

Job status banner should be hidden when user is editing the job. User shouldn't be allowed to perform other operations while editing a recurring job.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

