### PR TITLE
Tweak CPU resource requests

### DIFF
--- a/services/orchest-controller/pkg/controller/orchestcomponent/celery_worker.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/celery_worker.go
@@ -123,7 +123,7 @@ func getCeleryWorkerDeployment(metadata metav1.ObjectMeta,
 					Image: image,
 					Env:   component.Spec.Template.Env,
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
 					},
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					VolumeMounts: []corev1.VolumeMount{

--- a/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/orchest_api.go
@@ -209,7 +209,7 @@ func getOrchestApiDeployment(metadata metav1.ObjectMeta,
 					Env:          utils.GetEnvVarFromMap(envMap),
 					VolumeMounts: volumeMounts,
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
 					},
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
### Description
Tweaks are based on recommendations of VPA whilst cluster was put CPU load either by a single threaded process and/or concurrently running jobs. In both scenarios Orchest should operate without issue, even on single-node.

https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler

These changes should mitigate issues when the cluster is under load.