### PR TITLE
Create a port name for each user service port

### DIFF
--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -986,7 +986,14 @@ def _get_user_service_deployment_service_manifest(
         "spec": {
             "type": "ClusterIP",
             "selector": metadata["labels"],
-            "ports": [{"port": port} for port in service_config["ports"]],
+            "ports": [
+                {
+                    "port": port,
+                    # Must be a DNS_LABEL.
+                    "name": f"port-{port}",
+                }
+                for port in service_config["ports"]
+            ],
         },
     }
 


### PR DESCRIPTION
## Description

The request would otherwise fail since the port name is required when a service has more than one port.


- [X] I have manually tested my changes and I am happy with the result.

