### PR TITLE
Use `-exec ... +` notation for `find` to copy build context

### DIFF
--- a/services/orchest-api/app/app/core/environment_image_builds.py
+++ b/services/orchest-api/app/app/core/environment_image_builds.py
@@ -105,8 +105,8 @@ def write_environment_dockerfile(
     # Permission statements.
     ps = [
         "chown -R :$(id -g) . > /dev/null 2>&1 ",
-        "find . -type d -exec chmod g+rwxs {} \; > /dev/null 2>&1 ",
-        "find . -type f -exec chmod g+rwx {} \; > /dev/null 2>&1 ",
+        "find . -type d -not -perm -g+rwxs -exec chmod g+rwxs '{}' + > /dev/null 2>&1 ",
+        "find . -type f -not -perm -g+rwx -exec chmod g+rwx '{}' + > /dev/null 2>&1 ",
         "chmod g+rwx . > /dev/null 2>&1 ",
     ]
     # sudo'd permission statements.


### PR DESCRIPTION
Similar to https://github.com/orchest/orchest/pull/731.

Improves performance.
