### PR TITLE
Fail Project import if repo couldn't be `clone`d

### DIFF
--- a/services/orchest-webserver/app/scripts/background_tasks.py
+++ b/services/orchest-webserver/app/scripts/background_tasks.py
@@ -33,7 +33,9 @@ def git_clone_project(args) -> Tuple[int, str]:
 
         # This way we clone in a directory with the name of the repo if
         # the project_name is not provided.
-        git_command = f"git clone {args.url}"
+        # - GIT_TERMINAL_PROMPT makes the `git` command fail if it has
+        #   to prompt the user for input, e.g. for their username.
+        git_command = f"GIT_TERMINAL_PROMPT=0 git clone {args.url}"
 
         # args.path contains the desired project name, if the user
         # specified it.

--- a/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
+++ b/services/orchest-webserver/client/src/projects-view/ImportDialog.tsx
@@ -53,6 +53,8 @@ import React from "react";
 import { useImportGitRepo, validProjectName } from "./hooks/useImportGitRepo";
 
 const ERROR_MAPPING: Record<CreateProjectError, string> = {
+  "git clone failed":
+    "failed to clone repo. Only public repos can be imported.",
   "project move failed": "failed to move project because the directory exists.",
   "project name contains illegal character":
     "project name contains illegal character(s).",
@@ -542,7 +544,7 @@ export const ImportDialog = ({
               <>
                 <Stack direction="column" spacing={1}>
                   <Typography>
-                    Paste <Code>HTTPS</Code> link to <Code>git</Code>{" "}
+                    Paste <Code>HTTPS</Code> link to public <Code>git</Code>{" "}
                     repository:
                   </Typography>
                   <form

--- a/services/orchest-webserver/client/src/projects-view/hooks/useImportGitRepo.ts
+++ b/services/orchest-webserver/client/src/projects-view/hooks/useImportGitRepo.ts
@@ -69,7 +69,7 @@ export const useImportGitRepo = (
       );
 
       backgroundTaskPoller.startPollingBackgroundTask(uuid, (result) => {
-        if (result.status === "SUCCESS") {
+        if (["SUCCESS", "FAILURE"].includes(result.status)) {
           setData(result);
           backgroundTaskPoller.removeAllTasks();
           onComplete(result);

--- a/services/orchest-webserver/client/src/utils/webserver-utils.ts
+++ b/services/orchest-webserver/client/src/utils/webserver-utils.ts
@@ -224,6 +224,7 @@ export function checkGate(project_uuid: string) {
 }
 
 export type CreateProjectError =
+  | "git clone failed"
   | "project move failed"
   | "project name contains illegal character";
 


### PR DESCRIPTION
## Description

Properly handle `git clone` (e.g. specifying a private repo URL) failures during Project import:

https://user-images.githubusercontent.com/26223174/197776080-2245b982-d7c3-474d-b7d1-1c42b590733d.mp4


