### PR TITLE
Fix: Environment build logs sometimes are failed to render.

### DIFF
--- a/services/orchest-webserver/app/app/socketio_server.py
+++ b/services/orchest-webserver/app/app/socketio_server.py
@@ -87,6 +87,19 @@ def register_build_listener(namespace, socketio):
                     include_self=False,
                     namespace=namespace,
                 )
+            elif data["action"] == "sio_streamed_task_buffer_request":
+
+                # Send the entire buffer.
+                socketio.emit(
+                    "sio_streamed_task_buffer",
+                    {
+                        "identity": data["identity"],
+                        "output": "".join(build_buffer.get(data["identity"], [])),
+                        "action": "sio_streamed_task_buffer",
+                    },
+                    room=request.sid,
+                    namespace=namespace,
+                )
 
 
 def register_socketio_broadcast(socketio):

--- a/services/orchest-webserver/app/app/socketio_server.py
+++ b/services/orchest-webserver/app/app/socketio_server.py
@@ -91,7 +91,7 @@ def register_build_listener(namespace, socketio):
 
                 # Send the entire buffer.
                 socketio.emit(
-                    "sio_streamed_task_buffer",
+                    "sio_streamed_task_data",
                     {
                         "identity": data["identity"],
                         "output": "".join(build_buffer.get(data["identity"], [])),

--- a/services/orchest-webserver/app/app/socketio_server.py
+++ b/services/orchest-webserver/app/app/socketio_server.py
@@ -23,27 +23,6 @@ def register_build_listener(namespace, socketio):
         current_app.logger.info("socket.io client disconnected on /pty")
         disconnect(sid=request.sid, namespace="/pty")
 
-    @socketio.on("connect", namespace=namespace)
-    def connect_build_logger():
-        current_app.logger.info(f"socket.io client connected on {namespace}")
-
-        with lock:
-
-            # send build_buffers
-            for key, value in build_buffer.items():
-
-                # send buffer to new client
-                socketio.emit(
-                    "sio_streamed_task_data",
-                    {
-                        "identity": key,
-                        "output": "".join(value),
-                        "action": "sio_streamed_task_output",
-                    },
-                    room=request.sid,
-                    namespace=namespace,
-                )
-
     @socketio.on("disconnect", namespace=namespace)
     def disconnect_build_logger():
         current_app.logger.info(f"socket.io client disconnected on {namespace}")

--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -62,6 +62,7 @@ export const ImageBuildLog = ({
     [streamIdentity]
   );
   React.useEffect(() => {
+    socket?.emit("logs");
     socket?.on("sio_streamed_task_data", socketEventListener);
     return () => {
       socket?.off("sio_streamed_task_data", socketEventListener);

--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -50,20 +50,20 @@ export const ImageBuildLog = ({
   const socket = useSocketIO(socketIONamespace);
   const socketEventListener = React.useCallback(
     (data: { action: string; identity: string; output?: string }) => {
-      if (!streamIdentity) return;
-      if (data.identity === streamIdentity) {
-        if (data["action"] == "sio_streamed_task_started") {
-          xtermRef.current?.terminal.reset();
-        }
+      if (!streamIdentity || data.identity !== streamIdentity) return;
 
-        const shouldPrint = [
-          "sio_streamed_task_output",
-          "sio_streamed_task_buffer",
-        ].includes(data.action);
+      if (data["action"] == "sio_streamed_task_started") {
+        xtermRef.current?.terminal.reset();
+        return;
+      }
 
-        if (shouldPrint) {
-          printLogs(data.output);
-        }
+      const shouldPrintLogs = [
+        "sio_streamed_task_output",
+        "sio_streamed_task_buffer",
+      ].includes(data.action);
+
+      if (shouldPrintLogs) {
+        printLogs(data.output);
       }
     },
     [streamIdentity, printLogs]

--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -39,35 +39,47 @@ export const ImageBuildLog = ({
     }
   }, [fitAddon, xtermRef]);
 
+  const printLogs = React.useCallback((logs: string | undefined) => {
+    const lines = (logs || "").split("\n");
+    for (let x = 0; x < lines.length; x++) {
+      if (x > 0) xtermRef.current?.terminal.write("\n\r");
+      xtermRef.current?.terminal.write(lines[x]);
+    }
+  }, []);
+
   const socket = useSocketIO(socketIONamespace);
   const socketEventListener = React.useCallback(
     (data: { action: string; identity: string; output?: string }) => {
       if (!streamIdentity) return;
-      // ignore terminal outputs from other builds
       if (data.identity === streamIdentity) {
-        if (data.action === "sio_streamed_task_output") {
-          const lines = (data.output || "").split("\n");
-          for (let x = 0; x < lines.length; x++) {
-            if (x > 0) xtermRef.current?.terminal.write("\n\r");
-            xtermRef.current?.terminal.write(lines[x]);
-          }
-        } else if (data["action"] == "sio_streamed_task_started") {
-          // This blocking mechanism makes sure old build logs are
-          // not displayed after the user has started a build
-          // during an ongoing build.
+        if (data["action"] == "sio_streamed_task_started") {
           xtermRef.current?.terminal.reset();
+        }
+
+        const shouldPrint = [
+          "sio_streamed_task_output",
+          "sio_streamed_task_buffer",
+        ].includes(data.action);
+
+        if (shouldPrint) {
+          printLogs(data.output);
         }
       }
     },
-    [streamIdentity]
+    [streamIdentity, printLogs]
   );
   React.useEffect(() => {
-    socket?.emit("logs");
-    socket?.on("sio_streamed_task_data", socketEventListener);
+    if (streamIdentity) {
+      socket?.emit("sio_streamed_task_data", {
+        action: "sio_streamed_task_buffer_request",
+        identity: streamIdentity,
+      });
+      socket?.on("sio_streamed_task_data", socketEventListener);
+    }
     return () => {
       socket?.off("sio_streamed_task_data", socketEventListener);
     };
-  }, [socket, xtermRef, socketEventListener]);
+  }, [socket, xtermRef, socketEventListener, streamIdentity]);
 
   React.useEffect(() => {
     fitTerminal();

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
@@ -41,15 +41,13 @@ const useSocketIOStore = create<SocketIO>((set) => ({
 
 export const useSocketIO = (namespace: string | undefined) => {
   const init = useSocketIOStore((state) => state.init);
-  const disconnect = useSocketIOStore((state) => state.disconnect);
   const socket = useSocketIOStore((state) =>
     namespace ? state.sockets[namespace] : undefined
   );
 
   React.useEffect(() => {
-    init(namespace);
-    return () => disconnect(namespace);
-  }, [init, namespace, disconnect]);
+    if (namespace) init(namespace);
+  }, [init, namespace]);
 
   return socket;
 };

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useSocketIO.tsx
@@ -1,3 +1,4 @@
+import { useFocusBrowserTab } from "@/hooks/useFocusBrowserTab";
 import React from "react";
 import { io, Socket } from "socket.io-client";
 import create from "zustand";
@@ -40,14 +41,22 @@ const useSocketIOStore = create<SocketIO>((set) => ({
 }));
 
 export const useSocketIO = (namespace: string | undefined) => {
+  const isBrowserTabFocused = useFocusBrowserTab();
   const init = useSocketIOStore((state) => state.init);
+  const disconnect = useSocketIOStore((state) => state.disconnect);
   const socket = useSocketIOStore((state) =>
     namespace ? state.sockets[namespace] : undefined
   );
 
   React.useEffect(() => {
-    if (namespace) init(namespace);
-  }, [init, namespace]);
+    if (!namespace) return;
+
+    if (isBrowserTabFocused) {
+      init(namespace);
+    } else {
+      disconnect(namespace);
+    }
+  }, [init, namespace, isBrowserTabFocused, disconnect]);
 
   return socket;
 };


### PR DESCRIPTION
## Description

Environment build logs sometimes failed to render because socket.io failed to reconnect immediately after being disconnected. This connect and disconnect is actually not necessary, as FE could just continue using the same connection. 

This PR made the following changes to remove the unnecessary disconnect:
- BE doesn't send logs on connect.
- FE sends a request to get logs when needed.
- FE doesn't disconnect until the browser tab is closed.


## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
