### PR TITLE
Move log-streamer to its own container in webserver pod

### DIFF
--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
@@ -163,6 +163,17 @@ func getOrchestWebserverDeployment(metadata metav1.ObjectMeta,
 					},
 					VolumeMounts: volumeMounts,
 				},
+				{
+					Name:            "log-streamer",
+					Command:         []string{"python"},
+					Args:            []string{"/orchest/services/orchest-webserver/app/scripts/log_streamer.py"},
+					Image:           image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+					VolumeMounts: volumeMounts,
+				},
 			},
 		},
 	}

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_webserver.go
@@ -170,7 +170,7 @@ func getOrchestWebserverDeployment(metadata metav1.ObjectMeta,
 					Image:           image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("20m")},
 					},
 					VolumeMounts: volumeMounts,
 				},

--- a/services/orchest-webserver/app/app/__init__.py
+++ b/services/orchest-webserver/app/app/__init__.py
@@ -12,11 +12,9 @@ import json
 import logging
 import os
 import signal
-import subprocess
 import sys
 from logging.config import dictConfig
 from pprint import pformat
-from subprocess import Popen
 
 import requests
 import werkzeug
@@ -175,25 +173,7 @@ def create_app(to_migrate_db=False):
     register_socketio_broadcast(socketio)
     register_analytics_views(app, db)
 
-    processes = []
-
-    if (
-        os.environ.get("FLASK_ENV") != "development"
-        or _utils.is_running_from_reloader()
-    ):
-        file_dir = os.path.dirname(os.path.realpath(__file__))
-
-        # log_streamer process
-        log_streamer_process = Popen(
-            ["python3", "-m", "scripts.log_streamer"],
-            cwd=os.path.join(file_dir, ".."),
-            stderr=subprocess.STDOUT,
-        )
-
-        app.logger.info("Started log_streamer.py")
-        processes.append(log_streamer_process)
-
-    return app, socketio, processes
+    return app, socketio, []
 
 
 def init_logging():

--- a/services/orchest-webserver/app/scripts/log_streamer.py
+++ b/services/orchest-webserver/app/scripts/log_streamer.py
@@ -282,7 +282,7 @@ def main():
     sio = socketio.Client()
     logging.getLogger("engineio").setLevel(logging.ERROR)
 
-    sio.connect("http://localhost", namespaces=["/pty"])
+    sio.connect("http://localhost", namespaces=["/pty"], wait_timeout=3)
 
     @sio.on("connect", namespace="/pty")
     def on_connect():


### PR DESCRIPTION
Fixes an issue which would lead to having multiple `log_streamer` instances running thus duplicated logs. This can happen if the child of the PID1 gunicorn process dies, leaving the `log_streamer` process to be inherited by PID1. PID1 will start another instance of the application, leading to multiple `log_streamer`s.

Considered alternatives:
- using `prctl`, `subprocess.Popen(["sleep","10000"], preexec_fn=lambda : libc.prctl(1, signal.SIGKILL))`. 2nd favoured solution, I went with a separate container because it feels more native to k8s and decreases complexity, also considering that a webserver and `log-streamer` split will likely have to happen eventually
- checking in the `log_streamer` loop if the parent PID is 1, if so exit: felt like a breach of abstraction

Handwavy diagram
```
-> = parent/child process relationship

# normal state
gunicorn PID1 -> gunicorn C1 -> log_streamer
                             -> webserver threads

# C1 dies
gunicorn PID1 -> log_streamer

# PID1 restarts C1
              -> log_streamer
gunicorn PID1 -> gunicorn C1 -> log_streamer
                             -> webserver threads
 ```