### PR TITLE
Fix can't view service under pipeline settings

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/ServiceForm.tsx
@@ -469,7 +469,7 @@ const ServiceForm: React.FC<{
                   Environment variables
                 </FormSectionTitle>
                 <EnvVarList
-                  value={envVarsDictToList(service.env_variables || {})}
+                  variables={envVarsDictToList(service.env_variables || {})}
                   readOnly={disabled}
                   setValue={(
                     dispatcher: (


### PR DESCRIPTION
## Description

Currently, clicking on a service causes the page to go blank, this is due to a bad rename from #1406.
This PR fixes that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.