### PR TITLE
Just show disk used for very large available GB sizes

### DIFF
--- a/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
@@ -121,6 +121,14 @@ const SettingsView: React.FC = () => {
     }
   }, [userConfig]);
 
+  // Assuming any 2TB+ available GB indication to be
+  // unreliable. This is mainly due to unconstrained
+  // storage systems like EFS that report a fictitious
+  // upper bound of the storage.
+  const isDiskUsageReliable = hostInfo
+    ? hostInfo.disk_info.avail_GB < 2000
+    : false;
+
   return (
     <Layout>
       <div className={"view-page orchest-settings"}>
@@ -201,17 +209,26 @@ const SettingsView: React.FC = () => {
               <div className="column">
                 {hostInfo ? (
                   <>
-                    <LinearProgress
-                      className="disk-size-info"
-                      variant="determinate"
-                      value={hostInfo.disk_info.used_pcent}
-                    />
+                    {isDiskUsageReliable && (
+                      <LinearProgress
+                        className="disk-size-info"
+                        variant="determinate"
+                        value={hostInfo.disk_info.used_pcent}
+                      />
+                    )}
 
-                    <div className="disk-size-info push-up-half">
+                    <div
+                      className={
+                        "disk-size-info" +
+                        (isDiskUsageReliable ? " push-up-half" : "")
+                      }
+                    >
                       <span>{hostInfo.disk_info.used_GB + "GB used"}</span>
-                      <span className="float-right">
-                        {hostInfo.disk_info.avail_GB + "GB free"}
-                      </span>
+                      {isDiskUsageReliable && (
+                        <span className="float-right">
+                          {hostInfo.disk_info.avail_GB + "GB free"}
+                        </span>
+                      )}
                     </div>
                   </>
                 ) : (


### PR DESCRIPTION
## Description

Above 2TB available storage:
![image](https://user-images.githubusercontent.com/1309307/205643803-41398b13-1666-4663-8fc3-61776d98b166.png)

Below 2TB available storage:
![image](https://user-images.githubusercontent.com/1309307/205643904-c48ea099-1838-477d-9f81-3ec9753803f1.png)

This handles the EFS storage case (no hard upper limit) more gracefully.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.