### PR TITLE
Offset pipeline starting position if read-only banner is showing

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -1,4 +1,3 @@
-import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
 import { FileTree } from "@/types";
 import {
   isSamePoint,
@@ -54,18 +53,10 @@ const PipelineViewportComponent = React.forwardRef<HTMLDivElement, BoxProps>(
     ref
   ) {
     const { dragFile, fileTrees } = useFileManagerContext();
-    const {
-      disabled,
-      pipelineCwd,
-      isFetchingPipelineJson,
-    } = usePipelineDataContext();
+    const { disabled, isFetchingPipelineJson } = usePipelineDataContext();
     const isFileTreeLoaded = React.useMemo(
       () => Object.keys(fileTrees).length > 0,
       [fileTrees]
-    );
-
-    const environments = useEnvironmentsApi(
-      (state) => state.environments || []
     );
 
     const { scaleFactor, canvasPointAtPointer } = useCanvasScaling();

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/PipelineViewport.tsx
@@ -1,10 +1,5 @@
 import { FileTree } from "@/types";
-import {
-  isSamePoint,
-  Point2D,
-  stringifyPoint,
-  subtractPoints,
-} from "@/utils/geometry";
+import { Point2D, stringifyPoint, subtractPoints } from "@/utils/geometry";
 import { hasExtension } from "@/utils/path";
 import { setRefs } from "@/utils/refs";
 import Box, { BoxProps } from "@mui/material/Box";
@@ -12,10 +7,7 @@ import GlobalStyles from "@mui/material/GlobalStyles";
 import { ALLOWED_STEP_EXTENSIONS } from "@orchest/lib-utils";
 import classNames from "classnames";
 import React from "react";
-import {
-  DEFAULT_SCALE_FACTOR,
-  useCanvasScaling,
-} from "../contexts/CanvasScalingContext";
+import { useCanvasScaling } from "../contexts/CanvasScalingContext";
 import { usePipelineCanvasContext } from "../contexts/PipelineCanvasContext";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 import { usePipelineRefs } from "../contexts/PipelineRefsContext";
@@ -23,10 +15,7 @@ import { usePipelineUiStateContext } from "../contexts/PipelineUiStateContext";
 import { useFileManagerContext } from "../file-manager/FileManagerContext";
 import { useValidateFilesOnSteps } from "../file-manager/useValidateFilesOnSteps";
 import { useCreateStep } from "../hooks/useCreateStep";
-import {
-  INITIAL_PIPELINE_OFFSET,
-  PIPELINE_CANVAS_SIZE,
-} from "../hooks/usePipelineCanvasState";
+import { PIPELINE_CANVAS_SIZE } from "../hooks/usePipelineCanvasState";
 import { STEP_HEIGHT, STEP_WIDTH } from "../PipelineStep";
 import { FullViewportHolder } from "./components/FullViewportHolder";
 import { useViewportMouseEvents } from "./hooks/useViewportMouseEvents";
@@ -80,21 +69,11 @@ const PipelineViewportComponent = React.forwardRef<HTMLDivElement, BoxProps>(
         pipelineOrigin,
         pipelineCanvasOffset,
       },
-      setPipelineCanvasOrigin,
     } = usePipelineCanvasContext();
 
     const localRef = React.useRef<HTMLDivElement | null>(null);
 
     useViewportMouseEvents();
-
-    React.useEffect(() => {
-      if (
-        isSamePoint(pipelineOffset, INITIAL_PIPELINE_OFFSET) &&
-        scaleFactor === DEFAULT_SCALE_FACTOR
-      ) {
-        setPipelineCanvasOrigin([0, 0]);
-      }
-    }, [scaleFactor, pipelineOffset, setPipelineCanvasOrigin]);
 
     const onMouseDown = (event: React.MouseEvent) => {
       if (disabled || contextMenuUuid || !pipelineCanvasRef.current) return;

--- a/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportKeyboardEvents.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/pipeline-viewport/hooks/useViewportKeyboardEvents.tsx
@@ -172,7 +172,7 @@ export const useViewportKeyboardEvents = () => {
   React.useEffect(resetPipelineCanvas, [changedPipeline, resetPipelineCanvas]);
 
   // Apply the offset if readonly is set to true and the canvas hasn't moved
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!isReadOnly) return;
 
     setPipelineCanvasState((current) => {


### PR DESCRIPTION
## Description

If you open a pipeline editor where the steps are located close to `[0, 0]` in the canvas, the read-only banner covers them, which is undesired:

<img width="1637" alt="CleanShot 2022-10-13 at 10 39 29@2x" src="https://user-images.githubusercontent.com/8259221/195582436-187781d7-c4b3-4a1e-9a7f-b28e60511874.png">

This PR fixes that so that the starting position is offset when the banner is showing. If the user hasn't moved away from the starting position when the banner goes away, the offset is also automatically removed.

![image (1)](https://user-images.githubusercontent.com/8259221/195582917-99c8888c-0a26-4fc3-b2c9-628ee6e6f4af.png)

This offset triggers on any read-only state in the editor, so it automatically supports all banners.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.