### PR TITLE
Remove body size limit from jupyter server ingress

### DIFF
--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -575,10 +575,14 @@ def _get_jupyter_server_deployment_service_manifest(
         ]
     }
 
+    ingress_metadata = copy.deepcopy(metadata)
+    ingress_metadata["annotations"] = {
+        "nginx.ingress.kubernetes.io/proxy-body-size": "0"
+    }
     ingress_manifest = {
         "apiVersion": "networking.k8s.io/v1",
         "kind": "Ingress",
-        "metadata": metadata,
+        "metadata": ingress_metadata,
         "spec": {
             "ingressClassName": _config.INGRESS_CLASS,
             "rules": [ingress_rule],


### PR DESCRIPTION
## Description

Allows uploading files of any size through the JupyterLab file manager. Adding Y&N as reviewers to notify of the change.

Fixes: #1236

## Checklist

- [X] I have manually tested my changes and I am happy with the result.
