### PR TITLE
Make environment variables "secret" by default

### DIFF
--- a/services/orchest-webserver/client/src/components/EnvVarInput.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarInput.tsx
@@ -1,0 +1,82 @@
+import { isValidEnvironmentVariableName } from "@/utils/webserver-utils";
+import { VisibilityOffOutlined, VisibilityOutlined } from "@mui/icons-material";
+import DeleteOutline from "@mui/icons-material/DeleteOutline";
+import { InputAdornment } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import React from "react";
+
+export type EnvVarInputProps = {
+  /** The current environment variable name. */
+  name: string;
+  /** The current environment variable value.  */
+  value: string;
+  /** Disables both inputs. */
+  disabled?: boolean;
+  /** If true: the value is displayed as plain text, otherwise; a password. */
+  revealed?: boolean;
+  /** Called when name or value input is updated. */
+  onChange: (name: string, value: string) => void;
+  /** Called when the "remove"-button is clicked. */
+  onRemove: () => void;
+};
+
+export const EnvVarInput = ({
+  name,
+  value,
+  onChange,
+  onRemove,
+  revealed: initiallyRevealed = false,
+  disabled: readOnly = false,
+}: EnvVarInputProps) => {
+  const isValidName = !name || isValidEnvironmentVariableName(name);
+  const [revealed, setRevealed] = React.useState(initiallyRevealed);
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={1}
+      sx={{ maxWidth: "40rem" }}
+    >
+      <Tooltip
+        title="Must be alphanumeric characters mixed with underscores or hyphens"
+        open={!isValidName}
+        arrow
+      >
+        <TextField
+          label="Name"
+          value={name}
+          onChange={({ target }) => onChange(target.value, value)}
+          error={!isValidName}
+          disabled={readOnly}
+          data-test-id={`environment-variable-input-${name}-name`}
+        />
+      </Tooltip>
+      <TextField
+        label="Value"
+        value={value}
+        type={revealed ? "text" : "password"}
+        onChange={({ target }) => onChange(name, target.value)}
+        disabled={readOnly}
+        data-test-id={`environment-variable-input-${name}-value`}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton onClick={() => setRevealed(!revealed)}>
+                {revealed ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+      {!readOnly && (
+        <IconButton title="Delete variable" onClick={() => onRemove()}>
+          <DeleteOutline />
+        </IconButton>
+      )}
+    </Stack>
+  );
+};

