### PR TITLE
Pin pydata-sphinx-theme to avoid accessibility issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ myst-parser
 docutils>=0.18.1
 sphinx-design
 sphinx-version-warning
-pydata-sphinx-theme>=0.7.1
+pydata-sphinx-theme>=0.7.1,<0.12.0  # See https://github.com/orchest/orchest/issues/1445

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ html_theme_options = {
         {"url": "https://orchest.io", "name": "Website"},
     ],
     "navbar_align": "left",
-    "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
+    "page_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
     "navbar_center": ["navbar-nav"],
     "navbar_end": ["theme-switcher", "navbar-icon-links.html", "search-field.html"],
     "show_toc_level": 1,


### PR DESCRIPTION
Addresses (hopefully) gh-1445. It's a workaround and doesn't go to the root cause, but this has been difficult to reproduce in some environments so it's a quick solution.

## Description

Description (including a screenshot/video if applicable) of what your PR solves or adds.

Fixes: #issue

## Checklist

- [ ] I have manually tested my changes and I am happy with the result.
- [ ] The documentation reflects the changes.
- [ ] The PR branch is set up to merge into `dev` instead of `master`.
- [ ] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [ ] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [ ] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [ ] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [ ] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
