### PR TITLE
Minor consistency tweaks for text inputs & properties

### DIFF
--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentName.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EditEnvironmentName.tsx
@@ -48,7 +48,7 @@ export const EditEnvironmentName = () => {
       helperText={isInvalid ? "Environment name cannot be blank" : " "}
       label="Environment name"
       disabled={isEnvironmentBuilding(latestBuildStatus)}
-      sx={{ width: { xs: "100%", lg: "50%" } }}
+      sx={{ width: { xs: "100%", lg: "49%" } }}
     />
   );
 };

--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobName.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobName.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import React from "react";
 import { useEditJob } from "../stores/useEditJob";
@@ -20,20 +21,22 @@ export const EditJobName = () => {
   };
 
   return (
-    <TextField
-      required
-      value={value}
-      onFocus={() => setHasEdited(true)}
-      onBlur={() => {
-        const trimmedValue = value.trim();
-        if (trimmedValue) setJobChanges({ name: trimmedValue });
-      }}
-      onChange={handleChange}
-      InputLabelProps={{ required: false }}
-      error={isInvalid}
-      helperText={isInvalid ? "Job name cannot be blank" : " "}
-      label="Job name"
-      sx={{ width: { xs: "100%", lg: "70%" } }}
-    />
+    <Box>
+      <TextField
+        required
+        value={value}
+        onFocus={() => setHasEdited(true)}
+        onBlur={() => {
+          const trimmedValue = value.trim();
+          if (trimmedValue) setJobChanges({ name: trimmedValue });
+        }}
+        onChange={handleChange}
+        InputLabelProps={{ required: false }}
+        error={isInvalid}
+        helperText={isInvalid ? "Job name cannot be blank" : " "}
+        label="Job name"
+        sx={{ width: { xs: "100%", lg: "49%" } }}
+      />
+    </Box>
   );
 };

--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobPipeline.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobPipeline.tsx
@@ -40,7 +40,10 @@ export const EditJobPipeline = () => {
   return hasValue(pipelines) ? (
     <FormControl
       disabled={disabled}
-      sx={{ width: "50%", minWidth: (theme) => theme.spacing(35) }}
+      sx={{
+        width: { xs: "80%", lg: "32%" },
+        minWidth: (theme) => theme.spacing(35),
+      }}
     >
       <InputLabel
         id="job-pipeline-select-label"

--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobProperties.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobProperties.tsx
@@ -9,16 +9,16 @@ import { EditJobConfig } from "./EditJobConfig";
 import { EditJobName } from "./EditJobName";
 import { EditJobPipeline } from "./EditJobPipeline";
 
-type JobOverviewProps = { hideSelectPipeline?: true };
+type EditJobPropertiesProps = { hideSelectPipeline?: true };
 
-export const EditJobOverview = ({
+export const EditJobProperties = ({
   hideSelectPipeline = undefined,
-}: JobOverviewProps) => {
+}: EditJobPropertiesProps) => {
   return (
     <Accordion defaultExpanded>
       <AccordionSummary aria-controls="job-overview" id="job-overview-header">
         <Typography component="h5" variant="h6">
-          Overview
+          Properties
         </Typography>
       </AccordionSummary>
       <AccordionDetails sx={{ padding: (theme) => theme.spacing(2, 0) }}>

--- a/services/orchest-webserver/client/src/jobs-view/job-view/JobView.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/JobView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useEditJob } from "../stores/useEditJob";
-import { EditJobOverview } from "./EditJobOverview";
+import { EditJobProperties } from "./EditJobProperties";
 import { JobEnvVariables } from "./JobEnvVariables";
 import { JobParameters } from "./JobParameters";
 import { JobRuns } from "./JobRuns";
@@ -17,7 +17,7 @@ export const JobView = () => {
       <JobViewHeader />
       {!isEditing && <JobSummary />}
       {!isEditing && <JobRuns />}
-      {isEditing && <EditJobOverview />}
+      {isEditing && <EditJobProperties />}
       <JobParameters />
       <JobEnvVariables />
       <WebhookHint />

--- a/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobPanel.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/Layout/layout-with-side-panel/stores/useLayoutStore";
 import { ResizablePane } from "@/components/ResizablePane";
 import { useSaveJobChanges } from "@/jobs-view/hooks/useSaveJobChanges";
-import { EditJobOverview } from "@/jobs-view/job-view/EditJobOverview";
+import { EditJobProperties } from "@/jobs-view/job-view/EditJobProperties";
 import { JobEnvVariables } from "@/jobs-view/job-view/JobEnvVariables";
 import { JobParameters } from "@/jobs-view/job-view/JobParameters";
 import { useEditJob } from "@/jobs-view/stores/useEditJob";
@@ -82,7 +82,7 @@ export const ScheduleJobPanel = () => {
             marginTop: (theme) => theme.spacing(-2),
           }}
         >
-          <EditJobOverview hideSelectPipeline />
+          <EditJobProperties hideSelectPipeline />
           <JobParameters />
           <JobEnvVariables />
         </Box>


### PR DESCRIPTION
## Description

From @ncspost's "nice-to-have" checklist:

- [x] Jobs “overview” section should be renamed to “Properties” for general consistency with Step detail and Environments 
- [x] Job name text field should be same size as environment name text field

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
