### PR TITLE
Fix: Duplicated Environment build logs when switching browser tabs.

### DIFF
--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -9,7 +9,7 @@ import { ImageBuildStatus } from "./ImageBuildStatus";
 
 type ImageBuildLogProps = {
   build?: EnvironmentImageBuild;
-  ignoreIncomingLogs: boolean;
+  shouldCleanLogs: boolean;
   socketIONamespace?: string;
   streamIdentity: string | undefined;
   hideDefaultStatus?: boolean;
@@ -17,7 +17,7 @@ type ImageBuildLogProps = {
 
 export const ImageBuildLog = ({
   build,
-  ignoreIncomingLogs,
+  shouldCleanLogs,
   socketIONamespace = "",
   streamIdentity,
   hideDefaultStatus,
@@ -90,10 +90,10 @@ export const ImageBuildLog = ({
   }, [fitTerminal]);
 
   React.useEffect(() => {
-    if (ignoreIncomingLogs) {
+    if (shouldCleanLogs) {
       xtermRef.current?.terminal.reset();
     }
-  }, [ignoreIncomingLogs, xtermRef]);
+  }, [shouldCleanLogs, xtermRef]);
 
   useEscapeToBlur();
 

--- a/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildLog.tsx
@@ -41,10 +41,10 @@ export const ImageBuildLog = ({
 
   const printLogs = React.useCallback((logs: string | undefined) => {
     const lines = (logs || "").split("\n");
-    for (let x = 0; x < lines.length; x++) {
-      if (x > 0) xtermRef.current?.terminal.write("\n\r");
-      xtermRef.current?.terminal.write(lines[x]);
-    }
+    lines.forEach((line, index) => {
+      if (index > 0) xtermRef.current?.terminal.write("\n\r");
+      xtermRef.current?.terminal.write(line);
+    });
   }, []);
 
   const socket = useSocketIO(socketIONamespace);

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
@@ -41,7 +41,7 @@ export const EnvironmentImageBuildLogs = () => {
   // Rest logs upon disconnection, in order to prevent duplicated logs when connections is re-established.
   const isBrowserTabFocused = useFocusBrowserTab();
 
-  const ignoreIncomingLogs =
+  const shouldCleanLogs =
     !isBrowserTabFocused ||
     isTriggeringBuild ||
     streamIdentity !== streamIdentityFromStore;
@@ -58,7 +58,7 @@ export const EnvironmentImageBuildLogs = () => {
       </AccordionSummary>
       <AccordionDetails>
         <ImageBuildLog
-          ignoreIncomingLogs={ignoreIncomingLogs}
+          shouldCleanLogs={shouldCleanLogs}
           hideDefaultStatus
           build={latestBuild}
           socketIONamespace={

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
@@ -7,6 +7,7 @@ import {
 import { ImageBuildLog } from "@/components/ImageBuildLog";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { useFocusBrowserTab } from "@/hooks/useFocusBrowserTab";
 import Typography from "@mui/material/Typography";
 import { hasValue } from "@orchest/lib-utils";
 import "codemirror/mode/shell/shell";
@@ -36,9 +37,14 @@ export const EnvironmentImageBuildLogs = () => {
       : undefined;
 
   const streamIdentityFromStore = `${environmentChangesProjectUuid}-${uuid}`;
+  // SocketIO connection is disconnected when browser tab loses focus.
+  // Rest logs upon disconnection, in order to prevent duplicated logs when connections is re-established.
+  const isBrowserTabFocused = useFocusBrowserTab();
 
   const ignoreIncomingLogs =
-    isTriggeringBuild || streamIdentity !== streamIdentityFromStore;
+    !isBrowserTabFocused ||
+    isTriggeringBuild ||
+    streamIdentity !== streamIdentityFromStore;
 
   return (
     <Accordion defaultExpanded>


### PR DESCRIPTION
## Description

When the browser tab loses and regains focus, Environment build logs are printed again.
This PR resets the logs when the browser tab loses focus.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
