### PR TITLE
fix: Header should be hidden if no items available in Environments and Jobs

### DIFF
--- a/services/orchest-webserver/client/src/environments-view/EnvironmentsView.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentsView.tsx
@@ -1,3 +1,4 @@
+import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import { ViewLayout } from "@/components/layout/ViewLayout";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
@@ -9,10 +10,14 @@ import { EnvironmentMenuList } from "./EnvironmentMenuList";
 export const EnvironmentsView = () => {
   useSendAnalyticEvent("view:loaded", { name: siteMap.environments.path });
 
+  const hasEnvironments = useEnvironmentsApi(
+    (state) => state.environments?.length !== 0
+  );
+
   return (
     <ViewLayout
       sidePanel={<EnvironmentMenuList />}
-      header={() => <EnvironmentHeader />}
+      header={hasEnvironments ? () => <EnvironmentHeader /> : undefined}
     >
       <EditEnvironment />
     </ViewLayout>

--- a/services/orchest-webserver/client/src/jobs-view/JobsView.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/JobsView.tsx
@@ -1,3 +1,4 @@
+import { useJobsApi } from "@/api/jobs/useJobsApi";
 import { ViewLayout } from "@/components/layout/ViewLayout";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
@@ -8,9 +9,13 @@ import { JobMenuList } from "./JobMenuList";
 
 export const JobsView = () => {
   useSendAnalyticEvent("view:loaded", { name: siteMap.environments.path });
+  const hasJobs = useJobsApi((state) => state.jobs?.length !== 0);
 
   return (
-    <ViewLayout sidePanel={<JobMenuList />} header={() => <JobHeader />}>
+    <ViewLayout
+      sidePanel={<JobMenuList />}
+      header={hasJobs ? () => <JobHeader /> : undefined}
+    >
       <JobView />
     </ViewLayout>
   );


### PR DESCRIPTION
## Description

The header should be hidden if there's no item in the views of Environments and Jobs.

Fix: #1365 

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
