### PR TITLE
Replace "Unable to fetch sessions" alert with unintrusive snackbar message

### DIFF
--- a/services/orchest-webserver/client/src/header-bar/HeaderBar.tsx
+++ b/services/orchest-webserver/client/src/header-bar/HeaderBar.tsx
@@ -1,6 +1,5 @@
 import { IconButton } from "@/components/common/IconButton";
 import { useGlobalContext } from "@/contexts/GlobalContext";
-import { useSessionsPoller } from "@/hooks/useSessionsPoller";
 import LogoutIcon from "@mui/icons-material/Logout";
 import AppBar from "@mui/material/AppBar";
 import Stack from "@mui/material/Stack";
@@ -8,10 +7,10 @@ import Toolbar from "@mui/material/Toolbar";
 import React from "react";
 import { ProjectSelector } from "../project-selector/ProjectSelector";
 import { NavigationTabs } from "./NavigationTabs";
+import { SessionStatus } from "./SessionStatus";
 
 export const HeaderBar = () => {
   const { user_config } = useGlobalContext();
-  useSessionsPoller();
 
   const logoutHandler = () => {
     window.location.href = "/login/clear";
@@ -29,6 +28,8 @@ export const HeaderBar = () => {
         height: (theme) => theme.spacing(7),
       }}
     >
+      <SessionStatus />
+
       <Toolbar
         variant="dense"
         sx={{ justifyContent: "space-between", paddingLeft: "0 !important" }}

--- a/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
+++ b/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
@@ -1,0 +1,93 @@
+import { SnackBar } from "@/components/common/SnackBar";
+import { useSessionsPoller } from "@/hooks/useSessionsPoller";
+import CheckOutlined from "@mui/icons-material/CheckOutlined";
+import ErrorOutline from "@mui/icons-material/ErrorOutline";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import blue from "@mui/material/colors/blue";
+import green from "@mui/material/colors/green";
+import red from "@mui/material/colors/red";
+import Snackbar from "@mui/material/Snackbar";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+type ConnectionStatus = "ok" | "trying" | "failed";
+
+const FAILURES_ERROR = 180;
+const FAILURES_TRYING = 5;
+
+export const SessionStatus = () => {
+  const { failures } = useSessionsPoller();
+  const [initialized, setInitialized] = React.useState(false);
+  const [status, setStatus] = React.useState<ConnectionStatus>("ok");
+
+  React.useEffect(() => {
+    if (status !== "ok") setInitialized(true);
+  }, [status]);
+
+  React.useEffect(() => {
+    setStatus(
+      failures > FAILURES_ERROR
+        ? "failed"
+        : failures > FAILURES_TRYING
+        ? "trying"
+        : "ok"
+    );
+
+    const handle = window.setTimeout(() => {
+      // If there hasn't been a failure for some time
+      // we reset the state to remove the banner.
+      // This removes it from pages where the session is not needed.
+      setStatus("ok");
+      setInitialized(false);
+    }, 2500);
+
+    return () => window.clearTimeout(handle);
+  }, [failures]);
+
+  return (
+    <>
+      <Snackbar
+        open={initialized && status === "ok"}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        message={
+          <Stack direction="row" spacing={2} alignItems="center">
+            <CheckOutlined sx={{ fill: green[400] }} />
+
+            <Typography variant="subtitle2">Session connected!</Typography>
+          </Stack>
+        }
+      />
+      <SnackBar
+        open={status === "trying"}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        message={
+          <Stack direction="row" spacing={2} alignItems="center">
+            <CircularProgress size={24} sx={{ color: blue[200] }} />
+
+            <Typography variant="subtitle2">
+              Trying to connect to session…
+            </Typography>
+          </Stack>
+        }
+      />
+      <SnackBar
+        open={status === "failed"}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        message={
+          <Stack direction="row" spacing={2} alignItems="center">
+            <ErrorOutline sx={{ fill: red[500] }} />
+
+            <Box>
+              <Typography variant="subtitle2">
+                Pipeline runs and JupyterLab unavailable
+              </Typography>
+              Failed to connect to session
+            </Box>
+          </Stack>
+        }
+      />
+    </>
+  );
+};

--- a/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
+++ b/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
@@ -19,11 +19,19 @@ const FAILURES_TRYING = 5;
 
 export const SessionStatus = () => {
   const { failures, isPolling } = useSessionsPoller();
-  const [initialized, setInitialized] = React.useState(false);
+  const [hadIssue, setHadIssue] = React.useState(false);
   const [status, setStatus] = React.useState<ConnectionStatus>("ok");
 
   React.useEffect(() => {
-    if (status !== "ok") setInitialized(true);
+    if (status !== "ok") setHadIssue(true);
+  }, [status]);
+
+  React.useEffect(() => {
+    // Clear the "success message" after some time.
+    const handle =
+      status === "ok" ? window.setTimeout(() => setHadIssue(false), 2500) : -1;
+
+    return () => window.clearTimeout(handle);
   }, [status]);
 
   React.useEffect(() => {
@@ -39,7 +47,7 @@ export const SessionStatus = () => {
       // If there hasn't been a failure for some time
       // we reset the state to remove the banner.
       setStatus("ok");
-      setInitialized(false);
+      setHadIssue(false);
     }, 2500);
 
     return () => window.clearTimeout(handle);
@@ -50,7 +58,7 @@ export const SessionStatus = () => {
   return (
     <>
       <Snackbar
-        open={initialized && status === "ok"}
+        open={hadIssue && status === "ok"}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={
           <Stack direction="row" spacing={2} alignItems="center">

--- a/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
+++ b/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
@@ -18,7 +18,7 @@ const FAILURES_ERROR = 180;
 const FAILURES_TRYING = 5;
 
 export const SessionStatus = () => {
-  const { failures } = useSessionsPoller();
+  const { failures, isPolling } = useSessionsPoller();
   const [initialized, setInitialized] = React.useState(false);
   const [status, setStatus] = React.useState<ConnectionStatus>("ok");
 
@@ -38,13 +38,14 @@ export const SessionStatus = () => {
     const handle = window.setTimeout(() => {
       // If there hasn't been a failure for some time
       // we reset the state to remove the banner.
-      // This removes it from pages where the session is not needed.
       setStatus("ok");
       setInitialized(false);
     }, 2500);
 
     return () => window.clearTimeout(handle);
   }, [failures]);
+
+  if (!isPolling) return null;
 
   return (
     <>

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -44,7 +44,7 @@ export const useSessionsPoller = () => {
   // sessions are only needed when both conditions are met
   // 1. in the ConfigureJupyterLabView (they are root views without a pipeline_uuid)
   // 2. in the above views AND pipelineUuid is given AND is not read-only
-  const shouldPoll =
+  const isPolling =
     matchRooViews?.isExact ||
     (!pipelineReadOnlyReason &&
       hasValue(pipeline) &&
@@ -84,16 +84,16 @@ export const useSessionsPoller = () => {
           });
         }
       }),
-    shouldPoll ? 1000 : undefined
+    isPolling ? 1000 : undefined
   );
 
   React.useEffect(() => {
-    if (shouldPoll) fetchSessions();
-  }, [shouldPoll, fetchSessions]);
+    if (isPolling) fetchSessions();
+  }, [isPolling, fetchSessions]);
 
   React.useEffect(() => {
     if (error) setFailures((current) => current + 1);
   }, [error]);
 
-  return { failures, error };
+  return { failures, error, isPolling };
 };

--- a/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
+++ b/services/orchest-webserver/client/src/hooks/useSessionsPoller.ts
@@ -1,4 +1,3 @@
-import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useProjectsContext } from "@/contexts/ProjectsContext";
 import {
   getSessionKey,
@@ -24,13 +23,11 @@ type FetchSessionResponse = {
   status: TSessionStatus;
 };
 
-/**
- * NOTE: useSessionsPoller should only be placed in HeaderBar
- */
+/** NOTE: useSessionsPoller should only be placed in SessionStatus in HeaderBar*/
 export const useSessionsPoller = () => {
+  const [failures, setFailures] = React.useState(0);
   const { location, pipelineUuid } = useCustomRoute();
   const { dispatch } = useSessionsContext();
-  const { setAlert } = useGlobalContext();
   const {
     state: { pipeline, pipelineReadOnlyReason },
   } = useProjectsContext();
@@ -79,6 +76,8 @@ export const useSessionsPoller = () => {
     () =>
       fetchSessions().then((response) => {
         if (response) {
+          setFailures(0);
+
           dispatch({
             type: "SET_SESSIONS",
             payload: response,
@@ -93,9 +92,8 @@ export const useSessionsPoller = () => {
   }, [shouldPoll, fetchSessions]);
 
   React.useEffect(() => {
-    if (error) {
-      setAlert("Error", "Unable to fetch sessions.");
-      console.error("Unable to fetch sessions", error);
-    }
-  }, [error, setAlert]);
+    if (error) setFailures((current) => current + 1);
+  }, [error]);
+
+  return { failures, error };
 };


### PR DESCRIPTION
## Description

This PR removes the "Unable to fetch sessions" error dialog, in favor of a snackbar message that is less intrusive. This snackbar is only displayed after a few initial attempts to fetch sessions have failed and is only displayed in the "Pipelines" and "JupyterLab" views, where it is relevant.

https://user-images.githubusercontent.com/8259221/200020531-8bc768ec-0f76-498c-978d-890954281614.mp4

The logic for which the snackbar is displayed is this:
- Nothing is displayed if it succeeds in getting the session status under five tries (~5 seconds).
- We start displaying the spinner if it fails more than five times
- We display the error message if it fails more than 180 times (~3 minutes).
  - The user likely has to do some intervention here. There is probably something wrong with the instance.
- If any previous message was displayed, and if at any point the connection succeeds, "Session connected!" is displayed for 2.5 seconds.

The aforementioned "error message":
![image](https://user-images.githubusercontent.com/8259221/200021110-10103034-fd24-4f97-a7ca-b39854087c2e.png)


## Checklist

- [x] I have manually tested my changes and am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.