### PR TITLE
fix: Redundant warning about Environment building in progress.

### DIFF
--- a/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/ProjectsContext.tsx
@@ -8,6 +8,7 @@ import type {
   Project,
   ReducerActionWithCallback,
 } from "@/types";
+import { FetchError } from "@orchest/lib-utils";
 import React from "react";
 
 export enum BUILD_IMAGE_SOLUTION_VIEW {
@@ -409,8 +410,11 @@ export const ProjectsContextProvider: React.FC = ({ children }) => {
       });
 
       if (!readOnlyReason) return true;
-      if (buildStatus === "environmentsBuildInProgress")
-        return new Error(readOnlyReason);
+      if (buildStatus === "environmentsBuildInProgress") {
+        // In read-only mode, readOnlyReason should be populated via FetchError.
+        // because requestStartSession in useAutoStartSession will check if result instanceof FetchError
+        return new FetchError(readOnlyReason);
+      }
 
       return triggerRequestBuild(validationData, requestedFromView);
     },


### PR DESCRIPTION
## Description

When environment images are building, the pop-up warning is redundant. This PR removes this dialog.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
