### PR TITLE
Fix bad step offset being set when zoomed out and moving steps

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineStep.tsx
@@ -385,8 +385,8 @@ const PipelineStepComponent = React.forwardRef<
         const [x, y] = current.position;
         const [mouseX, mouseY] = getMouseDelta();
         const newPosition: Point2D = [
-          (x + mouseX) / scaleFactor,
-          (y + mouseY) / scaleFactor,
+          x + mouseX / scaleFactor,
+          y + mouseY / scaleFactor,
         ];
 
         draggedStepPositions.current[uuid] = newPosition;


### PR DESCRIPTION
## Description

Currently, if you zoom out and try to move a step, it tends to fly off the canvas.

https://user-images.githubusercontent.com/8259221/195647000-63370e4e-62b6-4771-8c65-c65c0882cc3e.mp4

This is because the scaling is applied to the final position, and not just the mouse delta.

This PR fixes that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.