### PR TITLE
Expand the pipeline canvas

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -124,7 +124,7 @@ type PipelineStepProps = {
   savePositions: () => void;
   onDoubleClick: (stepUUID: string) => void;
   interactiveConnections: Connection[];
-  getPosition: (node: HTMLElement) => Point2D;
+  getElementPosition: (node: HTMLElement) => Point2D;
   children: React.ReactNode;
 };
 
@@ -141,7 +141,7 @@ const PipelineStepComponent = React.forwardRef<
     onDoubleClick,
     // the cursor-controlled step also renders all the interactive connections, to ensure the precision of the positions
     interactiveConnections,
-    getPosition,
+    getElementPosition,
     children, // expose children, so that children doesn't re-render when step is being dragged
   },
   ref
@@ -524,8 +524,8 @@ const PipelineStepComponent = React.forwardRef<
             boolean
           ];
 
-          const startPoint = getPosition(startNode);
-          const endPoint = endNode ? getPosition(endNode) : undefined;
+          const startPoint = getElementPosition(startNode);
+          const endPoint = endNode ? getElementPosition(endNode) : undefined;
 
           const key = `${startNodeUUID}-${endNodeUUID}-interactive`;
           const selected =
@@ -538,7 +538,7 @@ const PipelineStepComponent = React.forwardRef<
                 key={key}
                 startNodeUUID={startNodeUUID}
                 endNodeUUID={endNodeUUID}
-                getPosition={getPosition}
+                getPosition={getElementPosition}
                 selected={selected}
                 startPoint={startPoint}
                 endPoint={endPoint}

--- a/services/orchest-webserver/client/src/pipeline-view/contexts/CanvasScalingContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/contexts/CanvasScalingContext.tsx
@@ -1,15 +1,21 @@
 import { getOffset } from "@/utils/element";
-import { dividePoint, Point2D, subtractPoints } from "@/utils/geometry";
+import { Point2D } from "@/utils/geometry";
 import { clamp } from "@/utils/math";
 import { getMousePoint } from "@/utils/mouse";
 import React from "react";
+import { CANVAS_PADDING } from "../pipeline-viewport/common";
 import { usePipelineRefs } from "./PipelineRefsContext";
 
 export type CanvasScaling = {
   scaleFactor: number;
   setScaleFactor: React.Dispatch<React.SetStateAction<number>>;
-  /** Given a position within the browser window, returns the unscaled position on the canvas. */
-  windowToCanvasPoint: (windowPoint: Point2D) => Point2D;
+  /**
+   * Given a position within the browser window, returns the unscaled position on the canvas.
+   * By default this function will take the `CANVAS_PADDING` into account.
+   * @param windowPoint The position within the window.
+   * @param padding Overrides the default `CANVAS_PADDING`.
+   */
+  windowToCanvasPoint: (windowPoint: Point2D, padding?: number) => Point2D;
   /** Returns the point on the canvas where the pointer is currently located. */
   canvasPointAtPointer: () => Point2D;
 };
