### PR TITLE
fix: Jupyter Image doesn't build if active sessions.

### DIFF
--- a/services/orchest-webserver/client/src/components/ImageBuildStatus.tsx
+++ b/services/orchest-webserver/client/src/components/ImageBuildStatus.tsx
@@ -1,4 +1,4 @@
-import { EnvironmentImageBuild } from "@/types";
+import { EnvironmentImageBuild, JupyterImageBuild } from "@/types";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DoDisturbOnOutlinedIcon from "@mui/icons-material/DoDisturbOnOutlined";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
@@ -53,7 +53,7 @@ export const ImageBuildStatus = ({
   build,
   sx,
 }: {
-  build: EnvironmentImageBuild | undefined;
+  build: EnvironmentImageBuild | JupyterImageBuild | undefined;
   sx?: SxProps<Theme>;
 }) => {
   const inProgress = ["PENDING", "STARTED"].includes(build?.status || "");

--- a/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
+++ b/services/orchest-webserver/client/src/components/legacy/LegacyImageBuildLog.tsx
@@ -1,7 +1,7 @@
 import { useFetcher } from "@/hooks/useFetcher";
 import { useInterval } from "@/hooks/useInterval";
 import { useSocketIO } from "@/pipeline-view/hooks/useSocketIO";
-import { EnvironmentImageBuild } from "@/types";
+import { EnvironmentImageBuild, JupyterImageBuild } from "@/types";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
@@ -49,7 +49,7 @@ const useFetchEnvironmentBuild = ({
 };
 
 type ImageBuildLogProps = {
-  build: EnvironmentImageBuild | undefined;
+  build: EnvironmentImageBuild | JupyterImageBuild | undefined;
   ignoreIncomingLogs: boolean;
   buildRequestEndpoint: string;
   buildsKey: string;

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -206,6 +206,14 @@ export type EnvironmentImageBuild = {
   celery_task_uuid: string;
 };
 
+export type JupyterImageBuild = {
+  finished_time: null | string;
+  requested_time: string;
+  started_time: null | string;
+  status: TStatus;
+  uuid: string;
+};
+
 export type PipelineStepStatus =
   | "STARTED"
   | "SUCCESS"

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -9,7 +9,7 @@ import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
-import { EnvironmentImageBuild } from "@/types";
+import { JupyterImageBuild } from "@/types";
 import CloseIcon from "@mui/icons-material/Close";
 import MemoryIcon from "@mui/icons-material/Memory";
 import SaveIcon from "@mui/icons-material/Save";
@@ -47,7 +47,7 @@ const ConfigureJupyterLabView: React.FC = () => {
   // local states
   const [ignoreIncomingLogs, setIgnoreIncomingLogs] = React.useState(false);
   const [jupyterBuild, setJupyterEnvironmentBuild] = React.useState<
-    EnvironmentImageBuild | undefined
+    JupyterImageBuild | undefined
   >(undefined);
 
   const [isBuildingImage, setIsBuildingImage] = React.useState(false);
@@ -95,17 +95,15 @@ const ConfigureJupyterLabView: React.FC = () => {
 
     try {
       await save();
-      let response = await cancelableFetch<{ jupyter_image_build: any }>(
-        "/catch/api-proxy/api/jupyter-builds",
-        { method: "POST" }
-      );
+      const response = await cancelableFetch<{
+        jupyter_image_build: JupyterImageBuild;
+      }>("/catch/api-proxy/api/jupyter-builds", { method: "POST" });
 
-      setJupyterEnvironmentBuild(response["jupyter_image_build"]);
+      setJupyterEnvironmentBuild(response.jupyter_image_build);
     } catch (error) {
       if (!error.isCanceled) {
         setIgnoreIncomingLogs(false);
-
-        if (error.message === "SessionInProgressException") {
+        if (error.body?.message === "SessionInProgressException") {
           setConfirm(
             "Warning",
             <>
@@ -137,7 +135,7 @@ const ConfigureJupyterLabView: React.FC = () => {
       }
     }
     setIsBuildingImage(false);
-  }, [deleteAllSessions, save, setAlert, setConfirm]);
+  }, [deleteAllSessions, save, setAlert, setConfirm, cancelableFetch]);
 
   const cancelImageBuild = async () => {
     // send DELETE to cancel ongoing build
@@ -179,7 +177,7 @@ const ConfigureJupyterLabView: React.FC = () => {
     } catch (e) {
       setAlert("Error", `Failed to fetch setup script. ${e}`);
     }
-  }, [setAlert]);
+  }, [setAlert, cancelableFetch]);
 
   React.useEffect(() => {
     getSetupScript();


### PR DESCRIPTION
## Description

When attempting to build JupyterLab image with active sessions, it should prompt user a warning with a call to action. This dialog doesn't appear due to some breaking changes on FE (i.e. FetchError refactor). This PR fixes this issue and add some type definitions.

Fixes: #1371

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

