### PR TITLE
Fix "session already exists"-error

### DIFF
--- a/lib/javascript/utils/src/fetcher.ts
+++ b/lib/javascript/utils/src/fetcher.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export class FetchError<B = any> extends Error {
+  readonly name = "FetchError";
   readonly status?: number;
   readonly body?: B;
 

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -7,7 +7,7 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useHasChanged } from "@/hooks/useHasChanged";
 import { siteMap } from "@/routingConfig";
-import { hasValue } from "@orchest/lib-utils";
+import { FetchError, hasValue } from "@orchest/lib-utils";
 import React from "react";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 
@@ -60,6 +60,7 @@ export const useAutoStartSession = () => {
         BUILD_IMAGE_SOLUTION_VIEW.PIPELINE
       );
       if (result === true) return;
+      if (result instanceof FetchError && result.status === 409) return; // When the session already exists, you get a 409 (CONFLICT).
       if (result.message === "environmentsBuildInProgress") return;
       if (result.message === "JupyterEnvironmentBuildInProgress") {
         dispatch({


### PR DESCRIPTION
## Description

This can can happen when the request to start the session is fired before the session has is fetched.
This error can safely be ignored, but as a follow-up, the root-cause should also be investigated.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.