### PR TITLE
Update file tree when duplicating a file

### DIFF
--- a/services/orchest-webserver/client/src/api/files/fileApi.ts
+++ b/services/orchest-webserver/client/src/api/files/fileApi.ts
@@ -64,10 +64,19 @@ const createDirectory = async (params: NodeParams) => {
   );
 };
 
+const duplicate = async (projectUuid: string, root: string, path: string) =>
+  await fetch(
+    join(FILE_MANAGEMENT_ENDPOINT, "duplicate") +
+      "?" +
+      queryArgs({ path, root, projectUuid }),
+    { method: "POST" }
+  );
+
 export const filesApi = {
   fetchNode,
   deleteNode,
   moveNode,
   createFile,
+  duplicate,
   createDirectory,
 };


### PR DESCRIPTION
## Description

When duplicating a file, the file tree is not currently updated with the new duplicated file after it succeeds.

This PR fixes that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
