### PR TITLE
Don't concurrently push or pull images

### DIFF
--- a/services/node-agent/app/container_runtime.py
+++ b/services/node-agent/app/container_runtime.py
@@ -34,6 +34,13 @@ class OngoingPullForSameImage(ImagePullError):
 
 
 class ContainerRuntime(object):
+    """Class to interface the underlying container runtime.
+
+    This class is meant to be used by a single threaded async
+    application. Given the sets used to keep track of pushes and pulls
+    this class can't be used in a multi process/thread context.
+    """
+
     def __init__(self) -> None:
 
         self.container_runtime = RuntimeType(os.getenv("CONTAINER_RUNTIME"))

--- a/services/node-agent/app/image_deleter.py
+++ b/services/node-agent/app/image_deleter.py
@@ -50,7 +50,7 @@ async def get_active_environment_images(session: aiohttp.ClientSession) -> Set[s
     async with session.get(endpoint) as response:
         response_json = await response.json()
         active_images = response_json["active_environment_images"]
-    logger.info(f"Found the following active env images: {active_images}")
+    logger.debug(f"Found the following active env images: {active_images}")
     return set(active_images)
 
 
@@ -60,7 +60,7 @@ async def get_active_custom_jupyter_images(session: aiohttp.ClientSession) -> Se
     async with session.get(endpoint) as response:
         response_json = await response.json()
         active_custom_jupyter_images = response_json["active_custom_jupyter_images"]
-    logger.info(
+    logger.debug(
         "Found the following active jupyter custom images: "
         f"{active_custom_jupyter_images}"
     )
@@ -175,10 +175,11 @@ async def run():
                             ):
                                 env_images_to_remove_from_node.append(img)
                     env_images_to_remove_from_node.sort()
-                    logger.info(
-                        "Found the following inactive env images on the node: "
-                        f"{env_images_to_remove_from_node}, will be removed."
-                    )
+                    if env_images_to_remove_from_node:
+                        logger.info(
+                            "Found the following inactive env images on the node: "
+                            f"{env_images_to_remove_from_node}, will be removed."
+                        )
 
                     # Find inactive custom jupyter images on the node.
                     active_custom_jupyter_images = (
@@ -192,17 +193,18 @@ async def run():
                             if not await has_ongoing_jupyter_build(session):
                                 custom_jupyter_images_to_remove_from_node.append(img)
                     custom_jupyter_images_to_remove_from_node.sort()
-                    logger.info(
-                        "Found the following inactive custom jupyter images on the "
-                        f"node: {custom_jupyter_images_to_remove_from_node}, will be "
-                        "removed."
-                    )
+                    if custom_jupyter_images_to_remove_from_node:
+                        logger.info(
+                            "Found the following inactive custom jupyter images on the "
+                            f"node: {custom_jupyter_images_to_remove_from_node}, will "
+                            "be removed."
+                        )
 
                     # Find old orchest images on the node.
                     orchest_v = _get_orchest_version()
                     orchest_images_to_remove_from_node = []
                     if orchest_v is not None:
-                        logger.info(
+                        logger.debug(
                             "Looking for Orchest images which version differs from: "
                             f" {orchest_v}."
                         )

--- a/services/node-agent/app/image_puller.py
+++ b/services/node-agent/app/image_puller.py
@@ -3,7 +3,7 @@ import logging
 from enum import Enum
 
 import aiohttp
-from container_runtime import ContainerRuntime
+from container_runtime import ContainerRuntime, OngoingPullForSameImage
 
 from _orchest.internals import config as _config
 from _orchest.internals import utils as _utils
@@ -82,10 +82,6 @@ class ImagePuller(object):
         self.container_runtime = ContainerRuntime()
         self.logger = logging.getLogger("IMAGE_PULLER")
         self.logger.setLevel(image_puller_log_level)
-
-        # Container to make sure that images that are already being
-        # pulled are not pulled concurrently again.
-        self._curr_pulling_imgs = set()
 
     async def _enqueue_pre_pull_orchest_images(
         self, session: aiohttp.ClientSession, queue: asyncio.Queue
@@ -192,10 +188,7 @@ class ImagePuller(object):
 
             should_pull = self.policy == Policy.Always or (
                 self.policy == Policy.IfNotPresent
-                and not (
-                    image_name in self._curr_pulling_imgs
-                    or await self.container_runtime.image_exists(image_name)
-                )
+                and not await self.container_runtime.image_exists(image_name)
             )
 
             for retry in range(self.num_retries):
@@ -225,10 +218,16 @@ class ImagePuller(object):
                     if should_pull:
                         if pulled_successfully:
                             self.logger.info(f"Image '{image_name}' was pulled.")
+                            break
                         else:
                             self.logger.warning(f"Image '{image_name}' was not pulled!")
                     else:
                         break
+                except OngoingPullForSameImage:
+                    self.logger.info(
+                        f"{image_name} is already being pulled, skipping task."
+                    )
+                    break
                 except Exception as ex:
                     self.logger.warning(
                         f"Attempt {retry} to pull image '{image_name}' and notify the "

--- a/services/node-agent/app/image_puller.py
+++ b/services/node-agent/app/image_puller.py
@@ -253,7 +253,10 @@ class ImagePuller(object):
     async def run(self):
         try:
             self.logger.info("Starting image puller.")
-            queue = asyncio.Queue()
+            # maxsize to avoid the queue being filled up with duplicate
+            # work and reduce pressure on the orchest-api when not
+            # needed.
+            queue = asyncio.Queue(maxsize=self.threadiness)
 
             get_images_task = asyncio.create_task(self.get_active_images_to_pull(queue))
             pullers = [

--- a/services/node-agent/app/image_pusher.py
+++ b/services/node-agent/app/image_pusher.py
@@ -19,7 +19,7 @@ import os
 from typing import Set
 
 import aiohttp
-from container_runtime import ContainerRuntime
+from container_runtime import ContainerRuntime, OngoingPushForSameImage
 
 from _orchest.internals import config as _config
 from _orchest.internals import utils as _utils
@@ -134,6 +134,8 @@ async def _push_image(
                 logger.info("Notifying the `orchest-api` of the push.")
                 await notify_orchest_api_of_registry_push(session, image)
 
+            except OngoingPushForSameImage:
+                logger.info(f"{image} is already being pushed, skipping task.")
             except Exception as e:
                 logger.error(f"Failed to push image, {e}.")
             finally:

--- a/services/node-agent/app/image_pusher.py
+++ b/services/node-agent/app/image_pusher.py
@@ -43,7 +43,7 @@ async def get_environment_images_to_push(session: aiohttp.ClientSession) -> Set[
     async with session.get(endpoint) as response:
         response_json = await response.json()
         active_images = response_json["active_environment_images"]
-    logger.info(f"Found the following active env images to push: {active_images}")
+    logger.debug(f"Found the following active env images to push: {active_images}")
     return set(active_images)
 
 
@@ -57,7 +57,7 @@ async def get_jupyter_images_to_push(session: aiohttp.ClientSession) -> Set[str]
     async with session.get(endpoint) as response:
         response_json = await response.json()
         active_images = response_json["active_custom_jupyter_images"]
-    logger.info(
+    logger.debug(
         f"Found the following active custom jupyter images to push: {active_images}"
     )
     return set(active_images)

--- a/services/node-agent/app/image_pusher.py
+++ b/services/node-agent/app/image_pusher.py
@@ -128,7 +128,7 @@ async def _push_image(
             try:
                 image = await queue.get()
                 logger.info("Pushing image to the registry.")
-                # Note: the name already incudes the registry.
+                # Note: the name already includes the registry.
                 await container_runtime.push_image(image)
 
                 logger.info("Notifying the `orchest-api` of the push.")
@@ -144,7 +144,9 @@ async def run(interval: int = 10, threadiness: int = 2) -> None:
     container_runtime = ContainerRuntime()
     logger.info("Starting image pusher.")
     try:
-        queue = asyncio.Queue()
+        # maxsize to avoid the queue being filled up with duplicate work
+        # and reduce pressure on the orchest-api when not needed.
+        queue = asyncio.Queue(maxsize=threadiness)
 
         get_images_task = asyncio.create_task(_queue_images_to_push(queue, interval))
         pushers = [


### PR DESCRIPTION
## Description

Makes it so that the `ContainerRuntime` class does not allow concurrent pushes or pulls of images. This has been done to reduce overhead and avoid some edge cases that have been observed, for example, multiple pushes through `buildah`.

I tried to go for the simplest solution, alternatives related to fiddling with the asyncio queue that holds images to pull or push (or other queues) felt a bit too risky for my tastes.

Also fixes a low impact bug where an image would be pulled multiple times in a row after being pulled successfully