### PR TITLE
Show dialog when session is stopping and you open JupyterLab

### DIFF
--- a/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
+++ b/services/orchest-webserver/client/src/jupyter/Jupyter.tsx
@@ -146,7 +146,7 @@ class Jupyter {
           window.clearInterval(this.showCheckInterval);
         }
       }
-    }, 10);
+    }, 300);
   }
 
   isShowing() {

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -42,7 +42,11 @@ const JupyterLabView = () => {
 
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();
   const { setAlert } = useGlobalContext();
-  const { getSession, startSession } = useSessionsContext();
+  const {
+    getSession,
+    startSession,
+    state: { sessions },
+  } = useSessionsContext();
   const {
     state: { pipelineReadOnlyReason },
   } = useProjectsContext();
@@ -88,7 +92,7 @@ const JupyterLabView = () => {
 
   // Launch the session on mount.
   React.useEffect(() => {
-    if (pipelineUuid && projectUuid && !session) {
+    if (pipelineUuid && projectUuid && sessions && !session) {
       startSession(pipelineUuid, BUILD_IMAGE_SOLUTION_VIEW.JUPYTER_LAB)
         .then((result) => {
           if (result === true) {
@@ -113,6 +117,7 @@ const JupyterLabView = () => {
         });
     }
   }, [
+    sessions,
     startSession,
     pipelineUuid,
     projectUuid,

--- a/services/orchest-webserver/client/src/views/JupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/JupyterLabView.tsx
@@ -1,6 +1,7 @@
 import BuildPendingDialog from "@/components/BuildPendingDialog";
 import { Layout } from "@/components/Layout";
 import ProjectBasedView from "@/components/ProjectBasedView";
+import { useGlobalContext } from "@/contexts/GlobalContext";
 import {
   BUILD_IMAGE_SOLUTION_VIEW,
   useProjectsContext,
@@ -40,11 +41,8 @@ const JupyterLabView = () => {
   const { dispatch } = useProjectsContext();
 
   const { navigateTo, projectUuid, pipelineUuid, filePath } = useCustomRoute();
-  const {
-    getSession,
-    startSession,
-    state: { sessions },
-  } = useSessionsContext();
+  const { setAlert } = useGlobalContext();
+  const { getSession, startSession } = useSessionsContext();
   const {
     state: { pipelineReadOnlyReason },
   } = useProjectsContext();
@@ -90,7 +88,7 @@ const JupyterLabView = () => {
 
   // Launch the session on mount.
   React.useEffect(() => {
-    if (pipelineUuid && projectUuid && sessions) {
+    if (pipelineUuid && projectUuid && !session) {
       startSession(pipelineUuid, BUILD_IMAGE_SOLUTION_VIEW.JUPYTER_LAB)
         .then((result) => {
           if (result === true) {
@@ -105,7 +103,7 @@ const JupyterLabView = () => {
               "environmentsFailedToBuild",
             ].includes(result.message)
           ) {
-            // When failed, it could be that the pipeline does no loner exist.
+            // When failed, it could be that the pipeline does no longer exist.
             // Navigate back to PipelineEditor.
             navigateTo(siteMap.pipeline.path, { query: { projectUuid } });
           }
@@ -114,7 +112,15 @@ const JupyterLabView = () => {
           navigateTo(siteMap.pipeline.path, { query: { projectUuid } });
         });
     }
-  }, [startSession, pipelineUuid, projectUuid, navigateTo, sessions, dispatch]);
+  }, [
+    startSession,
+    pipelineUuid,
+    projectUuid,
+    navigateTo,
+    dispatch,
+    setAlert,
+    session,
+  ]);
 
   const conditionalRenderingOfJupyterLab = React.useCallback(() => {
     if (session?.status === "RUNNING") {
@@ -181,6 +187,21 @@ const JupyterLabView = () => {
     },
     pipelineJson ? verifyKernelsInterval : undefined
   );
+
+  React.useEffect(() => {
+    if (session?.status === "STOPPING") {
+      setAlert(
+        "Session stopping",
+        "Your pipeline session is still stopping, " +
+          "please try opening JupyterLab again once the session has stopped.",
+        {
+          confirmLabel: "Close",
+          onConfirm: () => true,
+        }
+      );
+      navigateTo(siteMap.pipeline.path, { query: { projectUuid } });
+    }
+  }, [setAlert, navigateTo, session?.status, projectUuid]);
 
   return (
     <Layout disablePadding>


### PR DESCRIPTION
## Description

Had to make a few other changes in order to get this to work, as the error that we got was "Session already exists" (and not related to the session stopping). So I had to move this check to a separate `useEffect`, and it took some time to verify that there were no regressions.

Here it is, in all its glory!

![image](https://user-images.githubusercontent.com/8259221/192545210-e699cbf1-4f25-484e-9f6c-cce1b972def1.png)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `release/v2022.09.6` instead of `dev`.
