### PR TITLE
Fix broken command palette "Page:" shortcuts

### DIFF
--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -11,7 +11,6 @@ export type RouteName =
   | "jobs"
   | "jobRun"
   | "jobRunFilePreview"
-  | "snapshotFilePreview"
   | "pipelineReadonly"
   | "editJob"
   | "fileManager"
@@ -216,11 +215,13 @@ export const generatePathFromRoute = <T extends string>(
 };
 
 // Exclude detail views
-const excludedPaths = [
+const excludedPaths: readonly string[] = [
   siteMap.pipeline.path,
   siteMap.projectSettings.path,
   siteMap.jupyterLab.path,
   siteMap.filePreview.path,
+  siteMap.jobRunFilePreview.path,
+  siteMap.jobRun.path,
 ];
 
 // used in CommandPalette

--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -72,13 +72,6 @@ export const getOrderedRoutes = (getTitle = _getTitle) => {
       scope: ["projectUuid", "pipelineUuid"],
     },
     {
-      name: "logs",
-      path: "/logs",
-      root: "/pipeline",
-      title: getTitle("Logs"),
-      scope: ["projectUuid", "pipelineUuid"],
-    },
-    {
       name: "environments",
       path: "/environments",
       title: getTitle("Environments"),
@@ -95,13 +88,6 @@ export const getOrderedRoutes = (getTitle = _getTitle) => {
       path: "/job-run",
       root: "/jobs",
       title: getTitle("Job Run"),
-      scope: ["projectUuid", "jobRunUuid", "pipelineUuid"],
-    },
-    {
-      name: "jobRunLogs",
-      path: "/job-run/logs",
-      root: "/jobs",
-      title: getTitle("Job Run Logs"),
       scope: ["projectUuid", "jobRunUuid", "pipelineUuid"],
     },
     {


### PR DESCRIPTION
## Description

Also removes both `/logs` entries from the sitemap, since those are no longer available.

These are the remaining ones:

![image](https://user-images.githubusercontent.com/8259221/201363459-9cc1333d-ac29-4e2c-b66a-9a936b1a1fa0.png)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.