### PR TITLE
Right align ellipsis menu in projects table

### DIFF
--- a/services/orchest-webserver/client/src/projects-view/ProjectsTable.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ProjectsTable.tsx
@@ -57,7 +57,7 @@ export const ProjectsTable = ({
       {
         id: "settings",
         label: "",
-        sx: { margin: (theme) => theme.spacing(-0.5, 0) },
+        sx: { margin: (theme) => theme.spacing(-0.5, 0), textAlign: "right" },
         render: function ProjectSettingsButton(row, disabled) {
           return !projectsBeingDeleted.includes(row.uuid) ? (
             <IconButton


### PR DESCRIPTION
## Description

Fixes: [ORC-933](https://linear.app/orchest/issue/ORC-933/right-align-ellipses-menu-with-16px-margin-in-project-table-on)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
