### PR TITLE
fix: Hide Intercom when the side panel or a Snackbar appears.

### DIFF
--- a/services/orchest-webserver/client/src/components/common/SnackBar.tsx
+++ b/services/orchest-webserver/client/src/components/common/SnackBar.tsx
@@ -1,0 +1,21 @@
+import { useHideIntercom } from "@/hooks/useHideIntercom";
+import MuiSnackbar, { SnackbarProps } from "@mui/material/Snackbar";
+import React from "react";
+
+export const SnackBar = (props: SnackbarProps) => {
+  const isShowingSnackbar = React.useMemo(() => {
+    return (
+      Boolean(props.open) &&
+      props.anchorOrigin?.vertical === "bottom" &&
+      props.anchorOrigin?.horizontal === "right"
+    );
+  }, [
+    props.open,
+    props.anchorOrigin?.vertical,
+    props.anchorOrigin?.horizontal,
+  ]);
+
+  useHideIntercom(isShowingSnackbar);
+
+  return <MuiSnackbar {...props} />;
+};

--- a/services/orchest-webserver/client/src/hooks/useHideIntercom.tsx
+++ b/services/orchest-webserver/client/src/hooks/useHideIntercom.tsx
@@ -1,0 +1,18 @@
+import { useGlobalContext } from "@/contexts/GlobalContext";
+import React from "react";
+
+/** Hide Intercom in case the UI component is blocked by it */
+export const useHideIntercom = (
+  shouldHidIntercom: boolean,
+  shouldAutoShow = true
+) => {
+  const { hideIntercom, showIntercom } = useGlobalContext();
+
+  React.useEffect(() => {
+    if (shouldHidIntercom) {
+      hideIntercom();
+    } else if (shouldAutoShow) {
+      showIntercom();
+    }
+  }, [shouldHidIntercom, hideIntercom, showIntercom, shouldAutoShow]);
+};

--- a/services/orchest-webserver/client/src/jobs-view/job-view/WebhookHint.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/WebhookHint.tsx
@@ -1,3 +1,4 @@
+import { SnackBar } from "@/components/common/SnackBar";
 import { useAppContext } from "@/contexts/AppContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useHasChanged } from "@/hooks/useHasChanged";
@@ -6,7 +7,6 @@ import { siteMap } from "@/routingConfig";
 import CloseIcon from "@mui/icons-material/Close";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
-import Snackbar from "@mui/material/Snackbar";
 import React from "react";
 import { useEditJob } from "../stores/useEditJob";
 
@@ -60,7 +60,7 @@ export const WebhookHint = () => {
   );
 
   return (
-    <Snackbar
+    <SnackBar
       open={showHint}
       autoHideDuration={6000}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}

--- a/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJob.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJob.tsx
@@ -1,3 +1,4 @@
+import { useHideIntercom } from "@/hooks/useHideIntercom";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 import { usePipelineUiStateContext } from "../contexts/PipelineUiStateContext";
@@ -8,9 +9,15 @@ export const ScheduleJob = () => {
   const {
     uiState: { draftJob },
   } = usePipelineUiStateContext();
+  const isPanelOpen = hasValue(draftJob);
+  // Disable auto-show.
+  // Snackbar will appear right after closing the panel.
+  // Intercom should stay hidden.
+  useHideIntercom(isPanelOpen, false);
+
   return (
     <>
-      {hasValue(draftJob) && <ScheduleJobPanel />}
+      {isPanelOpen && <ScheduleJobPanel />}
       <ScheduleJobSnackBar />
     </>
   );

--- a/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobSnackBar.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobSnackBar.tsx
@@ -1,7 +1,7 @@
+import { SnackBar } from "@/components/common/SnackBar";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { siteMap } from "@/routingConfig";
 import Button from "@mui/material/Button";
-import Snackbar from "@mui/material/Snackbar";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 import create from "zustand";
@@ -48,7 +48,7 @@ export const ScheduleJobSnackBar = () => {
   };
 
   return (
-    <Snackbar
+    <SnackBar
       open={hasValue(snackBarMessage)}
       anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       autoHideDuration={3000}

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -1,6 +1,7 @@
 import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
+import { SnackBar } from "@/components/common/SnackBar";
 import { Layout } from "@/components/layout/Layout";
 import { LegacyImageBuildLog } from "@/components/legacy/LegacyImageBuildLog";
 import { useGlobalContext } from "@/contexts/GlobalContext";
@@ -15,7 +16,6 @@ import SaveIcon from "@mui/icons-material/Save";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import LinearProgress from "@mui/material/LinearProgress";
-import Snackbar from "@mui/material/Snackbar";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { hasValue, uuidv4 } from "@orchest/lib-utils";
@@ -309,7 +309,7 @@ const ConfigureJupyterLabView: React.FC = () => {
           <LinearProgress />
         )}
       </Box>
-      <Snackbar
+      <SnackBar
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         open={showStoppingAllSessionsWarning}
         message="Stopping all active sessions..."


### PR DESCRIPTION
## Description

Intercom should be hidden when the side panel in Pipeline Editor or a bottom-right Snackbar appears.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
