### PR TITLE
Fix: incorrect warning after saving a recurring Job.

### DIFF
--- a/services/orchest-webserver/client/src/jobs-view/job-view/JobPrimaryButtons.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/JobPrimaryButtons.tsx
@@ -33,16 +33,17 @@ const DiscardChangesButton = () => {
 };
 
 const SaveCronJobChangesButton = () => {
+  const { setAsSaved } = useGlobalContext();
   const isEditingActiveCronJob = useIsEditingActiveCronJob();
   const saveActiveCronJobChanges = useEditJob(
     (state) => state.saveActiveCronJobChanges
   );
+  const saveChanges = () => {
+    setAsSaved();
+    saveActiveCronJobChanges();
+  };
   return isEditingActiveCronJob ? (
-    <Button
-      color="primary"
-      variant="contained"
-      onClick={saveActiveCronJobChanges}
-    >
+    <Button color="primary" variant="contained" onClick={saveChanges}>
       Save job
     </Button>
   ) : null;

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActions.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useJobActions.tsx
@@ -1,3 +1,4 @@
+import { useJobRunsApi } from "@/api/job-runs/useJobRunsApi";
 import { useJobsApi } from "@/api/jobs/useJobsApi";
 import { useCancelJob } from "@/hooks/useCancelJob";
 import { useSelectJob } from "@/jobs-view/hooks/useSelectJob";
@@ -17,6 +18,8 @@ export const useJobActions = () => {
   const triggerScheduledRuns = useJobsApi(
     (state) => state.triggerScheduledRuns
   );
+  const fetchPage = useJobRunsApi((state) => state.fetchPage);
+  const pageSize = useJobRunsApi((state) => state.pagination?.page_size);
 
   const pauseJob = React.useCallback(() => {
     if (uuid) pauseCronJob(uuid);
@@ -39,7 +42,8 @@ export const useJobActions = () => {
   const triggerJobNow = React.useCallback(async () => {
     if (!uuid) return;
     await triggerScheduledRuns(uuid);
-  }, [triggerScheduledRuns, uuid]);
+    fetchPage({ page: 1, pageSize: pageSize || 10 });
+  }, [triggerScheduledRuns, uuid, pageSize, fetchPage]);
 
   return {
     scheduleJob,


### PR DESCRIPTION
## Description

This PR fixes two bugs: 
- After finishing editing a recurring job by clicking "SAVE JOB", user still gets a warning about "Unsaved progress" waring when navigating away.
- After clicking "Trigger job now", the JobRunTable doesn't show the new job run right away.


## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

