### PR TITLE
Fix: Make sure panel max width is based on current window width

### DIFF
--- a/services/orchest-webserver/client/src/components/layout/MainSidePanel.tsx
+++ b/services/orchest-webserver/client/src/components/layout/MainSidePanel.tsx
@@ -2,7 +2,6 @@ import { ResizablePane } from "@/components/ResizablePane";
 import { SxProps, Theme } from "@mui/material";
 import React from "react";
 import {
-  MAX_WIDTH,
   MIN_MAIN_SIDE_PANEL_WIDTH,
   useMainSidePanelWidth,
 } from "./stores/useLayoutStore";
@@ -27,7 +26,7 @@ export const MainSidePanel: React.FC = (props) => {
       direction="horizontal"
       initialSize={mainSidePanelWidth}
       minWidth={MIN_MAIN_SIDE_PANEL_WIDTH}
-      maxWidth={MAX_WIDTH}
+      maxWidth={window.innerWidth / 2}
       position="relative"
       sx={paneSx}
       onSetSize={setMainSidePanelWidth}

--- a/services/orchest-webserver/client/src/components/layout/stores/useLayoutStore.tsx
+++ b/services/orchest-webserver/client/src/components/layout/stores/useLayoutStore.tsx
@@ -18,7 +18,6 @@ const DEFAULT_MAIN_SIDE_PANEL_WIDTH = 300;
 export const MIN_MAIN_SIDE_PANEL_WIDTH = 280;
 const DEFAULT_SECONDARY_SIDE_PANEL_WIDTH = 450;
 export const MIN_SECONDARY_SIDE_PANEL_WIDTH = 420;
-export const MAX_WIDTH = window.innerWidth / 2;
 
 export const useLayoutStore = create(
   persist<LayoutState>(
@@ -29,7 +28,7 @@ export const useLayoutStore = create(
           mainSidePanelWidth: clamp(
             getValue(mainSidePanelWidth, value),
             MIN_MAIN_SIDE_PANEL_WIDTH,
-            MAX_WIDTH
+            window.innerWidth / 2
           ),
         }));
       },
@@ -39,7 +38,7 @@ export const useLayoutStore = create(
           secondarySidePanelWidth: clamp(
             getValue(secondarySidePanelWidth, value),
             MIN_SECONDARY_SIDE_PANEL_WIDTH,
-            MAX_WIDTH
+            window.innerWidth / 2
           ),
         }));
       },

--- a/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobPanel.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/schedule-job/ScheduleJobPanel.tsx
@@ -1,6 +1,5 @@
 import { Overflowable } from "@/components/common/Overflowable";
 import {
-  MAX_WIDTH,
   MIN_SECONDARY_SIDE_PANEL_WIDTH,
   useSecondarySidePanelWidth,
 } from "@/components/layout/stores/useLayoutStore";
@@ -45,7 +44,7 @@ export const ScheduleJobPanel = () => {
       onSetSize={setPanelWidth}
       initialSize={panelWidth}
       minWidth={MIN_SECONDARY_SIDE_PANEL_WIDTH}
-      maxWidth={MAX_WIDTH}
+      maxWidth={window.innerWidth / 2}
       sx={{
         position: "relative",
         display: "flex",

--- a/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/step-details/StepDetails.tsx
@@ -1,7 +1,6 @@
 import { Overflowable } from "@/components/common/Overflowable";
 import { TabLabel, TabPanel, Tabs } from "@/components/common/Tabs";
 import {
-  MAX_WIDTH,
   MIN_SECONDARY_SIDE_PANEL_WIDTH,
   useSecondarySidePanelWidth,
 } from "@/components/layout/stores/useLayoutStore";
@@ -96,7 +95,7 @@ const StepDetailsComponent = ({ onSave, onClose }: StepDetailsProps) => {
         onSetSize={setStepDetailsPanelWidth}
         initialSize={stepDetailsPanelWidth}
         minWidth={MIN_SECONDARY_SIDE_PANEL_WIDTH}
-        maxWidth={MAX_WIDTH}
+        maxWidth={window.innerWidth / 2}
         sx={{
           position: "relative",
           display: "flex",


### PR DESCRIPTION
## Description

Currently, the max width for the side panels/drawers is based on the initial window width (when the page is loaded) and is never updated.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.