--- a/services/orchest-webserver/client/src/components/EnvVarInput.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarInput.tsx
@@ -61,6 +61,7 @@ export const EnvVarInput = ({
         autoComplete="off"
         type={revealed ? "text" : "password"}
         onChange={({ target }) => onChange(name, target.value)}
+        onBlur={() => setRevealed(!value)}
         disabled={readOnly}
         data-test-id={`environment-variable-input-${name}-value`}
         InputProps={{

--- a/services/orchest-webserver/client/src/components/EnvVarInput.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarInput.tsx
@@ -58,6 +58,7 @@ export const EnvVarInput = ({
       <TextField
         label="Value"
         value={value}
+        autoComplete="off"
         type={revealed ? "text" : "password"}
         onChange={({ target }) => onChange(name, target.value)}
         disabled={readOnly}

--- a/services/orchest-webserver/client/src/components/EnvVarList.tsx
+++ b/services/orchest-webserver/client/src/components/EnvVarList.tsx
@@ -1,52 +1,46 @@
-import { isValidEnvironmentVariableName } from "@/utils/webserver-utils";
 import AddIcon from "@mui/icons-material/Add";
-import DeleteIcon from "@mui/icons-material/Delete";
 import Button from "@mui/material/Button";
-import Stack from "@mui/material/Stack";
-import TextField from "@mui/material/TextField";
-import Tooltip from "@mui/material/Tooltip";
+import Stack, { StackProps } from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import produce from "immer";
 import React from "react";
-import { IconButton } from "./common/IconButton";
+import { EnvVarInput } from "./EnvVarInput";
 
-export type EnvVarPair = {
-  name: string;
-  value: string;
-};
+export type EnvVarPair = { name: string; value: string };
 
-export const EnvVarList: React.FC<{
-  value: EnvVarPair[];
+export type EnvVarListProps = StackProps & {
+  variables: EnvVarPair[];
   setValue?: (
     callback: (
       currentValue: EnvVarPair[] | undefined
     ) => EnvVarPair[] | undefined
   ) => void;
   readOnly?: boolean;
-  ["data-test-id"]?: string;
-}> = ({
-  value: variables,
-  setValue,
-  readOnly,
-  ["data-test-id"]: testId = "",
-}) => {
-  const onChange = (payload: string, index: number, type: "name" | "value") => {
-    if (!setValue) return;
-    setValue((current) => {
-      if (!current) return current;
-      const found = current[index];
-      const updated = { ...found, [type]: payload };
-      return [...current.slice(0, index), updated, ...current.slice(index + 1)];
-    });
-  };
+};
 
-  const onAdd = () => {
-    if (!setValue) return;
-    setValue((current) => [...(current || []), { name: "", value: "" }]);
-  };
+export const EnvVarList = ({
+  variables,
+  readOnly,
+  setValue: onChange,
+  ...stackProps
+}: EnvVarListProps) => {
+  const update = React.useCallback(
+    (index: number, name: string, value: string) =>
+      onChange?.((current) => {
+        if (!current) return current;
+
+        return produce(current, (draft) => {
+          draft[index] = { name, value };
+        });
+      }),
+    [onChange]
+  );
+
+  const add = () =>
+    onChange?.((current) => [...(current || []), { name: "", value: "" }]);
 
   const remove = (index: number) => {
-    if (!setValue) return;
-    setValue((current) => {
+    onChange?.((current) => {
       if (!current) return [];
       if (index < 0 || index >= current.length) return current;
       return [...current.slice(0, index), ...current.slice(index + 1)];
@@ -54,72 +48,32 @@ export const EnvVarList: React.FC<{
   };
 
   return (
-    <Stack direction="column" spacing={3} alignItems="flex-start">
+    <Stack
+      direction="column"
+      spacing={3}
+      alignItems="flex-start"
+      {...stackProps}
+    >
       {variables.length === 0 && readOnly && (
         <Typography>
           <i>No environment variables have been defined.</i>
         </Typography>
       )}
-      {variables.map((pair, idx) => {
-        if (!pair) return null;
-        const elementKey = `env-variable-${idx}`;
-        const isValidName =
-          pair.name.length === 0 || isValidEnvironmentVariableName(pair.name);
-        return (
-          <Stack
-            direction="row"
-            alignItems="center"
-            spacing={1}
-            sx={{ maxWidth: "40rem" }}
-            key={elementKey}
-          >
-            <Tooltip
-              title="Must be alphanumeric characters mixed with underscores or hyphens"
-              open={!isValidName}
-              arrow
-            >
-              <TextField
-                key={`${elementKey}-name`}
-                error={!isValidName}
-                value={pair.name || ""}
-                onChange={(e) => {
-                  onChange(e.target.value, idx, "name");
-                }}
-                label="Name"
-                disabled={readOnly === true}
-                data-test-id={`${testId}-env-var-name`}
-                data-test-title={`${testId}-env-var-${pair.name}-name`}
-              />
-            </Tooltip>
-            <TextField
-              key={`${elementKey}-value`}
-              value={pair.value || ""}
-              onChange={(e) => onChange(e.target.value, idx, "value")}
-              label="Value"
-              disabled={readOnly === true}
-              data-test-id={`${testId}-env-var-value`}
-              data-test-title={`${testId}-env-var-${pair.name}-value`}
-            />
-            {!readOnly && (
-              <IconButton title="Delete entry" onClick={() => remove(idx)}>
-                <DeleteIcon />
-              </IconButton>
-            )}
-          </Stack>
-        );
-      })}
+      {variables.map((variable, index) => (
+        <EnvVarInput
+          {...variable}
+          key={index}
+          disabled={readOnly}
+          onChange={(name, value) => update(index, name, value)}
+          onRemove={() => remove(index)}
+          revealed={!Boolean(variable.value)}
+        />
+      ))}
       {!readOnly && (
-        <Button
-          startIcon={<AddIcon />}
-          color="primary"
-          onClick={onAdd}
-          data-test-id={`${testId}-env-var-add`}
-        >
+        <Button startIcon={<AddIcon />} color="primary" onClick={add}>
           New variable
         </Button>
       )}
     </Stack>
   );
 };
-
-export default EnvVarList;

--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobEnvVariables.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobEnvVariables.tsx
@@ -1,4 +1,4 @@
-import EnvVarList, { EnvVarPair } from "@/components/EnvVarList";
+import { EnvVarList, EnvVarPair } from "@/components/EnvVarList";
 import {
   envVariablesArrayToDict,
   envVariablesDictToArray,
@@ -57,7 +57,7 @@ export const EditJobEnvVariables = () => {
 
   return (
     <EnvVarList
-      value={envVariables || []}
+      variables={envVariables || []}
       setValue={setEnvVariables}
       readOnly={isReadOnly}
     />

--- a/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/PipelineSettingsView.tsx
@@ -5,7 +5,7 @@ import {
   DataTableColumn,
   DataTableRow,
 } from "@/components/DataTable";
-import EnvVarList from "@/components/EnvVarList";
+import { EnvVarList } from "@/components/EnvVarList";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import { useSessionsContext } from "@/contexts/SessionsContext";
@@ -583,7 +583,7 @@ export const PipelineSettingsView: React.FC = () => {
                 )}
                 {isReadOnly ? (
                   <EnvVarList
-                    value={envVariables}
+                    variables={envVariables}
                     readOnly
                     data-test-id="pipeline-read-only"
                   />
@@ -599,7 +599,7 @@ export const PipelineSettingsView: React.FC = () => {
                         Project environment variables
                       </Typography>
                       <EnvVarList
-                        value={projectEnvVariables}
+                        variables={projectEnvVariables}
                         readOnly
                         data-test-id="project-read-only"
                       />
@@ -613,7 +613,7 @@ export const PipelineSettingsView: React.FC = () => {
                         Pipeline environment variables
                       </Typography>
                       <EnvVarList
-                        value={envVariables}
+                        variables={envVariables}
                         setValue={setEnvVariables}
                         data-test-id="pipeline"
                       />

--- a/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
@@ -1,5 +1,5 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
-import EnvVarList, { EnvVarPair } from "@/components/EnvVarList";
+import { EnvVarList, EnvVarPair } from "@/components/EnvVarList";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { Service } from "@/types";
 import CheckIcon from "@mui/icons-material/Check";

--- a/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
+++ b/services/orchest-webserver/client/src/views/ProjectSettingsView.tsx
@@ -1,6 +1,6 @@
 import { projectsApi } from "@/api/projects/projectsApi";
 import { PageTitle } from "@/components/common/PageTitle";
-import EnvVarList, { EnvVarPair } from "@/components/EnvVarList";
+import { EnvVarList, EnvVarPair } from "@/components/EnvVarList";
 import { Layout } from "@/components/layout/Layout";
 import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
@@ -231,7 +231,7 @@ const ProjectSettingsView: React.FC = () => {
                 <h3 className="push-down">Project environment variables</h3>
 
                 <EnvVarList
-                  value={envVariables}
+                  variables={envVariables}
                   setValue={setUnsavedEnvVariables}
                   data-test-id="project"
                 />


### PR DESCRIPTION
## Description

This PR makes all environment variables "secret" by default, meaning you have to click a "reveal" button to make them visible. However, if the value of the variable is empty; the input is automatically revealed as this makes it more convenient to enter a value.

https://user-images.githubusercontent.com/8259221/199490076-a3b83b01-f0cc-4cb9-91bc-2cd41d3f38c7.mp4

I decided to create a new component called `EnvVarInput` to more easily encapsulate the "revealed" state and some logic around that.

Fixes: #679

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

## Tests

- [x] Ensure it works as intended in ...
  - [x] The project settings
  - [x] The pipeline settings
  - [x] The job settings