### PR TITLE
Fix: add missing "back to settings" buttons

### DIFF
--- a/services/orchest-webserver/client/src/components/BackToOrchestSettingsButton.tsx
+++ b/services/orchest-webserver/client/src/components/BackToOrchestSettingsButton.tsx
@@ -1,0 +1,13 @@
+import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { siteMap } from "@/routingConfig";
+import React from "react";
+import { BackButton } from "./common/BackButton";
+
+export const BackToOrchestSettingsButton = () => {
+  const { navigateTo } = useCustomRoute();
+  const returnToSettings = () => {
+    navigateTo(siteMap.settings.path);
+  };
+
+  return <BackButton onClick={returnToSettings}>Back to settings</BackButton>;
+};

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -141,7 +141,7 @@ export const useCheckUpdate = () => {
             resolve(false);
             return false;
           },
-          confirmLabel: "Update",
+          confirmLabel: "Go to Update view",
           cancelLabel: "Skip this version",
         }
       );

--- a/services/orchest-webserver/client/src/notification-settings-view/NotificationSettingsView.tsx
+++ b/services/orchest-webserver/client/src/notification-settings-view/NotificationSettingsView.tsx
@@ -1,10 +1,10 @@
+import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { PageTitle } from "@/components/common/PageTitle";
 import { SectionTitle } from "@/components/common/SectionTitle";
 import { Layout } from "@/components/layout/Layout";
 import { useAppContext } from "@/contexts/AppContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { siteMap } from "@/routingConfig";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Alert from "@mui/material/Alert";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
@@ -48,12 +48,6 @@ const ReturnToJobsAlert = () => {
 };
 
 export const NotificationSettingsView = () => {
-  const { navigateTo } = useCustomRoute();
-
-  const returnToSettings = () => {
-    navigateTo(siteMap.settings.path);
-  };
-
   return (
     <Layout>
       <Stack
@@ -62,14 +56,7 @@ export const NotificationSettingsView = () => {
         sx={{ maxWidth: "1000px" }}
       >
         <NotificationSettingsContextProvider>
-          <Button
-            color="secondary"
-            startIcon={<ArrowBackIcon />}
-            onAuxClick={returnToSettings}
-            onClick={returnToSettings}
-          >
-            Back to settings
-          </Button>
+          <BackToOrchestSettingsButton />
           <PageTitle sx={{ marginTop: (theme) => theme.spacing(2.5) }}>
             Notification settings
           </PageTitle>

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -1,3 +1,4 @@
+import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/layout/Layout";
@@ -11,6 +12,7 @@ import { EnvironmentImageBuild } from "@/types";
 import CloseIcon from "@mui/icons-material/Close";
 import MemoryIcon from "@mui/icons-material/Memory";
 import SaveIcon from "@mui/icons-material/Save";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import LinearProgress from "@mui/material/LinearProgress";
 import Snackbar from "@mui/material/Snackbar";
@@ -209,7 +211,11 @@ const ConfigureJupyterLabView: React.FC = () => {
 
   return (
     <Layout>
-      <div className={"view-page jupyterlab-config-page"}>
+      <BackToOrchestSettingsButton />
+      <Box
+        className={"view-page jupyterlab-config-page"}
+        sx={{ marginTop: (theme) => theme.spacing(2) }}
+      >
         {hasValue(jupyterSetupScript) ? (
           <>
             <PageTitle>Configure JupyterLab</PageTitle>
@@ -302,7 +308,7 @@ const ConfigureJupyterLabView: React.FC = () => {
         ) : (
           <LinearProgress />
         )}
-      </div>
+      </Box>
       <Snackbar
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         open={showStoppingAllSessionsWarning}

--- a/services/orchest-webserver/client/src/views/ManageUsersView.tsx
+++ b/services/orchest-webserver/client/src/views/ManageUsersView.tsx
@@ -1,20 +1,26 @@
+import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { Layout } from "@/components/layout/Layout";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
+import Box from "@mui/material/Box";
 import React from "react";
 
 const ManageUsersView: React.FC = () => {
   useSendAnalyticEvent("view:loaded", { name: siteMap.manageUsers.path });
 
   return (
-    <Layout disablePadding>
-      <div className="view-page no-padding manage-users fullheight">
+    <Layout>
+      <BackToOrchestSettingsButton />
+      <Box
+        className="view-page no-padding manage-users fullheight"
+        sx={{ marginTop: (theme) => theme.spacing(2) }}
+      >
         <iframe
           className="borderless fullsize"
           src="/login/admin"
           data-test-id="auth-admin-iframe"
         />
-      </div>
+      </Box>
     </Layout>
   );
 };

--- a/services/orchest-webserver/client/src/views/UpdateView.tsx
+++ b/services/orchest-webserver/client/src/views/UpdateView.tsx
@@ -1,3 +1,4 @@
+import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { ConsoleOutput } from "@/components/ConsoleOutput";
 import { Layout } from "@/components/layout/Layout";
 import { useGlobalContext } from "@/contexts/GlobalContext";
@@ -142,9 +143,11 @@ const UpdateView: React.FC = () => {
 
   return (
     <Layout>
+      <BackToOrchestSettingsButton />
       <Paper
         sx={{
-          padding: (theme) => theme.spacing(3),
+          padding: (theme) => theme.spacing(3, 3, 1, 3),
+          marginTop: (theme) => theme.spacing(2),
         }}
         className={"view-page update-page"}
       >


### PR DESCRIPTION
## Description

In Orchest settings view, some of the sub views don't have the "Back to settings" button.


## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
