### PR TITLE
Move all Snackbar message to bottom center.

### DIFF
--- a/services/orchest-webserver/client/src/components/common/SnackBar.tsx
+++ b/services/orchest-webserver/client/src/components/common/SnackBar.tsx
@@ -3,19 +3,17 @@ import MuiSnackbar, { SnackbarProps } from "@mui/material/Snackbar";
 import React from "react";
 
 export const SnackBar = (props: SnackbarProps) => {
-  const isShowingSnackbar = React.useMemo(() => {
-    return (
-      Boolean(props.open) &&
-      props.anchorOrigin?.vertical === "bottom" &&
-      props.anchorOrigin?.horizontal === "right"
-    );
-  }, [
-    props.open,
-    props.anchorOrigin?.vertical,
-    props.anchorOrigin?.horizontal,
-  ]);
+  const overlapsIntercom =
+    Boolean(props.open) &&
+    props.anchorOrigin?.vertical === "bottom" &&
+    props.anchorOrigin?.horizontal === "right";
 
-  useHideIntercom(isShowingSnackbar);
+  useHideIntercom(overlapsIntercom);
 
-  return <MuiSnackbar {...props} />;
+  return (
+    <MuiSnackbar
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      {...props}
+    />
+  );
 };

--- a/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
+++ b/services/orchest-webserver/client/src/header-bar/SessionStatus.tsx
@@ -68,7 +68,6 @@ export const SessionStatus = () => {
     <>
       <Snackbar
         open={showConnected}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={
           <Stack direction="row" spacing={2} alignItems="center">
             <CheckOutlined sx={{ fill: green[400] }} />
@@ -79,7 +78,6 @@ export const SessionStatus = () => {
       />
       <SnackBar
         open={status === "trying"}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={
           <Stack direction="row" spacing={2} alignItems="center">
             <CircularProgress size={24} sx={{ color: blue[200] }} />
@@ -92,7 +90,6 @@ export const SessionStatus = () => {
       />
       <SnackBar
         open={status === "failed"}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
         message={
           <Stack direction="row" spacing={2} alignItems="center">
             <ErrorOutline sx={{ fill: red[500] }} />

--- a/services/orchest-webserver/client/src/jobs-view/job-view/WebhookHint.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/WebhookHint.tsx
@@ -63,7 +63,6 @@ export const WebhookHint = () => {
     <SnackBar
       open={showHint}
       autoHideDuration={6000}
-      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       onClose={closeHintAndDisable}
       message="Use webhooks to get notified when pipeline runs fail"
       action={action}

--- a/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobSnackBar.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobSnackBar.tsx
@@ -50,7 +50,6 @@ export const ScheduleJobSnackBar = () => {
   return (
     <SnackBar
       open={hasValue(snackBarMessage)}
-      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       autoHideDuration={3000}
       onClose={closeSnackBar}
       message={snackBarMessage}

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -324,7 +324,6 @@ const ConfigureJupyterLabView: React.FC = () => {
         )}
       </Box>
       <SnackBar
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         open={showStoppingAllSessionsWarning}
         message="Stopping all active sessions..."
       />


### PR DESCRIPTION
## Description

For #1409 @ncspost mentioned that "the best position for Snackbars is the center for Orchest". So this PR changes that.
The `Snackbar` component will now (by default) be displayed in the bottom center of the app.

This also means that we don't have to hide the Intercom-button in the general case.

## Checklist

- [x] I have manually tested my changes and am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.