### PR TITLE
Update flake8 URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
           - eslint-plugin-react-hooks@4.2.0
           - "@typescript-eslint/eslint-plugin@4.29.3"
           - "@typescript-eslint/parser@4.29.3"
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
## Description

Update flake8 URL to avoid `fatal: could not read Username for 'https://gitlab.com/': No such device or address` (see for example https://github.com/orchest/orchest/actions/runs/3603114378/jobs/6070903616#step:6:66)

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The documentation reflects the changes.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
- [x] I haven't introduced breaking changes that would disrupt existing jobs, i.e. backwards compatibility is maintained.
- [x] In case I changed the dependencies in any `requirements.in` I have run `pip-compile` to update the corresponding `requirements.txt`.
- [x] In case I changed one of the services' `models.py` I have performed the appropriate database migrations (refer to the [DB migration docs](https://docs.orchest.io/en/stable/development/development_workflow.html#database-schema-migrations)).
- [x] In case I changed code in the `orchest-sdk` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-sdk/python/RELEASE-CHECKLIST.md).
- [x] In case I changed code in the `orchest-cli` I followed its [release checklist](https://github.com/orchest/orchest/blob/master/orchest-cli/RELEASE-CHECKLIST.md).
