### PR TITLE
Fix: The file tree can't be expanded beyond the third level

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFileDialog.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFileDialog.tsx
@@ -1,3 +1,4 @@
+import { ErrorSummary } from "@/components/common/ErrorSummary";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useAsync } from "@/hooks/useAsync";
 import { Checkbox, FormControlLabel } from "@mui/material";
@@ -12,7 +13,11 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import TextField from "@mui/material/TextField";
-import { ALLOWED_STEP_EXTENSIONS, StepExtension } from "@orchest/lib-utils";
+import {
+  ALLOWED_STEP_EXTENSIONS,
+  FetchError,
+  StepExtension,
+} from "@orchest/lib-utils";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { FileManagementRoot } from "../common";
@@ -95,15 +100,6 @@ export const CreateFileDialog = ({
   );
 
   React.useEffect(() => {
-    if (error) {
-      setAlert("Failed to create file", String(error), () => {
-        setError(null);
-        return true;
-      });
-    }
-  }, [error, setAlert, setError]);
-
-  React.useEffect(() => {
     if (isOpen) {
       reset(defaultFormState(canCreateStep));
     }
@@ -120,6 +116,22 @@ export const CreateFileDialog = ({
     fileName,
     extension
   );
+
+  React.useEffect(() => {
+    if (!error) return;
+
+    const message =
+      error instanceof FetchError && error.status === 409 ? (
+        `A file named "${fileName}" already exists.`
+      ) : (
+        <ErrorSummary error={error} />
+      );
+
+    setAlert("Error", message, () => {
+      setError(null);
+      return true;
+    });
+  }, [error, setAlert, setError, fileName]);
 
   return (
     <Dialog

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFileDialog.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFileDialog.tsx
@@ -1,6 +1,7 @@
 import { ErrorSummary } from "@/components/common/ErrorSummary";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useAsync } from "@/hooks/useAsync";
+import { join, truncateForDisplay } from "@/utils/path";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
@@ -111,10 +112,8 @@ export const CreateFileDialog = ({
     "shouldCreateStep",
   ]);
 
-  const displayPath = combinePath(
-    `${prettifyRoot(root)}${selectedFolder}`,
-    fileName,
-    extension
+  const displayPath = truncateForDisplay(
+    join(prettifyRoot(root), selectedFolder, `${fileName}.${extension}`)
   );
 
   React.useEffect(() => {

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFolderDialog.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFolderDialog.tsx
@@ -1,6 +1,7 @@
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useAsync } from "@/hooks/useAsync";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
+import { join, truncateForDisplay } from "@/utils/path";
 import { queryArgs } from "@/utils/text";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
@@ -118,7 +119,9 @@ export const CreateFolderDialog = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  {prettifyRoot(root) + lastSelectedFolder}
+                  {truncateForDisplay(
+                    join(prettifyRoot(root), lastSelectedFolder, "/")
+                  )}
                 </InputAdornment>
               ),
             }}

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFolderDialog.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/CreateFolderDialog.tsx
@@ -120,7 +120,7 @@ export const CreateFolderDialog = ({
               startAdornment: (
                 <InputAdornment position="start">
                   {truncateForDisplay(
-                    join(prettifyRoot(root), lastSelectedFolder, "/")
+                    join(prettifyRoot(root), lastSelectedFolder)
                   )}
                 </InputAdornment>
               ),

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -10,6 +10,7 @@ import { treeRoots } from "../common";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 import { ActionBar } from "./ActionBar";
 import {
+  combinePath,
   FileTrees,
   findTreeNode,
   getActiveRoot,
@@ -260,6 +261,6 @@ const filterExistingNodes = (
   combinedPaths: string[]
 ): string[] =>
   combinedPaths
-    .map((originalPath) => [originalPath, unpackPath(originalPath)] as const)
-    .filter(([, { root, path }]) => findTreeNode(fileTrees[root], path))
-    .map(([originalPath]) => originalPath);
+    .map(unpackPath)
+    .filter(({ root, path }) => findTreeNode(fileTrees[root], path))
+    .map(combinePath);

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -73,7 +73,7 @@ export function FileManager() {
     async (depth?: number) => {
       setInProgress(true);
 
-      await fetchFileTrees(depth);
+      await fetchFileTrees(Math.max(2, depth ?? 0));
 
       setInProgress(false);
     },

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -1,5 +1,4 @@
 import { useDebounce } from "@/hooks/useDebounce";
-import { useHasChanged } from "@/hooks/useHasChanged";
 import { useUploader } from "@/hooks/useUploader";
 import { isDirectory, segments } from "@/utils/path";
 import LinearProgress from "@mui/material/LinearProgress";
@@ -32,12 +31,12 @@ import { FileTreeContainer } from "./FileTreeContainer";
 const START_EXPANDED = ["/project-dir:/"];
 
 export function FileManager() {
-  /**
-   * States
-   */
-
-  const { projectUuid } = usePipelineDataContext();
-
+  const {
+    projectUuid,
+    pipelineUuid,
+    runUuid,
+    jobUuid,
+  } = usePipelineDataContext();
   const {
     isDragging,
     selectedFiles,
@@ -149,14 +148,13 @@ export function FileManager() {
     [browsePath, expanded, fileTrees, isDragging]
   );
 
-  const hasChangedProject = useHasChanged(
-    projectUuid,
-    (prev, current) => hasValue(prev) && prev !== current
-  );
-
   React.useEffect(() => {
+    if (!projectUuid) return;
+    // The below causes a 400:
+    if (jobUuid && runUuid && !pipelineUuid) return;
+
     reload();
-  }, [hasChangedProject, reload]);
+  }, [projectUuid, pipelineUuid, runUuid, jobUuid, reload]);
 
   React.useEffect(() => {
     if (Object.keys(fileTrees).length === 0) return;

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -148,7 +148,10 @@ export function FileManager() {
     [browsePath, expanded, fileTrees, isDragging]
   );
 
-  const hasChangedProject = useHasChanged(projectUuid);
+  const hasChangedProject = useHasChanged(
+    projectUuid,
+    (prev, current) => hasValue(prev) && prev !== current
+  );
 
   React.useEffect(() => {
     reload();

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -1,22 +1,21 @@
 import { useDebounce } from "@/hooks/useDebounce";
 import { useHasChanged } from "@/hooks/useHasChanged";
 import { useUploader } from "@/hooks/useUploader";
-import { queryArgs } from "@/utils/text";
+import { isDirectory, segments } from "@/utils/path";
 import LinearProgress from "@mui/material/LinearProgress";
 import MenuItem from "@mui/material/MenuItem";
-import { fetcher, hasValue } from "@orchest/lib-utils";
+import { hasValue } from "@orchest/lib-utils";
 import React from "react";
-import { FileManagementRoot, treeRoots } from "../common";
+import { treeRoots } from "../common";
 import { usePipelineDataContext } from "../contexts/PipelineDataContext";
 import { ActionBar } from "./ActionBar";
 import {
-  FILE_MANAGEMENT_ENDPOINT,
+  combinePath,
+  FileTrees,
+  findTreeNode,
   getActiveRoot,
-  isCombinedPathChildless,
   lastSelectedFolderPath,
-  mergeTrees,
-  searchTrees,
-  TreeNode,
+  replaceTreeNode,
   unpackPath,
 } from "./common";
 import { CreatePipelineButton } from "./CreatePipelineButton";
@@ -30,50 +29,14 @@ import { FileManagerLocalContextProvider } from "./FileManagerLocalContext";
 import { FileTree } from "./FileTree";
 import { FileTreeContainer } from "./FileTreeContainer";
 
-const deepestExpand = (expanded: string[]) => {
-  if (expanded.length === 0) {
-    return 0;
-  }
-  return Math.max(
-    ...expanded.map((e) => unpackPath(e).path.split("/").length - 1)
-  );
-};
-
-const createInvalidEntryFilter = ({
-  treeRoots,
-  fileTrees,
-}: {
-  treeRoots: readonly FileManagementRoot[];
-  fileTrees: Record<string, TreeNode>;
-}) => (combinedPathList: string[]): [string[], boolean] => {
-  let invalid = new Set();
-  let foundInvalid = false;
-
-  combinedPathList.forEach((combinedPath) => {
-    if (
-      searchTrees({ combinedPath, treeRoots, fileTrees }).node === undefined
-    ) {
-      foundInvalid = true;
-      invalid.add(combinedPath);
-    }
-  });
-
-  const uniqueArr = Array.from(new Set(combinedPathList));
-
-  return [uniqueArr.filter((e) => !invalid.has(e)), foundInvalid];
-};
+const START_EXPANDED = ["/project-dir"];
 
 export function FileManager() {
   /**
    * States
    */
 
-  const {
-    projectUuid,
-    pipelineUuid,
-    jobUuid,
-    runUuid,
-  } = usePipelineDataContext();
+  const { projectUuid } = usePipelineDataContext();
 
   const {
     isDragging,
@@ -81,6 +44,7 @@ export function FileManager() {
     setSelectedFiles,
     fileTrees,
     fetchFileTrees,
+    browse,
     setFileTrees,
   } = useFileManagerContext();
 
@@ -90,26 +54,32 @@ export function FileManager() {
   const [_inProgress, setInProgress] = React.useState(false);
   const inProgress = useDebounce(_inProgress, 125);
 
-  const [expanded, setExpanded] = React.useState(["/project-dir"]);
+  const [expanded, setExpanded] = React.useState<string[]>(START_EXPANDED);
   const [progress, setProgress] = React.useState(0);
   const [contextMenu, setContextMenu] = React.useState<ContextMenuMetadata>(
     undefined
   );
+  const deepestExpandRef = React.useRef(0);
+
+  deepestExpandRef.current = React.useMemo(() => {
+    if (expanded.length === 0) return 0;
+    else return Math.max(...expanded.map(directoryLevel));
+  }, [expanded]);
 
   const root = React.useMemo(() => getActiveRoot(selectedFiles, treeRoots), [
     selectedFiles,
   ]);
 
-  /**
-   * Actions
-   */
-  const reload = React.useCallback(async () => {
-    setInProgress(true);
+  const reload = React.useCallback(
+    async (depth?: number) => {
+      setInProgress(true);
 
-    await fetchFileTrees(deepestExpand(expanded));
+      await fetchFileTrees(depth);
 
-    setInProgress(false);
-  }, [expanded, fetchFileTrees]);
+      setInProgress(false);
+    },
+    [fetchFileTrees]
+  );
 
   const collapseAll = () => {
     setExpanded([]);
@@ -117,29 +87,27 @@ export function FileManager() {
   };
 
   const browsePath = React.useCallback(
-    async (combinedPath) => {
+    async (combinedPath: string) => {
       if (!projectUuid) return;
+
       setInProgress(true);
 
       const { root, path } = unpackPath(combinedPath);
+      const existingNode = findTreeNode(fileTrees[root], path);
 
-      const url = `${FILE_MANAGEMENT_ENDPOINT}/browse?${queryArgs({
-        projectUuid,
-        pipelineUuid,
-        jobUuid,
-        runUuid,
-        root,
-        path,
-      })}`;
+      // If this node has already been loaded,
+      // we don't reload it.
+      if (existingNode?.children.length) return;
 
-      const response = await fetcher<TreeNode>(url);
+      const node = await browse(root, path, 1);
 
-      // Augment existing fileTree with path specific tree
-      mergeTrees(response, fileTrees[root]);
-      setFileTrees(fileTrees);
+      setFileTrees({
+        ...fileTrees,
+        [root]: replaceTreeNode(fileTrees[root], node),
+      });
       setInProgress(false);
     },
-    [fileTrees, projectUuid, setFileTrees, jobUuid, pipelineUuid, runUuid]
+    [browse, fileTrees, projectUuid, setFileTrees]
   );
 
   const selectedFolder = React.useMemo(
@@ -160,54 +128,45 @@ export function FileManager() {
     setInProgress(uploader.inProgress);
   }, [uploader.inProgress]);
 
-  /**
-   * Callback handlers
-   */
-
   const handleToggle = React.useCallback(
-    (event: React.SyntheticEvent<Element, Event>, nodeIds: string[]) => {
+    (event: React.SyntheticEvent<Element, Event>, paths: string[]) => {
       if (!isDragging) {
-        // Newly expanded Ids
-        let expandedSet = new Set(expanded);
-        let addedIds = nodeIds.filter((e) => !expandedSet.has(e));
+        const newPaths = paths.filter((path) => !expanded.includes(path));
 
-        // Note, nodeIds are absolute paths
-        addedIds.forEach((combinedPath) => {
-          if (isCombinedPathChildless(combinedPath, fileTrees)) {
-            // Attempt path load
+        newPaths.forEach((combinedPath) => {
+          const { root, path } = unpackPath(combinedPath);
+          const node = findTreeNode(fileTrees[root], path);
+
+          // Only attempt to load paths if it appears as the node hasn't been fetched.
+          if (!node?.children.length && node?.type === "directory") {
             browsePath(combinedPath);
           }
         });
 
-        setExpanded(nodeIds);
+        setExpanded(paths);
       }
     },
     [browsePath, expanded, fileTrees, isDragging]
   );
 
-  /**
-   * Final component init
-   */
-
   const hasChangedProject = useHasChanged(projectUuid);
+
   React.useEffect(() => {
     reload();
-    // Only load when projectUuid is updated.
-    // Put `reload` in the deps would trigger unwanted requests.
-  }, [hasChangedProject]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hasChangedProject, reload]);
 
   React.useEffect(() => {
-    const filterInvalidEntries = createInvalidEntryFilter({
-      treeRoots,
-      fileTrees,
-    });
-    // Check expansion/selection based
-    let [newSelect, foundInvalidSelect] = filterInvalidEntries(selectedFiles);
-    let [newExpanded, foundInvalidExpanded] = filterInvalidEntries(expanded);
-    if (foundInvalidSelect) {
-      setSelectedFiles(newSelect);
+    if (Object.keys(fileTrees).length === 0) return;
+
+    const newSelected = filterExistingNodes(fileTrees, selectedFiles);
+
+    if (newSelected.length !== selectedFiles.length) {
+      setSelectedFiles(newSelected);
     }
-    if (foundInvalidExpanded) {
+
+    const newExpanded = filterExistingNodes(fileTrees, expanded);
+
+    if (newExpanded.length < expanded.length) {
       setExpanded(newExpanded);
     }
   }, [fileTrees]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -219,25 +178,23 @@ export function FileManager() {
   const onMoved = React.useCallback(
     (oldPath: string, newPath: string) => {
       if (!selectedFiles.includes(newPath)) {
-        setSelectedFiles((current) => {
-          return [...current, newPath];
-        });
+        setSelectedFiles((current) => [...current, newPath]);
       }
 
       const wasExpandedBeforeMove =
         expanded.includes(oldPath) && !expanded.includes(newPath);
 
       if (wasExpandedBeforeMove) {
-        setExpanded((expanded) => {
-          return [...expanded, newPath];
-        });
+        setExpanded((expanded) => [...expanded, newPath]);
       }
     },
     [expanded, selectedFiles, setSelectedFiles]
   );
 
   const handleUpload = (files: FileList | File[]) =>
-    uploader.uploadFiles(selectedFolder, files).then(reload);
+    uploader
+      .uploadFiles(selectedFolder, files)
+      .then(() => reload(deepestExpandRef.current));
 
   return (
     <>
@@ -250,7 +207,7 @@ export function FileManager() {
           />
         )}
         <FileManagerLocalContextProvider
-          reload={reload}
+          reload={() => reload(deepestExpandRef.current)}
           setContextMenu={setContextMenu}
         >
           <CreatePipelineButton />
@@ -294,3 +251,16 @@ export function FileManager() {
     </>
   );
 }
+
+const directoryLevel = (path: string) =>
+  segments(path).length - (isDirectory(path) ? 0 : 1);
+
+/** Returns the paths which exist in the provided file trees. */
+const filterExistingNodes = (
+  fileTrees: FileTrees,
+  combinedPaths: string[]
+): string[] =>
+  combinedPaths
+    .map(unpackPath)
+    .filter(({ root, path }) => hasValue(findTreeNode(fileTrees[root], path)))
+    .map(combinePath);

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -29,7 +29,7 @@ import { FileManagerLocalContextProvider } from "./FileManagerLocalContext";
 import { FileTree } from "./FileTree";
 import { FileTreeContainer } from "./FileTreeContainer";
 
-const START_EXPANDED = ["/project-dir"];
+const START_EXPANDED = ["/project-dir:/"];
 
 export function FileManager() {
   /**

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
@@ -1,9 +1,10 @@
 import { useCancelableFetch } from "@/hooks/useCancelablePromise";
-import { FileTree } from "@/types";
+import { prune } from "@/utils/record";
 import { queryArgs } from "@/utils/text";
+import { hasValue } from "@orchest/lib-utils";
 import React from "react";
-import { treeRoots } from "../common";
-import type { FileTrees } from "./common";
+import { FileManagementRoot, treeRoots } from "../common";
+import type { FileTrees, TreeNode } from "./common";
 import { FILE_MANAGEMENT_ENDPOINT } from "./common";
 
 type DragFile = {
@@ -28,7 +29,23 @@ export type FileManagerContextType = {
   isDragging: boolean;
   setIsDragging: React.Dispatch<React.SetStateAction<boolean>>;
   resetMove: () => void;
+  /**
+   * Fetches (or reloads) all file trees to a certain depth.
+   * Anything deeper than the provided depth will be pruned in the updated file trees.
+   * @param depth How many subdirectories deep to search.
+   */
   fetchFileTrees: (depth?: number) => Promise<void>;
+  /**
+   * Fetches a portion of the file tree from the back-end and updates the file trees.
+   * @param root The root to search: either `/project-dir` or `/data`.
+   * @param path The path to browser, or `undefined` if you want to search from the root.
+   * @param depth How many subdirectories deep to search. Defaults to 1 when a path is specified otherwise 2.
+   */
+  browse: (
+    root: FileManagementRoot,
+    path?: string,
+    depth?: number
+  ) => Promise<TreeNode>;
   fileTrees: FileTrees;
   setFileTrees: React.Dispatch<React.SetStateAction<FileTrees>>;
   fileTreeDepth: React.MutableRefObject<number>;
@@ -46,7 +63,7 @@ export const FileManagerContextProvider: React.FC<{
   jobUuid?: string | undefined;
   runUuid?: string | undefined;
 }> = ({ children, projectUuid, pipelineUuid, jobUuid, runUuid }) => {
-  const fileTreeDepth = React.useRef<number>(3);
+  const fileTreeDepth = React.useRef<number>(2);
   const [selectedFiles, _setSelectedFiles] = React.useState<string[]>([]);
 
   const setSelectedFiles = React.useCallback(
@@ -79,61 +96,50 @@ export const FileManagerContextProvider: React.FC<{
     }, 1);
   }, [setIsDragging, setDragFile, setHoveredPath]);
 
-  const browseUrl = React.useMemo(() => {
-    if (!projectUuid) return undefined;
-    const commonArgs = {
-      projectUuid,
-      depth: fileTreeDepth.current,
-    };
-
-    // For normal pipelines, FileManager reads from the whole project, it doesn't need `pipelineUuid`.
-    // `pipelineUuid` is only needed together with `jobuuid`, so that it could read from the snapshot.
-    return `${FILE_MANAGEMENT_ENDPOINT}/browse?${queryArgs(
-      pipelineUuid && jobUuid
-        ? {
-            pipelineUuid,
-            jobUuid,
-            runUuid,
-            ...commonArgs,
-          }
-        : commonArgs
-    )}`;
-  }, [projectUuid, pipelineUuid, jobUuid, runUuid]);
-
   const { cancelableFetch } = useCancelableFetch();
+
+  const browse = React.useCallback(
+    (
+      root: FileManagementRoot,
+      path?: string | undefined,
+      depth = hasValue(path) ? 1 : 2
+    ) =>
+      cancelableFetch<TreeNode>(
+        `${FILE_MANAGEMENT_ENDPOINT}/browse?` +
+          queryArgs(
+            prune({
+              projectUuid,
+              pipelineUuid,
+              jobUuid,
+              runUuid,
+              root,
+              path: path || undefined,
+              depth,
+            })
+          )
+      ),
+    [cancelableFetch, projectUuid, pipelineUuid, jobUuid, runUuid]
+  );
 
   const fetchFileTrees = React.useCallback(
     async (depth?: number) => {
-      if (!browseUrl) return;
-      if (depth) {
-        fileTreeDepth.current = Math.max(fileTreeDepth.current, depth);
-      }
-
-      const newFiles = await Promise.all(
-        treeRoots.map(async (root) => {
-          try {
-            const file = await cancelableFetch<FileTree>(
-              `${browseUrl}&${queryArgs({ root })}`
-            );
-            return { key: root, file };
-          } catch (error) {
-            return undefined;
-          }
-        })
+      const newRoots = await Promise.all(
+        treeRoots.map((root) =>
+          browse(root, undefined, depth)
+            .then((node) => [root, node] as const)
+            .catch(() => [root, undefined] as const)
+        )
       );
 
-      setFileTrees(
-        newFiles.reduce((obj, curr) => {
-          return curr ? { ...obj, [curr.key]: curr.file } : obj;
-        }, {})
-      );
+      setFileTrees(prune(Object.fromEntries(newRoots)));
     },
-    [browseUrl, cancelableFetch]
+    [browse]
   );
 
   return (
     <FileManagerContext.Provider
       value={{
+        browse,
         selectedFiles,
         setSelectedFiles,
         dragFile,

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManagerContext.tsx
@@ -4,8 +4,7 @@ import { queryArgs } from "@/utils/text";
 import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 import { FileManagementRoot, treeRoots } from "../common";
-import type { FileTrees, TreeNode } from "./common";
-import { FILE_MANAGEMENT_ENDPOINT } from "./common";
+import { FileTrees, FILE_MANAGEMENT_ENDPOINT, TreeNode } from "./common";
 
 type DragFile = {
   labelText: string;

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -6,7 +6,7 @@ import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { fetchPipelines } from "@/hooks/useFetchPipelines";
 import { siteMap } from "@/routingConfig";
 import { firstAncestor } from "@/utils/element";
-import { basename, dirname, join } from "@/utils/path";
+import { basename, dirname } from "@/utils/path";
 import { queryArgs } from "@/utils/text";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -19,6 +19,7 @@ import { FileManagementRoot } from "../common";
 import { useOpenFile } from "../hooks/useOpenFile";
 import {
   cleanFilePath,
+  combinePath,
   FileTrees,
   FILE_MANAGEMENT_ENDPOINT,
   FILE_MANAGER_ROOT_CLASS,
@@ -34,7 +35,6 @@ import {
   Move,
   pathFromElement,
   prettifyRoot,
-  ROOT_SEPARATOR,
   UnpackedPath,
   unpackMove,
   unpackPath,
@@ -410,13 +410,13 @@ export const FileTree = React.memo(function FileTreeComponent({
         multiSelect
       >
         {treeRoots.map((root) => {
-          const combinedPath = join(root + ROOT_SEPARATOR + "/");
+          const combinedPath = combinePath({ root, path: "/" });
 
           return (
             <FileTreeItem
               disableDragging
               key={root}
-              nodeId={root}
+              nodeId={combinedPath}
               sx={{
                 backgroundColor:
                   hoveredPath === combinedPath

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
@@ -1,5 +1,5 @@
 import { Code } from "@/components/common/Code";
-import { FileTree, StepData } from "@/types";
+import { StepData } from "@/types";
 import {
   basename,
   dirname,
@@ -56,7 +56,7 @@ export const isInProjectFolder = (combinedPath: string) =>
  */
 export const unpackPath = (combinedPath: string): UnpackedPath => {
   const root = combinedPath.split(":")[0] as FileManagementRoot;
-  const path = combinedPath.slice(root.length + ROOT_SEPARATOR.length) || "/";
+  const path = combinedPath.slice(root.length + ROOT_SEPARATOR.length);
 
   return { root, path };
 };
@@ -136,7 +136,7 @@ export const replaceTreeNode = (
   const children: TreeNode[] = [];
 
   for (const child of root.children) {
-    if (child.path === replacement.path) {
+    if (pathMatchesNode(child, replacement.path)) {
       children.push(replacement);
     } else if (child.type === "file") {
       children.push(child);
@@ -148,14 +148,18 @@ export const replaceTreeNode = (
   return { ...root, children };
 };
 
+/** Checks if the node matches the provided path. */
+const pathMatchesNode = (node: TreeNode, path: string) =>
+  node.path === path || (node.root && (path === "" || path === "/"));
+
 export const findTreeNode = (
-  root: FileTree | undefined,
+  root: TreeNode | undefined,
   path: string
-): FileTree | undefined => {
-  if (!root || root.path === path) return root;
+): TreeNode | undefined => {
+  if (!root || pathMatchesNode(root, path)) return root;
 
   for (const child of root.children) {
-    if (child.path === path) {
+    if (pathMatchesNode(child, path)) {
       return child;
     } else if (child.type === "directory") {
       const node = findTreeNode(child, path);

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/common.tsx
@@ -73,7 +73,7 @@ export const isInProjectFolder = (combinedPath: string) =>
  */
 export const unpackPath = (combinedPath: string): UnpackedPath => {
   const root = combinedPath.split(":")[0] as FileManagementRoot;
-  const path = combinedPath.slice(root.length + ROOT_SEPARATOR.length);
+  const path = combinedPath.slice(root.length + ROOT_SEPARATOR.length) || "/";
 
   return { root, path };
 };

--- a/services/orchest-webserver/client/src/utils/path.ts
+++ b/services/orchest-webserver/client/src/utils/path.ts
@@ -114,6 +114,28 @@ export const relative = (from: string, to: string) => {
 /** Returns the segments of the paths, ignoring empty segments. */
 export const segments = (path: string) => path.split("/").filter(Boolean);
 
+/**
+ * Truncates the path to display the root, topmost directory and file name.
+ * @param path The path to truncate
+ * @param delimiter What to replace the omitted segments with. Default " … ".
+ */
+export const truncateForDisplay = (path: string, delimiter = " … ") => {
+  const parts = segments(path);
+
+  if (parts.length <= 3) {
+    return path;
+  } else if (isDirectory(path)) {
+    return join(parts[0], delimiter, parts[parts.length - 1]) + "/";
+  } else {
+    return join(
+      parts[0],
+      delimiter,
+      parts[parts.length - 2],
+      parts[parts.length - 1]
+    );
+  }
+};
+
 /** Resolves `..` and `.`, and removes empty segments. */
 export const normalizeSegments = (
   segments: readonly string[],


### PR DESCRIPTION
## Description

Currently, it is not possible to manage files in Orchest below the third sub-directory—we never load that far. 

https://user-images.githubusercontent.com/8259221/196445243-194b3750-3291-4c5f-8235-56bfcc0f2d21.mp4

This PR fixes so that …
- Expanding seemingly empty directories in the file tree also attempts to load them
- Reloading the file browser reloads everything up until the deepest expanded level

Resulting in …

https://user-images.githubusercontent.com/8259221/196445322-bac56a86-b456-489a-a394-fb1ed8b2821e.mp4

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

## Test checklist
- [x] View a job snapshot and ensure the right files (from the snapshot) are loaded
- [x] Create a file in a "deep directory", expand it all the way, then use "reload" to make sure it's still expanded
- [x] Move a file to a "deep directory", and make sure it appears as soon as it is dropped
- [x] Moving files and folders around in the file tree
- [x] Moving files between the project directory and data
- [x] Ensured that `/browse` requests are deduplicated