### PR TITLE
Fix: draft job schedule is empty after switching to another pipeline

### DIFF
--- a/services/orchest-webserver/client/src/api/jobs/useJobsApi.ts
+++ b/services/orchest-webserver/client/src/api/jobs/useJobsApi.ts
@@ -123,9 +123,7 @@ export const useJobsApi = create<JobsApi>((set, get) => {
       );
       set((state) => {
         const jobs = state.jobs ? [draftJob, ...state.jobs] : [draftJob];
-        return {
-          jobs: jobs.sort((a, b) => -1 * a.name.localeCompare(b.name)),
-        };
+        return { jobs };
       });
       return draftJob;
     },

--- a/services/orchest-webserver/client/src/jobs-view/hooks/useScheduleJob.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/hooks/useScheduleJob.tsx
@@ -16,7 +16,12 @@ export const useScheduleJob = () => {
   const stopEditing = useEditJob((state) => state.stopEditing);
 
   const scheduleJob = React.useCallback(async () => {
-    if (!hasValue(jobChanges)) return;
+    const isValid =
+      hasValue(jobChanges) &&
+      (hasValue(jobChanges.schedule) ||
+        hasValue(jobChanges.next_scheduled_time));
+
+    if (!isValid) return;
 
     stopEditing();
 

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobScheduleOption.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobScheduleOption.tsx
@@ -28,13 +28,19 @@ export const useJobScheduleOption = () => {
       : "one-off";
   });
 
-  const hasInitialized = React.useRef(false);
+  const jobPipelineUuid = useEditJob(
+    (state) => state.jobChanges?.pipeline_uuid
+  );
+  const hasInitializedForPipelineUuid = React.useRef(jobPipelineUuid);
   React.useEffect(() => {
-    if (initialScheduleOption && !hasInitialized.current) {
-      hasInitialized.current = true;
+    if (
+      initialScheduleOption &&
+      hasInitializedForPipelineUuid.current !== jobPipelineUuid
+    ) {
+      hasInitializedForPipelineUuid.current = jobPipelineUuid;
       setScheduleOption(initialScheduleOption);
     }
-  }, [initialScheduleOption]);
+  }, [initialScheduleOption, jobPipelineUuid]);
 
   const [cronString, setCronString] = useCronString();
   const [nextScheduledTime, setNextScheduledTime] = useScheduleDateTime();
@@ -57,19 +63,9 @@ export const useJobScheduleOption = () => {
     [cronString, nextScheduledTime, setJobChanges]
   );
 
-  const jobPipelineUuid = useEditJob(
-    (state) => state.jobChanges?.pipeline_uuid
-  );
-  React.useEffect(() => {
-    if (initialScheduleOption && jobPipelineUuid) {
-      setScheduleOption(initialScheduleOption);
-      setSchedule(initialScheduleOption);
-    }
-  }, [initialScheduleOption, jobPipelineUuid, setSchedule]);
-
   React.useEffect(() => {
     setSchedule(scheduleOption);
-  }, [scheduleOption, setSchedule]);
+  }, [scheduleOption, setSchedule, jobPipelineUuid]);
 
   return {
     scheduleOption,


### PR DESCRIPTION
## Description

If user doesn't change schedule after switching to another pipeline, the submitted schedule is empty (i.e. both `schedule` and `next_scheduled_time` are `null`). This PR ensures that the schedule is re-assigned right after switching pipelines of a draft job. This PR also remove the unnecessary sorting when creating a draft job.


## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

