### PR TITLE
Only consider `PENDING|STARTED` jobs for the `next_scheduled_job` query/endpoint

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -1181,7 +1181,12 @@ class UpdateJobParameters(TwoPhaseFunction):
         max_retained_pipeline_runs: int,
         confirm_draft,
     ):
-        job = models.Job.query.with_for_update().filter_by(uuid=job_uuid).one()
+        job = (
+            models.Job.query.with_for_update()
+            .filter(models.Job.status.not_in(["SUCCESS", "ABORTED", "FAILURE"]))
+            .filter_by(uuid=job_uuid)
+            .one()
+        )
         old_job = job.as_dict()
 
         if name is not None:

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -114,7 +114,7 @@ class NextScheduledJob(Resource):
             next_job = next_job.filter_by(project_uuid=request.args["project_uuid"])
 
         next_job = (
-            next_job.filter(models.Job.status != "DRAFT")
+            next_job.filter(models.Job.status.in_(["PENDING", "STARTED"]))
             .filter(models.Job.next_scheduled_time.isnot(None))
             # Order by time ascending so that the job that will be
             # scheduled next is returned, even if the scheduler is


### PR DESCRIPTION
## Description

Tightens the query (although the filters are now slightly overlapping assuming `next_scheduled_time` is always updated correctly) in order to avoid an incorrect state affecting the result of the endpoint. One use case is limiting the damage of the inconsistent state that could have been created in releases prior to this race condition fix: https://github.com/orchest/orchest/commit/9b7eefeb2c2908329466b0407c75ec3a39603fde

## Checklist

- [X] I have manually tested my changes and I am happy with the result.
