### PR TITLE
fix: File Manager is not refreshed when switching to a project that doesn't have a pipeline.

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -1,4 +1,5 @@
 import { useDebounce } from "@/hooks/useDebounce";
+import { useHasChanged } from "@/hooks/useHasChanged";
 import { useUploader } from "@/hooks/useUploader";
 import { queryArgs } from "@/utils/text";
 import LinearProgress from "@mui/material/LinearProgress";
@@ -188,11 +189,12 @@ export function FileManager() {
    * Final component init
    */
 
+  const hasChangedProject = useHasChanged(projectUuid);
   React.useEffect(() => {
     reload();
-    // Only load once when on mount.
+    // Only load when projectUuid is updated.
     // Put `reload` in the deps would trigger unwanted requests.
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hasChangedProject]); // eslint-disable-line react-hooks/exhaustive-deps
 
   React.useEffect(() => {
     const filterInvalidEntries = createInvalidEntryFilter({


### PR DESCRIPTION
## Description

This PR makes it so that File Manager would attempt to fetch the file tree when project_uuid is changed.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

