### PR TITLE
Do not persist base image version by default

### DIFF
--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -127,7 +127,7 @@ DEFAULT_SETUP_SCRIPT = """#!/bin/bash
 DEFAULT_ENVIRONMENTS = [
     {
         "name": "Python 3",
-        "base_image": f'orchest/base-kernel-py:{os.getenv("ORCHEST_VERSION")}',
+        "base_image": "orchest/base-kernel-py",
         "language": "python",
         "setup_script": DEFAULT_SETUP_SCRIPT,
         "gpu_support": False,

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useLoadSelectedBaseImage.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/hooks/useLoadSelectedBaseImage.tsx
@@ -1,4 +1,3 @@
-import { useAppContext } from "@/contexts/AppContext";
 import { DEFAULT_BASE_IMAGES } from "@/environments-view/common";
 import { useEditEnvironment } from "@/environments-view/stores/useEditEnvironment";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
@@ -26,7 +25,6 @@ export const getDefaultImageFromEnvironment = (
  * Performs a side effect that loads selected base image into the store when query args change.
  */
 export const useLoadSelectedBaseImage = () => {
-  const { orchestVersion } = useAppContext();
   const { environmentUuid, projectUuid } = useCustomRoute();
   const environmentChangesProjectUuid = useEditEnvironment(
     (state) => state.environmentChanges?.project_uuid
@@ -60,21 +58,16 @@ export const useLoadSelectedBaseImage = () => {
         gpu_support: gpuSupport,
         language,
       } as CustomImage;
-      // From the BE perspective, `orchest/base-kernel-py` means latest, equivalent to `orchest/base-kernel-py:${current_orchest_version}`.
-      // If the image is, for example, orchest/base-kernel-py, BE will fill the latest matching version of the image, e.g. `orchest/base-kernel-py:v2022.05.3`.
-      // User could still choose to use an older version of the Orchest default image, e.g. `orchest/base-kernel-py:v2022.05.1`.
-      // Then this is considered as a custom image, because user choose to specify an image themselves, so do the other non-Orchest images.
-      const selectedDefaultImage = getDefaultImageFromEnvironment(
-        baseImage,
-        orchestVersion
+
+      const foundDefaultImage = DEFAULT_BASE_IMAGES.find(
+        (image) => image.base_image === baseImage
       );
 
-      setSelectedImage(uuid, selectedDefaultImage || savedImage);
-      if (!selectedDefaultImage) setCustomImage(uuid, savedImage);
+      setSelectedImage(uuid, savedImage);
+      if (!foundDefaultImage) setCustomImage(uuid, savedImage);
     }
   }, [
     hasDataFetched,
-    orchestVersion,
     setCustomImage,
     setSelectedImage,
     baseImage,


### PR DESCRIPTION
## Description

Fixes an issue where, unintentionally, the version of the base image was persisted in the environment properties. This led to the image being recognized as a custom image after an update despite being an Orchest base image.
