### PR TITLE
Fix: Wrong dialog when visiting PipelineEditor while JupyterLab is building.

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/PipelineEditor.tsx
@@ -11,6 +11,7 @@ import { useCanvasScaling } from "./contexts/CanvasScalingContext";
 import { usePipelineDataContext } from "./contexts/PipelineDataContext";
 import { usePipelineRefs } from "./contexts/PipelineRefsContext";
 import { usePipelineUiStateContext } from "./contexts/PipelineUiStateContext";
+import { useAutoStartSession } from "./hooks/useAutoStartSession";
 import { useOpenFile } from "./hooks/useOpenFile";
 import { useSavePipelineJson } from "./hooks/useSavePipelineJson";
 import { PipelineCanvasHeaderBar } from "./pipeline-canvas-header-bar/PipelineCanvasHeaderBar";
@@ -50,6 +51,7 @@ const elementCenter = (
 
 export const PipelineEditor = () => {
   const { pipelineCwd, isReadOnly, pipelineJson } = usePipelineDataContext();
+  useAutoStartSession();
 
   const { openNotebook, openFilePreviewView } = useOpenFile();
 

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useAutoStartSession.tsx
@@ -60,24 +60,28 @@ export const useAutoStartSession = () => {
         BUILD_IMAGE_SOLUTION_VIEW.PIPELINE
       );
       if (result === true) return;
-      if (result instanceof FetchError && result.status === 409) return; // When the session already exists, you get a 409 (CONFLICT).
-      if (result.message === "environmentsBuildInProgress") return;
-      if (result.message === "JupyterEnvironmentBuildInProgress") {
-        dispatch({
-          type: "SET_PIPELINE_READONLY_REASON",
-          payload: "JupyterEnvironmentBuildInProgress",
-        });
-        setConfirm(
-          "Notice",
-          "A JupyterLab environment build is in progress. You can cancel to view the pipeline in read-only mode.",
-          {
-            onConfirm: () => {
-              navigateTo(siteMap.configureJupyterLab.path);
-              return true;
-            },
-            confirmLabel: "Configure JupyterLab",
-          }
-        );
+      if (result instanceof FetchError) {
+        if (result.status === 409) return; // When the session already exists, you get a 409 (CONFLICT).
+
+        const errorMessage = result.body?.message || result.message;
+        if (errorMessage === "environmentsBuildInProgress") return;
+        if (errorMessage === "JupyterEnvironmentBuildInProgress") {
+          dispatch({
+            type: "SET_PIPELINE_READONLY_REASON",
+            payload: "JupyterEnvironmentBuildInProgress",
+          });
+          setConfirm(
+            "Notice",
+            "A JupyterLab environment build is in progress. You can cancel to view the pipeline in read-only mode.",
+            {
+              onConfirm: () => {
+                navigateTo(siteMap.configureJupyterLab.path);
+                return true;
+              },
+              confirmLabel: "Configure JupyterLab",
+            }
+          );
+        }
       } else {
         setAlert(
           "Error",

--- a/services/orchest-webserver/client/src/pipeline-view/hooks/useInteractiveRuns.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/hooks/useInteractiveRuns.tsx
@@ -2,17 +2,22 @@ import { RunStepsType } from "@/api/pipeline-runs/pipelineRunsApi";
 import { ErrorSummary } from "@/components/common/ErrorSummary";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { BUILD_IMAGE_SOLUTION_VIEW } from "@/contexts/ProjectsContext";
+import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useActivePipelineRun } from "@/hooks/useActivePipelineRun";
 import { useCancelJobRun } from "@/hooks/useCancelJobRun";
 import React from "react";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
-import { useAutoStartSession } from "./useAutoStartSession";
 import { usePipelineRuns } from "./usePipelineRuns";
 
 export const useInteractiveRuns = () => {
   const { setConfirm, setAlert } = useGlobalContext();
-  const { pipelineJson } = usePipelineDataContext();
-  const { session, startSession } = useAutoStartSession();
+  const { pipelineJson, pipeline } = usePipelineDataContext();
+  const { getSession, startSession } = useSessionsContext();
+
+  const session = React.useMemo(() => {
+    return getSession(pipeline?.uuid);
+  }, [getSession, pipeline?.uuid]);
+
   const cancel = useActivePipelineRun((state) => state.cancel);
   const cancelJobRun = useCancelJobRun(cancel);
   const isJobRun = useActivePipelineRun((state) => state.isJobRun);

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -5,6 +5,7 @@ import { SnackBar } from "@/components/common/SnackBar";
 import { Layout } from "@/components/layout/Layout";
 import { LegacyImageBuildLog } from "@/components/legacy/LegacyImageBuildLog";
 import { useGlobalContext } from "@/contexts/GlobalContext";
+import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
 import { useCancelableFetch } from "@/hooks/useCancelablePromise";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
@@ -86,6 +87,21 @@ const ConfigureJupyterLabView: React.FC = () => {
       console.error(e);
     }
   }, [jupyterSetupScript, setAsSaved, cancelableFetch]);
+
+  const {
+    dispatch,
+    state: { pipelineReadOnlyReason },
+  } = useProjectsContext();
+  React.useEffect(() => {
+    if (isBuildingImage) {
+      dispatch({
+        type: "SET_PIPELINE_READONLY_REASON",
+        payload: "JupyterEnvironmentBuildInProgress",
+      });
+    } else if (pipelineReadOnlyReason === "JupyterEnvironmentBuildInProgress") {
+      dispatch({ type: "SET_PIPELINE_READONLY_REASON", payload: undefined });
+    }
+  }, [dispatch, isBuildingImage, pipelineReadOnlyReason]);
 
   const buildImage = React.useCallback(async () => {
     window.orchest.jupyter?.unload();


### PR DESCRIPTION
## Description

The warning dialog should be replaced by a custom dialog stating "A JupyterLab environment build is in progress. You can cancel to view the pipeline in read-only mode." 

Fixes: #1381 

## Checklist

- [ ] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

