### PR TITLE
Support stopping starting sessions

### DIFF
--- a/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
+++ b/services/orchest-webserver/client/src/components/SessionToggleButton.tsx
@@ -38,11 +38,9 @@ const SessionToggleButton = (props: ISessionToggleButtonProps) => {
     _: React.MouseEvent | React.ChangeEvent,
     checked: boolean
   ) => {
-    const shouldStart = checked || !session;
-
-    if (shouldStart) {
+    if (checked) {
       startSession(pipelineUuid, BUILD_IMAGE_SOLUTION_VIEW.PIPELINE);
-    } else {
+    } else if (!checked && (isLaunching || isRunning)) {
       stopSession(pipelineUuid);
     }
   };
@@ -54,7 +52,7 @@ const SessionToggleButton = (props: ISessionToggleButtonProps) => {
       control={
         <Switch
           classes={{ root: isLaunching ? "launching" : "" }}
-          disabled={isLaunching || isStopping}
+          disabled={isStopping}
           size="small"
           inputProps={{
             "aria-label": `Switch ${isRunning ? "off" : "on"} session`,


### PR DESCRIPTION
## Description

This PR removes the disabled state from the session toggle buttons while sessions are starting, allowing you to stop sessions before they are started.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.