### PR TITLE
fix: Unable to create a file in /data folder

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/ActionBar.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/ActionBar.tsx
@@ -48,7 +48,7 @@ export function ActionBar({
       reload();
 
       if (file.shouldCreateStep) {
-        createStep(file.projectPath);
+        createStep(file.fullPath);
       }
     },
     [createStep, setSelectedFiles, reload]

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
@@ -356,12 +356,13 @@ const getFilePathInDataFolder = (dragFilePath: string) =>
   cleanFilePath(dragFilePath);
 
 export const getFilePathRelativeToPipeline = (
-  absFilePath: string,
+  fullFilePath: string | undefined,
   pipelineCwd: string
 ) => {
-  return isInDataFolder(absFilePath)
-    ? getFilePathInDataFolder(absFilePath)
-    : relative(pipelineCwd, cleanFilePath(absFilePath));
+  if (!hasValue(fullFilePath)) return pipelineCwd;
+  return isInDataFolder(fullFilePath)
+    ? getFilePathInDataFolder(fullFilePath)
+    : relative(pipelineCwd, cleanFilePath(fullFilePath));
 };
 
 export const lastSelectedFolderPath = (selectedFiles: string[]) => {

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -1,5 +1,4 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
-import { getFilePathRelativeToPipeline } from "@/pipeline-view/file-manager/common";
 import { getOffset } from "@/utils/element";
 import {
   isSamePoint,
@@ -12,7 +11,6 @@ import Box, { BoxProps } from "@mui/material/Box";
 import GlobalStyles from "@mui/material/GlobalStyles";
 import classNames from "classnames";
 import React from "react";
-import { createStepAction } from "../action-helpers/eventVarsHelpers";
 import {
   DEFAULT_SCALE_FACTOR,
   useCanvasScaling,
@@ -23,6 +21,7 @@ import { usePipelineRefs } from "../contexts/PipelineRefsContext";
 import { usePipelineUiStateContext } from "../contexts/PipelineUiStateContext";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "../file-manager/useValidateFilesOnSteps";
+import { useCreateStep } from "../hooks/useCreateStep";
 import {
   INITIAL_PIPELINE_OFFSET,
   PIPELINE_CANVAS_SIZE,
@@ -142,26 +141,16 @@ const PipelineViewportComponent = React.forwardRef<HTMLDivElement, BoxProps>(
 
     const getApplicableStepFiles = useValidateFilesOnSteps();
 
+    const createStep = useCreateStep();
+
     const createStepsWithFiles = React.useCallback(
       (dropPoint: Point2D) => {
-        if (!pipelineCwd) return;
         const { allowed } = getApplicableStepFiles();
-
-        const environment = environments.length > 0 ? environments[0] : null;
-
         allowed.forEach((filePath) => {
-          // Adjust filePath to pipelineCwd, incoming filePath is relative to project
-          // root.
-          const pipelineRelativeFilePath = getFilePathRelativeToPipeline(
-            filePath,
-            pipelineCwd
-          );
-          uiStateDispatch(
-            createStepAction(environment, dropPoint, pipelineRelativeFilePath)
-          );
+          createStep(filePath, dropPoint);
         });
       },
-      [uiStateDispatch, pipelineCwd, environments, getApplicableStepFiles]
+      [createStep, getApplicableStepFiles]
     );
 
     const onDropFiles = React.useCallback(() => {


### PR DESCRIPTION
## Description

This PR unifies the FE logic of creating a step, and thus fixed the following bugs:

- When creating a file in `/data` folder and check "Create a step", the file assigned to the step is incorrect.
- When dropping a file to create a step, the `Step Name` should be auto-focused.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
