### PR TITLE
Fix: Orchest version should be refreshed after being updated.

### DIFF
--- a/services/orchest-webserver/client/src/contexts/AppContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/AppContext.tsx
@@ -9,6 +9,7 @@ import { useAutoFetchPipelines } from "./useAutoFetchPipelines";
 
 export type AppContextType = {
   orchestVersion: string | null | undefined;
+  fetchOrchestVersion: () => Promise<string | void | null | undefined>;
   checkUpdate: () => Promise<void>;
   webhooks: NotificationWebhookSubscriber[];
   setWebhooks: StateDispatcher<NotificationWebhookSubscriber[]>;
@@ -22,7 +23,7 @@ export const AppContext = React.createContext<AppContextType>(
 export const useAppContext = () => React.useContext(AppContext);
 
 export const AppContextProvider: React.FC = ({ children }) => {
-  const { checkUpdate, orchestVersion } = useCheckUpdate();
+  const { checkUpdate, fetchOrchestVersion, orchestVersion } = useCheckUpdate();
   const {
     subscribers: webhooks = [],
     setSubscribers: setWebhooks,
@@ -45,6 +46,7 @@ export const AppContextProvider: React.FC = ({ children }) => {
       value={{
         checkUpdate,
         orchestVersion,
+        fetchOrchestVersion,
         webhooks,
         setWebhooks,
         fetchWebhooks,

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/CustomImageDetails.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/CustomImageDetails.tsx
@@ -30,7 +30,7 @@ const DEFAULT_FORM_STATE: CustomImage = {
   gpu_support: false,
 };
 
-export const isDefaultImage = (baseImage: string) => {
+const isDefaultImage = (baseImage: string) => {
   baseImage = baseImage.toLowerCase().trim();
 
   return DEFAULT_BASE_IMAGES.some((image) => baseImage === image.base_image);

--- a/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
+++ b/services/orchest-webserver/client/src/hooks/useCheckUpdate.tsx
@@ -80,7 +80,7 @@ const useLatestVersion = () => {
 };
 
 const useVersionsPoller = () => {
-  const { orchestVersion } = useOrchestVersion();
+  const { orchestVersion, fetchOrchestVersion } = useOrchestVersion();
   const { latestVersion, fetchLatestVersion } = useLatestVersion();
 
   // Only check the latest version every hour, because the latest Orchest version gets
@@ -89,7 +89,7 @@ const useVersionsPoller = () => {
     fetchLatestVersion();
   }, 3600000);
 
-  return { orchestVersion, latestVersion };
+  return { orchestVersion, fetchOrchestVersion, latestVersion };
 };
 
 // To limit the number of api calls and make sure only one prompt is shown,
@@ -110,7 +110,11 @@ export const useCheckUpdate = () => {
     siteMap.settings,
     siteMap.help,
   ]);
-  const { orchestVersion, latestVersion } = useVersionsPoller();
+  const {
+    orchestVersion,
+    fetchOrchestVersion,
+    latestVersion,
+  } = useVersionsPoller();
 
   const promptUpdate = React.useCallback(
     (localVersion: string, versionToUpdate: string) => {
@@ -206,5 +210,5 @@ export const useCheckUpdate = () => {
     location,
   ]);
 
-  return { orchestVersion, checkUpdate };
+  return { orchestVersion, fetchOrchestVersion, checkUpdate };
 };

--- a/services/orchest-webserver/client/src/views/UpdateView.tsx
+++ b/services/orchest-webserver/client/src/views/UpdateView.tsx
@@ -1,6 +1,7 @@
 import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { ConsoleOutput } from "@/components/ConsoleOutput";
 import { Layout } from "@/components/layout/Layout";
+import { useAppContext } from "@/contexts/AppContext";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import {
   useCancelableFetch,
@@ -19,6 +20,7 @@ import React from "react";
 
 const UpdateView: React.FC = () => {
   const { setConfirm, setAlert } = useGlobalContext();
+  const { fetchOrchestVersion } = useAppContext();
   useSendAnalyticEvent("view:loaded", { name: siteMap.update.path });
 
   const { cancelableFetch } = useCancelableFetch();
@@ -126,6 +128,7 @@ const UpdateView: React.FC = () => {
             ...prevState,
             updating: false,
           }));
+          fetchOrchestVersion();
           setUpdatePollInterval(null);
         } else {
           setState((prevState) => ({


### PR DESCRIPTION
## Description

Currently FE only fetches Orchest version once, on launch. However, it will no longer be correct after updating Orchest to the latest version, unless user refresh the page. This is causing some other issues, e.g. the latest Environment image is seen as a custom image. This PR makes it so that it will refetch Orchest version right after updating succeeded.

Note: it's quite tricky to test it locally. Because running in dev mode doesn't really allow you to update to a _real_ version, which always results in the same version. Nevertheless, this PR should fix the said issue. 😅

## Checklist

- [x] The PR branch is set up to merge into `dev` instead of `master`.
