### PR TITLE
Hotfix UTC dates without tz

### DIFF
--- a/services/orchest-webserver/client/src/jobs-view/common.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/common.tsx
@@ -179,8 +179,11 @@ export const formatRunStatus = (status: PipelineRunStatus) => {
   }
 };
 
+const ensureUTC = (isoDateString: string) =>
+  isoDateString.endsWith("+00:00") ? isoDateString : isoDateString + "+00:00";
+
 export const humanizeDate = (isoDateString: string) =>
-  format(new Date(isoDateString), "MMM d yyyy, p");
+  format(Date.parse(ensureUTC(isoDateString)), "MMM d yyyy, p");
 
 export const canCancelRun = (
   run: PipelineRun | undefined


### PR DESCRIPTION
## Description

Some dates were displayed as UTC. This is because the server doesn't add "+00:00" to the end of the date string.

This is a quick hotfix in the front-end. Will investigate what can be done in the back-end.