### PR TITLE
Add retries to k8s python sdk

### DIFF
--- a/orchest-cli/orchestcli/cmds.py
+++ b/orchest-cli/orchestcli/cmds.py
@@ -69,11 +69,11 @@ def _get_k8s_api_client() -> ApiClient:
 
 
 API_CLIENT = _get_k8s_api_client()
-APPS_API = client.AppsV1Api(api_client=API_CLIENT)
-CORE_API = client.CoreV1Api(api_client=API_CLIENT)
-CUSTOM_OBJECT_API = client.CustomObjectsApi(api_client=API_CLIENT)
-EXT_API = client.ApiextensionsV1Api(api_client=API_CLIENT)
-RBAC_API = client.RbacAuthorizationV1Api(api_client=API_CLIENT)
+APPS_API = client.AppsV1Api(api_client=_get_k8s_api_client())
+CORE_API = client.CoreV1Api(api_client=_get_k8s_api_client())
+CUSTOM_OBJECT_API = client.CustomObjectsApi(api_client=_get_k8s_api_client())
+EXT_API = client.ApiextensionsV1Api(api_client=_get_k8s_api_client())
+RBAC_API = client.RbacAuthorizationV1Api(api_client=_get_k8s_api_client())
 
 get_namespaced_custom_object = partial(
     CUSTOM_OBJECT_API.get_namespaced_custom_object,

--- a/services/orchest-api/app/app/connections.py
+++ b/services/orchest-api/app/app/connections.py
@@ -1,9 +1,26 @@
 from flask_sqlalchemy import SQLAlchemy
 from kubernetes import client as k8s_client
 from kubernetes import config
+from kubernetes.client.api_client import ApiClient
+from kubernetes.client.configuration import Configuration
 from sqlalchemy import MetaData
+from urllib3.util.retry import Retry
 
 from _orchest.internals import config as _config
+
+
+# Keep in sync with the one in orchest-cli/orchestcli/cmds.py.
+def _get_k8s_api_client() -> ApiClient:
+    configuration = Configuration.get_default_copy()
+    _retry_strategy = Retry(
+        total=5,
+        backoff_factor=1,
+    )
+    # See urllib3 poolmanager.py usage of "retries".
+    configuration.retries = _retry_strategy
+    a = ApiClient(configuration=configuration)
+    return a
+
 
 # This will make it so that constraints and indexes follow a certain
 # naming pattern.
@@ -12,8 +29,8 @@ db = SQLAlchemy(metadata=metadata)
 
 
 config.load_incluster_config()
-k8s_core_api = k8s_client.CoreV1Api()
-k8s_apps_api = k8s_client.AppsV1Api()
-k8s_networking_api = k8s_client.NetworkingV1Api()
-k8s_custom_obj_api = k8s_client.CustomObjectsApi()
-k8s_rbac_api = k8s_client.RbacAuthorizationV1Api()
+k8s_core_api = k8s_client.CoreV1Api(api_client=_get_k8s_api_client())
+k8s_apps_api = k8s_client.AppsV1Api(api_client=_get_k8s_api_client())
+k8s_networking_api = k8s_client.NetworkingV1Api(api_client=_get_k8s_api_client())
+k8s_custom_obj_api = k8s_client.CustomObjectsApi(api_client=_get_k8s_api_client())
+k8s_rbac_api = k8s_client.RbacAuthorizationV1Api(api_client=_get_k8s_api_client())


### PR DESCRIPTION
## Description

Adds retries to the k8s python SDK to reduce failures under system load.

To test, run this script after having killed the `kube-apiserver` container.
```
from kubernetes import client as k8s_client
from kubernetes import config
config.load_config()
from kubernetes.client.api_client import ApiClient
from kubernetes.client.configuration import Configuration
from urllib3.util.retry import Retry

def _get_k8s_api_client() -> ApiClient:
    configuration = Configuration.get_default_copy()
    _retry_strategy = Retry(
        total=5,
        backoff_factor=1,
    )
    # See urllib3 poolmanager.py usage of "retries".
    configuration.retries = _retry_strategy
    a= ApiClient(configuration=configuration)
    return a


k8s_core_api = k8s_client.CoreV1Api(api_client=_get_k8s_api_client())

a = k8s_core_api.list_namespace()
print(len(a.items))

```