### PR TITLE
Detect cluster nodes readiness when scheduling pods

### DIFF
--- a/services/orchest-api/app/app/core/pod_scheduling.py
+++ b/services/orchest-api/app/app/core/pod_scheduling.py
@@ -36,7 +36,7 @@ def _get_k8s_nodes_information() -> Tuple[List[str], List[str]]:
 def _get_k8s_nodes_information_cached_with_ttl(
     ttl_period: int,
 ) -> Tuple[List[str], List[str]]:
-    nodes = k8s_core_api.CoreV1Api.list_node()
+    nodes = k8s_core_api.list_node()
     known_nodes_names = []
     ready_nodes_names = []
     for node in nodes.items:


### PR DESCRIPTION
## Description

Before deciding on where to schedule pods the `orchest-api` will check with the k8s api what's the state of the nodes of the cluster, which avoids scheduling pods on nodes that have been removed from the cluster or are not considered ready.