### PR TITLE
fix: session doesn't auto start after environments finish building.

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { useHasChanged } from "@/hooks/useHasChanged";
 import { siteMap } from "@/routingConfig";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
@@ -41,6 +42,12 @@ export const useAutoStartSession = () => {
   // session.status was once set as "STOPPING",
   // because this state "STOPPING" can only happen if user clicks on "Stop Session" on purpose.
   const startedPipelineUuid = React.useRef<string>();
+
+  const environmentFinishedBuilding = useHasChanged(
+    pipelineReadOnlyReason,
+    (prev, curr) => hasValue(prev) && !hasValue(curr)
+  );
+
   React.useEffect(() => {
     if (session?.status === "STOPPING")
       startedPipelineUuid.current = pipeline?.uuid;
@@ -84,7 +91,8 @@ export const useAutoStartSession = () => {
     if (
       pipeline?.uuid &&
       shouldCheckIfAutoStartIsNeeded &&
-      startedPipelineUuid.current !== pipeline?.uuid
+      (startedPipelineUuid.current !== pipeline?.uuid ||
+        environmentFinishedBuilding)
     ) {
       startedPipelineUuid.current = pipeline?.uuid;
       requestStartSession(pipeline.uuid);
@@ -94,6 +102,7 @@ export const useAutoStartSession = () => {
     startSession,
     pipeline?.uuid,
     requestStartSession,
+    environmentFinishedBuilding,
   ]);
 
   /**


### PR DESCRIPTION
## Description

This PR fixes a regression: session doesn't auto start after environments finish building.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