@@ -51,10 +57,16 @@ export const CanvasScalingProvider: React.FC = ({ children }) => {
   );
 
   const windowToCanvasPoint = React.useCallback(
-    (point: Readonly<Point2D>): Point2D => {
-      const canvasOffset = getOffset(pipelineCanvasRef.current);
+    (
+      [pointX, pointY]: Readonly<Point2D>,
+      padding = CANVAS_PADDING
+    ): Point2D => {
+      const [offsetX, offsetY] = getOffset(pipelineCanvasRef.current);
 
-      return dividePoint(subtractPoints(point, canvasOffset), scaleFactor);
+      return [
+        (pointX - offsetX) / scaleFactor - padding,
+        (pointY - offsetY) / scaleFactor - padding,
+      ];
     },
     [scaleFactor, pipelineCanvasRef]
   );

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
@@ -7,6 +7,7 @@ import { usePipelineCanvasContext } from "../contexts/PipelineCanvasContext";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 import { usePipelineRefs } from "../contexts/PipelineRefsContext";
 import { usePipelineUiStateContext } from "../contexts/PipelineUiStateContext";
+import { CANVAS_PADDING } from "../pipeline-viewport/common";
 import { STEP_HEIGHT, STEP_WIDTH } from "../PipelineStep";
 import { useSetShouldAutoFocusStepName } from "../step-details/store/useAutoFocusStepName";
 
@@ -49,8 +50,8 @@ export const useCreateStep = (): StepCreator => {
         const [offsetX, offsetY] = pipelineOffset;
 
         const position: Point2D = [
-          -offsetX + clientWidth / 2 - STEP_WIDTH / 2,
-          -offsetY + clientHeight / 2 - STEP_HEIGHT / 2,
+          -offsetX + clientWidth / 2 - STEP_WIDTH / 2 - CANVAS_PADDING,
+          -offsetY + clientHeight / 2 - STEP_HEIGHT / 2 - CANVAS_PADDING,
         ];
 
         const stepPath = relativeToPipeline(pipelineCwd, filePath);

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useCreateStep.tsx
@@ -50,8 +50,8 @@ export const useCreateStep = (): StepCreator => {
         const [offsetX, offsetY] = pipelineOffset;
 
         const position: Point2D = [
-          -offsetX + clientWidth / 2 - STEP_WIDTH / 2 - CANVAS_PADDING,
-          -offsetY + clientHeight / 2 - STEP_HEIGHT / 2 - CANVAS_PADDING,
+          -(offsetX + CANVAS_PADDING) + clientWidth / 2 - STEP_WIDTH / 2,
+          -(offsetY + CANVAS_PADDING) + clientHeight / 2 - STEP_HEIGHT / 2,
         ];
 
         const stepPath = relativeToPipeline(pipelineCwd, filePath);

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/usePipelineCanvasState.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/usePipelineCanvasState.tsx
@@ -1,8 +1,11 @@
 import { Point2D } from "@/utils/geometry";
 import React from "react";
+import { CANVAS_PADDING } from "../pipeline-viewport/common";
 
-export const PIPELINE_CANVAS_SIZE = 2000;
-export const INITIAL_PIPELINE_OFFSET: Point2D = [-1, -1];
+export const INITIAL_PIPELINE_OFFSET: Point2D = [
+  -CANVAS_PADDING,
+  -CANVAS_PADDING,
+];
 
 type PanningState = "ready-to-pan" | "panning" | "idle";
 

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/usePipelineUiState.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/usePipelineUiState.tsx
@@ -6,15 +6,8 @@ import type {
   StepsDict,
   StepState,
 } from "@/types";
-import {
-  createRect,
-  dividePoint,
-  Point2D,
-  rectsIntersect,
-  subtractPoints,
-} from "@/utils/geometry";
+import { createRect, Point2D, rectsIntersect } from "@/utils/geometry";
 import { getOuterHeight, getOuterWidth } from "@/utils/jquery-replacement";
-import { getMousePoint } from "@/utils/mouse";
 import { setOutgoingConnections } from "@/utils/webserver-utils";
 import { hasValue, uuidv4 } from "@orchest/lib-utils";
 import produce from "immer";
@@ -129,11 +122,11 @@ export type Action =
     }
   | {
       type: "CREATE_SELECTOR";
-      payload: Readonly<Point2D>;
+      payload: Point2D;
     }
   | {
       type: "UPDATE_STEP_SELECTOR";
-      payload: Readonly<Point2D>;
+      payload: Point2D;
     }
   | {
       type: "SET_STEP_SELECTOR_INACTIVE";
@@ -463,20 +456,13 @@ export const usePipelineUiState = () => {
         case "CREATE_SELECTOR": {
           // not dragging the canvas, so user must be creating a selection rectangle
           // NOTE: this also deselect all steps
-          const canvasOffset = action.payload;
-
-          const start = dividePoint(
-            subtractPoints(getMousePoint(), canvasOffset),
-            scaleFactor
-          );
-
           return {
             ...state,
             grabbedStep: undefined,
             selectedSteps: [],
             stepSelector: {
-              start,
-              end: start,
+              start: action.payload,
+              end: action.payload,
               active: true,
             },
           };
@@ -567,15 +553,7 @@ export const usePipelineUiState = () => {
         }
 
         case "UPDATE_STEP_SELECTOR": {
-          const canvasOffset = action.payload;
-
-          const end = dividePoint(
-            subtractPoints(getMousePoint(), canvasOffset),
-            scaleFactor
-          );
-
-          const newRect = { ...state.stepSelector, end };
-
+          const newRect = { ...state.stepSelector, end: action.payload };
           const rect = createRect(newRect.start, newRect.end);
 
           return produce(state, (draft) => {

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-connection/PipelineConnection.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-connection/PipelineConnection.tsx
@@ -15,13 +15,13 @@ type PipelineConnectionProps = {
   endNodeUUID?: string;
   selected: boolean;
   shouldUpdate: readonly [boolean, boolean];
-  getPosition: (element: HTMLElement) => Point2D;
+  getElementPosition: (element: HTMLElement) => Point2D;
 };
 
 const PipelineConnectionComponent = ({
   shouldRedraw,
   isNew,
-  getPosition,
+  getElementPosition,
   selected,
   startNodeUUID,
   endNodeUUID,
@@ -49,13 +49,13 @@ const PipelineConnectionComponent = ({
   const endNode = stepRefs.current[`${endNodeUUID}-incoming`];
 
   const start =
-    shouldUpdateStart && startNode ? getPosition(startNode) : startPoint;
+    shouldUpdateStart && startNode ? getElementPosition(startNode) : startPoint;
 
   const newConnectionEnd = newConnection.current?.end;
 
   const end =
     shouldUpdateEnd && endNode
-      ? getPosition(endNode)
+      ? getElementPosition(endNode)
       : newConnectionEnd
       ? newConnectionEnd
       : endPoint || startPoint;

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineCanvas.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineCanvas.tsx
@@ -1,4 +1,11 @@
 import React from "react";
+import { CANVAS_PADDING } from "./common";
+
+/**
+ * To preserve relative positions within the canvas the canvas gets expanded
+ * and its content offset with `transform` instead of padded.
+ */
+const PADDING_TRANSFORM = `translate(${CANVAS_PADDING}px, ${CANVAS_PADDING}px)`;
 
 export const PipelineCanvas = React.forwardRef<
   HTMLDivElement,
@@ -11,7 +18,7 @@ export const PipelineCanvas = React.forwardRef<
       ref={ref}
       {...props}
     >
-      {children}
+      <div style={{ transform: PADDING_TRANSFORM }}>{children}</div>
     </div>
   );
 });

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -1,6 +1,5 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import { getFilePathRelativeToPipeline } from "@/pipeline-view/file-manager/common";
-import { getOffset } from "@/utils/element";
 import {
   isSamePoint,
   Point2D,
@@ -23,11 +22,9 @@ import { usePipelineRefs } from "../contexts/PipelineRefsContext";
 import { usePipelineUiStateContext } from "../contexts/PipelineUiStateContext";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "../file-manager/useValidateFilesOnSteps";
-import {
-  INITIAL_PIPELINE_OFFSET,
-  PIPELINE_CANVAS_SIZE,
-} from "../hooks/usePipelineCanvasState";
+import { INITIAL_PIPELINE_OFFSET } from "../hooks/usePipelineCanvasState";
 import { STEP_HEIGHT, STEP_WIDTH } from "../PipelineStep";
+import { CANVAS_SIZE_WITH_PADDING } from "./common";
 import { FullViewportHolder } from "./components/FullViewportHolder";
 import { Overlay } from "./components/Overlay";
 import { useViewportMouseEvents } from "./hooks/useViewportMouseEvents";
@@ -111,7 +108,7 @@ const PipelineViewportComponent = React.forwardRef<HTMLDivElement, BoxProps>(
       if (isCreatingSelection) {
         uiStateDispatch({
           type: "CREATE_SELECTOR",
-          payload: getOffset(pipelineCanvasRef.current),
+          payload: canvasPointAtPointer(),
         });
       }
     };
@@ -209,8 +206,8 @@ const PipelineViewportComponent = React.forwardRef<HTMLDivElement, BoxProps>(
         <PipelineCanvas
           ref={pipelineCanvasRef}
           style={{
-            width: PIPELINE_CANVAS_SIZE,
-            height: PIPELINE_CANVAS_SIZE,
+            width: CANVAS_SIZE_WITH_PADDING,
+            height: CANVAS_SIZE_WITH_PADDING,
             boxSizing: "content-box",
             transformOrigin: `${pipelineOrigin[0]}px ${pipelineOrigin[1]}px`,
             transform:

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/common.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/common.tsx
@@ -1,0 +1,3 @@
+export const CANVAS_PADDING = 5000;
+export const CANVAS_SIZE = 2000;
+export const CANVAS_SIZE_WITH_PADDING = CANVAS_SIZE + CANVAS_PADDING * 2;

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportGestures.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportGestures.tsx
@@ -44,7 +44,7 @@ export const useViewportGestures = (
     (origin: Point2D, delta: number) => {
       if (disabled) return;
 
-      const relativeOrigin = windowToCanvasPoint(origin);
+      const relativeOrigin = windowToCanvasPoint(origin, 0);
 
       setPipelineCanvasOrigin(relativeOrigin);
       setScaleFactor((current) => current + delta);
@@ -66,7 +66,7 @@ export const useViewportGestures = (
         if (isZooming(event)) {
           const { deltaY, clientX, clientY } = event;
           const wheelDelta = (deltaY * ZOOM_SCROLL_FACTOR) / 100;
-          const originOnCanvas = windowToCanvasPoint([clientX, clientY]);
+          const originOnCanvas = windowToCanvasPoint([clientX, clientY], 0);
 
           setPipelineCanvasOrigin(originOnCanvas);
           setScaleFactor((current) => current - wheelDelta);
@@ -85,7 +85,7 @@ export const useViewportGestures = (
         const center = getClientCenter(event);
 
         if (hasValue(center)) {
-          setPipelineCanvasOrigin(windowToCanvasPoint(center));
+          setPipelineCanvasOrigin(windowToCanvasPoint(center, 0));
         }
 
         setScaleFactor(offset);

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportKeyboardEvents.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportKeyboardEvents.tsx
@@ -83,12 +83,10 @@ export const useViewportKeyboardEvents = () => {
   );
 
   const centerPipelineOrigin = React.useCallback(() => {
-    const viewportOffset = getOffset(pipelineViewportRef.current ?? undefined);
-    const canvasOffset = getOffset(pipelineCanvasRef.current ?? undefined);
+    if (!pipelineViewportRef.current) return;
 
-    if (pipelineViewportRef.current === null) {
-      return;
-    }
+    const viewportOffset = getOffset(pipelineViewportRef.current);
+    const canvasOffset = getOffset(pipelineCanvasRef.current);
 
     const viewportWidth = pipelineViewportRef.current.clientWidth;
     const viewportHeight = pipelineViewportRef.current.clientHeight;

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportMouseEvents.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportMouseEvents.tsx
@@ -3,16 +3,15 @@ import { usePipelineCanvasContext } from "@/pipeline-view/contexts/PipelineCanva
 import { usePipelineDataContext } from "@/pipeline-view/contexts/PipelineDataContext";
 import { usePipelineRefs } from "@/pipeline-view/contexts/PipelineRefsContext";
 import { usePipelineUiStateContext } from "@/pipeline-view/contexts/PipelineUiStateContext";
-import { getOffset } from "@/utils/element";
-import { addPoints, dividePoint, subtractPoints } from "@/utils/geometry";
-import { getMouseDelta, getMousePoint } from "@/utils/mouse";
+import { addPoints } from "@/utils/geometry";
+import { getMouseDelta } from "@/utils/mouse";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 
 /**A hook that handles all mouse events that within the pipeline viewport. */
 export const useViewportMouseEvents = () => {
   const { disabled } = usePipelineDataContext();
-  const { scaleFactor } = useCanvasScaling();
+  const { canvasPointAtPointer } = useCanvasScaling();
   const { keysDown, pipelineCanvasRef, newConnection } = usePipelineRefs();
 
   const {
@@ -33,20 +32,16 @@ export const useViewportMouseEvents = () => {
       return;
     }
 
-    const canvasOffset = getOffset(pipelineCanvasRef.current);
-
     // update newConnection's position
     if (newConnection.current) {
-      const end = dividePoint(
-        subtractPoints(getMousePoint(), canvasOffset),
-        scaleFactor
-      );
-
-      newConnection.current = { ...newConnection.current, end };
+      newConnection.current.end = canvasPointAtPointer();
     }
 
     if (stepSelector.active) {
-      uiStateDispatch({ type: "UPDATE_STEP_SELECTOR", payload: canvasOffset });
+      uiStateDispatch({
+        type: "UPDATE_STEP_SELECTOR",
+        payload: canvasPointAtPointer(),
+      });
     }
 
     if (panningState === "panning") {
@@ -59,11 +54,9 @@ export const useViewportMouseEvents = () => {
     newConnection,
     stepSelector.active,
     panningState,
-    getMousePoint,
-    scaleFactor,
+    canvasPointAtPointer,
     uiStateDispatch,
     setPipelineCanvasState,
-    getMouseDelta,
   ]);
 
   const onMouseLeaveViewport = React.useCallback(() => {


### PR DESCRIPTION
## Description

This PR expands the canvas from `2000px` to `12000px`. Not _quite_ infinite of course, but you now really have to put your back into it in order to find the edges of it. :wink: 

After a lot of trial and error with trying to find a strategy that doesn't require too many recalculations of positions, I decided to go with this approach:
- The pipeline canvas size is expanded by the padding (times two) so `2000 + 5000 * 2` pixels.
- The _content_ on the canvas is offset by the padding in the X and Y axis using `transform: translate(5000px, 5000px)`.
- The initial position of the canvas is set to the negative padding in both the X and Y direction: `[-5000, -5000]`

The simple solution of setting `{ padding: CANVAS_PADDING }` causes more inconsistencies than the above solution.

As an added bonus: While making the selection rectangle compatible with this solution, I also managed to optimize it further, so it's now even snappier. :tada:

Fixes: #94

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

## Tested

- [x] A newly imported "quickstart pipeline" is located in the expected position
- [x] Connections are positioned correctly
- [x] Interactive connections (visible when steps are moved) are positioned correctly
- [x] New connection lines are positioned correctly  
- [x] Padding is _not_ added to moved steps in the pipeline definition metadata
- [x] Dropping a pipeline step on the canvas positions it under the cursor
- [x] Hitting <kbd>+ NEW STEP</kbd> adds the step to the center of the canvas 
- [x] Zooming is performed towards the cursor
