### PR TITLE
fix: Jobs view crashes on Safari

### DIFF
--- a/services/orchest-webserver/client/src/jobs-view/common.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/common.tsx
@@ -7,6 +7,7 @@ import {
   PipelineRunStatus,
   StrategyJson,
 } from "@/types";
+import { toValidDateString } from "@/utils/date-time";
 import { pick } from "@/utils/record";
 import capitalize from "@mui/utils/capitalize";
 import format from "date-fns/format";
@@ -179,11 +180,24 @@ export const formatRunStatus = (status: PipelineRunStatus) => {
   }
 };
 
-const ensureUTC = (isoDateString: string) =>
-  isoDateString.endsWith("+00:00") ? isoDateString : isoDateString + "+00:00";
+const ensureUTC = (isoDateString: string) => {
+  const validIsoDateString = toValidDateString(isoDateString);
+  return validIsoDateString.endsWith("+00:00")
+    ? validIsoDateString
+    : validIsoDateString + "+00:00";
+};
 
-export const humanizeDate = (isoDateString: string) =>
-  format(Date.parse(ensureUTC(isoDateString)), "MMM d yyyy, p");
+const parseDate = (date: string) => {
+  const parsed = Date.parse(date);
+  // Date.parse would fail on Safari if the date is separated with "-".
+  if (!isNaN(parsed)) return parsed;
+  return Date.parse(date.replace(/-/g, "/").replace(/[a-z]+/gi, " "));
+};
+
+export const humanizeDate = (isoDateString: string) => {
+  const date = parseDate(ensureUTC(isoDateString));
+  return format(date, "MMM d yyyy, p");
+};
 
 export const canCancelRun = (
   run: PipelineRun | undefined

--- a/services/orchest-webserver/client/src/utils/date-time.ts
+++ b/services/orchest-webserver/client/src/utils/date-time.ts
@@ -1,9 +1,15 @@
 export const getCurrentDateTimeString = () => toUtcDateTimeString(new Date());
+export const toValidDateString = (dateString: string) => {
+  // 2011-06-21 14:27:28.593 => 2011-06-21T14:27:28.593
+  return dateString.trim().replace(" ", "T");
+};
 export const toUtcDateTimeString = (dateTime: Date) => {
   // API accept UTC time but not in ISO date format (i.e. T and Z should be removed).
   return dateTime.toISOString().replace("T", " ").replace("Z", "");
 };
-export const convertUtcToLocalDate = (utcString: string) =>
-  new Date(
-    new Date(utcString).getTime() - new Date().getTimezoneOffset() * 60000
+export const convertUtcToLocalDate = (utcString: string) => {
+  const validUtcString = toValidDateString(utcString);
+  return new Date(
+    new Date(validUtcString).getTime() - new Date().getTimezoneOffset() * 60000
   );
+};


### PR DESCRIPTION
## Description

The datetime string from BE was invalid for Date.parse() on Safari. Adding the missing `T` fixes the issue.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
