### PR TITLE
Change installation docs.

### DIFF
--- a/docs/source/_static/js/installer_widget.js
+++ b/docs/source/_static/js/installer_widget.js
@@ -2,262 +2,33 @@ window.document.addEventListener("DOMContentLoaded", function () {
   const CONTAINER_CLASS = ".installer-container";
 
   let installerData = {
-    Linux: {
-      minikube: {
-        instructions: `
-<p>We provide an automated convenience script for a complete <a
-href="https://minikube.sigs.k8s.io/docs/start/">minikube</a> deployment. Taking care of installing
-minikube, installing the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code> and installing Orchest, run it with:</p>
-<div class="highlight">
-<pre>
-curl -fsSL https://get.orchest.io > convenience_install.sh \\
-    && bash convenience_install.sh
-</pre>
-</div>
-<p>In case any of these technologies is already installed on your machine, then the convenience script
-will simply proceed to the next step.</p>
-
-<p>Now that Orchest is installed, it can be reached on the IP returned by:</p>
-<div class="highlight">
-  <pre>minikube ip</pre>
-</div>
-        `,
-      },
-      MicroK8s: {
-        instructions: `
-<p>First, ensure you have <a href="https://microk8s.io/#install-microk8s">MicroK8s</a> installed.
-Next, <a href="https://microk8s.io/docs/working-with-kubectl">configure kubectl</a> to access the cluster
-and install the following addons:</p>
-<div class="highlight">
-<pre>
-microk8s enable hostpath-storage \\
-    && microk8s enable dns \\
-    && microk8s enable ingress
-</pre>
-</div>
-<p>These make sure your MicroK8s cluster is properly configured for you to use Orchest.</p>
-
-<p>Next up, Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install --socket-path=/var/snap/microk8s/common/run/containerd.sock
-</pre>
-</div>
-<p>Passing the <code class="docutils literal notranslate"><span
-class="pre">--socket-path</span></code> flag is required for MicroK8s deployments for Orchest
-to know the location of the container runtime socket. Without it Orchest won't be able to pull
-your custom Environments to the MicroK8s node.
-
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost/">localhost</a>
-directly.</p>
-          `,
-      },
-      K3s: {
-        instructions: `
-<p>First, install <a href="https://k3s.io/">K3s</a> without deploying <a href="https://traefik.io/">traefik</a> 
-by running the following command:</p>
-<div class="highlight">
-<pre>
-curl -sfL https://get.k3s.io | \\
-    INSTALL_K3S_EXEC="--no-deploy traefik" sh -s -
-</pre>
-</div>
-<p>Now Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-# Omit the socket path if you pointed k3s to use the system containerd.
-orchest install --socket-path=/run/k3s/containerd/containerd.sock
-</pre>
-</div>
-<p>Now that Orchest is installed, it can be reached on the IP address returned by:</p>
-<div class="highlight">
-  <pre>kubectl get service orchest-ingress-nginx-controller -n orchest \\
-      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'</pre>
-</div>`,
-      },
-      "Docker Desktop": {
-        instructions: `
-<p>Follow the instructions to <a href="https://docs.docker.com/desktop/install/linux-install/"> install
-Docker Desktop </a> on linux.</p>
-<p>Once installed, go to its settings (top right) and if you wish to do so, change the
-allocated resources. At least 2 cpus, 8GB of memory and 15GB of disk are required.</p>
-<p><a href="https://docs.docker.com/desktop/kubernetes/"> Enable kubernetes in Docker Desktop</a></p>
-<p>Now Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install
-</pre>
-</div>
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost:80">localhost</a>.</p>`,
-      },
-    },
-    macOS: {
-      minikube: {
-        instructions: `
-<p>We provide an automated convenience script for a complete <a
-href="https://minikube.sigs.k8s.io/docs/start/">minikube</a> deployment. Taking care of installing
-minikube, installing the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code> and installing Orchest, run it with:</p>
-<div class="highlight">
-<pre>
-curl -fsSL https://get.orchest.io > convenience_install.sh \\
-    && bash convenience_install.sh
-</pre>
-</div>
-<p>In case any of these technologies is already installed on your machine, then the convenience script
-will simply proceed to the next step.</p>
-
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost/">localhost</a> by
-running the <code class="docutils literal notranslate"><span class="pre">minikube
-tunnel</span></code> daemon.
-          `,
-      },
-      "Docker Desktop": {
-        instructions: `
-<p>Follow the instructions to <a href="https://docs.docker.com/desktop/install/mac-install/"> install
-Docker Desktop </a> on macOS.</p>
-<p>Once installed, go to its settings (top right) and if you wish to do so, change the
-allocated resources. At least 2 cpus, 8GB of memory and 15GB of disk are required.</p>
-<p><a href="https://docs.docker.com/desktop/kubernetes/"> Enable kubernetes in Docker Desktop</a></p>
-<p>Now Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install
-</pre>
-</div>
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost:80">localhost</a>.</p>`,
-      },
-    },
-    Windows: {
-      minikube: {
-        instructions: `
-<p>For Orchest to work on Windows, Docker has to be configured to use WSL 2 (<a class="reference
-external" href="https://docs.docker.com/desktop/windows/wsl/">Docker Desktop WSL 2 backend</a>).
-For all further steps make sure to run CLI commands inside a WSL terminal. You can do this by
-opening the distribution using the Start menu or by <a class="reference external"
-href="https://docs.microsoft.com/en-us/windows/wsl/setup/environment#set-up-windows-terminal">setting
-up the Windows Terminal</a>.</p>
-
-<p>We provide an automated convenience script for a complete <a
-href="https://minikube.sigs.k8s.io/docs/start/">minikube</a> deployment. Taking care of installing
-minikube, installing the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code> and installing Orchest, run it with:</p>
-<div class="highlight">
-<pre>
-curl -fsSL https://get.orchest.io > convenience_install.sh \\
-    && bash convenience_install.sh
-</pre>
-</div>
-<p>In case any of these technologies is already installed on your machine, then the convenience script
-will simply proceed to the next step.</p>
-
-<p>Now that Orchest is installed, it can be reached on the IP returned by:</p>
-<div class="highlight">
-  <pre>minikube ip</pre>
-</div>
-        `,
-      },
-      MicroK8s: {
-        instructions: `
-<p>For Orchest to work on Windows, Docker has to be configured to use WSL 2 (<a class="reference
-external" href="https://docs.docker.com/desktop/windows/wsl/">Docker Desktop WSL 2 backend</a>).
-For all further steps make sure to run CLI commands inside a WSL terminal. You can do this by
-opening the distribution using the Start menu or by <a class="reference external"
-href="https://docs.microsoft.com/en-us/windows/wsl/setup/environment#set-up-windows-terminal">setting
-up the Windows Terminal</a>.</p>
-
-<p>First, ensure you have <a href="https://microk8s.io/#install-microk8s">MicroK8s</a> installed.
-Next, <a href="https://microk8s.io/docs/working-with-kubectl">configure kubectl</a> to access the cluster
-and install the following addons:</p>
-<div class="highlight">
-<pre>
-microk8s enable hostpath-storage \\
-    && microk8s enable dns \\
-    && microk8s enable ingress
-</pre>
-</div>
-<p>These make sure your MicroK8s cluster is properly configured for you to use Orchest.</p>
-
-<p>Next up, Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install --socket-path=/var/snap/microk8s/common/run/containerd.sock
-</pre>
-</div>
-<p>Passing the <code class="docutils literal notranslate"><span
-class="pre">--socket-path</span></code> flag is required for MicroK8s deployments for Orchest
-to know the location of the container runtime socket. Without it Orchest won't be able to pull
-your custom Environments to the MicroK8s node.
-
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost/">localhost</a>
-directly.</p>
-          `,
-      },
-      K3s: {
-        instructions: `
-<p>For Orchest to work on Windows, Docker has to be configured to use WSL 2 (<a class="reference
-external" href="https://docs.docker.com/desktop/windows/wsl/">Docker Desktop WSL 2 backend</a>).
-For all further steps make sure to run CLI commands inside a WSL terminal. You can do this by
-opening the distribution using the Start menu or by <a class="reference external"
-href="https://docs.microsoft.com/en-us/windows/wsl/setup/environment#set-up-windows-terminal">setting
-up the Windows Terminal</a>.</p>        
-
-<p>First, install <a href="https://k3s.io/">K3s</a> without deploying <a href="https://traefik.io/">traefik</a> 
-by running the following command:</p>
-<div class="highlight">
-<pre>
-curl -sfL https://get.k3s.io | \\
-    INSTALL_K3S_EXEC="--no-deploy traefik" sh -s -
-</pre>
-</div>
-<p>Now Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install
-</pre>
-</div>
-<p>Now that Orchest is installed, it can be reached on the IP address returned by:</p>
-<div class="highlight">
-  <pre>kubectl get service orchest-ingress-nginx-controller -n orchest \\
-      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'</pre>
-</div>`,
-      },
-      "Docker Desktop": {
-        instructions: `
-<p>For Orchest to work on Windows, Docker Desktop has to be configured to use WSL 2 (<a class="reference
-external" href="https://docs.docker.com/desktop/windows/wsl/">Docker Desktop WSL 2 backend</a>).
-For all further steps make sure to run CLI commands inside a WSL terminal. You can do this by
-opening the distribution using the Start menu or by <a class="reference external"
-href="https://docs.microsoft.com/en-us/windows/wsl/setup/environment#set-up-windows-terminal">setting
-up the Windows Terminal</a>.</p>        
-<p>Once installed, go to its settings (top right) and if you wish to do so, change the
-allocated resources. At least 2 cpus, 8GB of memory and 15GB of disk are required.</p>
-<p><a href="https://docs.docker.com/desktop/kubernetes/"> Enable kubernetes in Docker Desktop</a></p>
-<p>Now Orchest can be installed using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
-<div class="highlight">
-<pre>
-pip install --upgrade orchest-cli
-orchest install
-</pre>
-</div>
-<p>Now that Orchest is installed, it can be reached on <a href="http://localhost:80">localhost</a>.</p>`,
-      },
-    },
     Cloud: {
+      EKS: {
+        instructions: `
+<p>
+Get started by installing <a href="https://kubernetes.io/docs/tasks/tools/">kubectl</a> and setting up an
+<a href="https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html">EKS cluster</a>
+on AWS.
+</p>
+
+<p>All that is left is installing Orchest using the <code class="docutils literal notranslate"><span
+class="pre">orchest-cli</span></code>:</p>
+<div class="highlight">
+<pre>
+pip install --upgrade orchest-cli
+orchest install
+</pre>
+</div>
+
+<p>Now that Orchest is installed, it can be reached on the address returned by:</p>
+<div class="highlight">
+<pre>kubectl get service orchest-ingress-nginx-controller -n orchest \\
+      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+</pre>
+</div>
+<p>
+        `,
+      },
       GKE: {
         instructions: `
 <p>Make sure to first create a
@@ -285,30 +56,27 @@ orchest install
 <p>
 `,
       },
-      EKS: {
+    },
+    Linux: {
+      minikube: {
         instructions: `
-<p>
-Get started by installing <a href="https://kubernetes.io/docs/tasks/tools/">kubectl</a> and setting up an
-<a href="https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html">EKS cluster</a>
-on AWS.
-</p>
-
-<p>All that is left is installing Orchest using the <code class="docutils literal notranslate"><span
-class="pre">orchest-cli</span></code>:</p>
+<p>We provide an automated convenience script for a complete <a
+href="https://minikube.sigs.k8s.io/docs/start/">minikube</a> deployment. Taking care of installing
+minikube, installing the <code class="docutils literal notranslate"><span
+class="pre">orchest-cli</span></code> and installing Orchest, run it with:</p>
 <div class="highlight">
 <pre>
-pip install --upgrade orchest-cli
-orchest install
+curl -fsSL https://get.orchest.io > convenience_install.sh \\
+    && bash convenience_install.sh
 </pre>
 </div>
+<p>In case any of these technologies is already installed on your machine, then the convenience script
+will simply proceed to the next step.</p>
 
-<p>Now that Orchest is installed, it can be reached on the address returned by:</p>
+<p>Now that Orchest is installed, it can be reached on the IP returned by:</p>
 <div class="highlight">
-<pre>kubectl get service orchest-ingress-nginx-controller -n orchest \\
-      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-</pre>
+  <pre>minikube ip</pre>
 </div>
-<p>
         `,
       },
     },

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -9,8 +9,7 @@
 
 This page contains the installation instructions for self-hosting the open source version of Orchest.
 
-Alternatively, you can try out [our Cloud offering](https://cloud.orchest.io/signup)
-which comes with a free, fully configured Orchest instance.
+The easiest way to use Orchest is through our free [hosted version](https://cloud.orchest.io/signup). Get up and running with a fully configured Orchest instance in less than 2 minutes.
 
 ```{note}
 Orchest is in beta.
@@ -18,9 +17,9 @@ Orchest is in beta.
 
 ## Prerequisites
 
-To install Orchest you will need a running [Kubernetes (k8s) cluster](https://kubernetes.io/docs/setup/). Any cluster should work. You can either pick a managed
+To install Orchest you will need a running [Kubernetes (k8s) cluster](https://kubernetes.io/docs/setup/). You can either pick a managed
 service by one of the certified [cloud platforms](https://kubernetes.io/docs/setup/production-environment/turnkey-solutions/) or create a cluster
-locally. For single node deployments, we recommend using at (the very) least 2 CPU and 8GB of RAM
+yourself. For single node deployments, we recommend using at (the very) least 2 CPU and 8GB of RAM
 (see {ref}`CPU contention <cpu-contention-dns>`).
 Do note that only the following container runtimes are supported:
 
@@ -37,11 +36,7 @@ below. In case you have custom requirements, be sure to first check out the
 
 We recommend installing Orchest on a clean cluster to prevent clashes with existing cluster-level resources,
 even though installing Orchest on an existing cluster is fully supported.
-The supported operating systems are:
-
-- Linux (`x86_64`)
-- [Windows Subsystem for Linux 2](https://docs.microsoft.com/en-us/windows/wsl/about) (WSL2)
-- macOS (M1 Macs should use [Rosetta](https://support.apple.com/en-us/HT211861) for emulation)
+At this time we only support running Orchest on Linux (`x86_64`). Either through `minikube` on a Linux bare-metal/VM or on a Kubernetes cluster.
 
 ```{raw} html
 :file: install_widget.html
@@ -75,7 +70,7 @@ cluster, then one of the following subsections might be helpful:
   such as AWS EC2 instances.
 - {ref}`Scarse (CPU) resources - tweak DNS settings <cpu-contention-dns>`: Increase DNS query
   timeout to prevent name resolution failing during time of CPU resource contention. Especially
-  applicable for single node deployments close to the minimum requirement of 2 CPU.
+  applicable for single node deployments close to the minimum requirement of 2 vCPU.
 
 (install-fqdn)=
 


### PR DESCRIPTION
## Description

Change installation targets in docs. We're deprecating macOS and Windows based installations. From now on we offer the free Orchest Cloud hosted version and offer documentation and support on installing Orchest on Linux through `minikube` or on managed k8s with flavors `EKS` and `GKE` (AWS/GCP).

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.