### PR TITLE
Fix job parameter rendering issues

### DIFF
--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobParameters.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobParameters.tsx
@@ -27,8 +27,7 @@ export const EditJobParameters = ({ isReadOnly }: EditJobParametersProps) => {
   const initialStrategyJson = useEditJob(
     (state) => state.jobChanges?.strategy_json,
     (existingStrategy = {}) => {
-      const existingStrategyKeys = Object.keys(existingStrategy);
-      return existingStrategyKeys.length > 0 && !hasChangedPipeline;
+      return hasChangedPipeline && Object.keys(existingStrategy).length > 0;
     }
   );
 
@@ -89,7 +88,7 @@ const ParameterEditor = ({
       <AccordionSummary aria-controls="job-parameters">
         <Typography variant="subtitle1">
           {parameter.title
-            ? capitalize(source) + " " + parameter.title
+            ? capitalize(source) + ": " + parameter.title
             : "Unnamed " + source}
         </Typography>
       </AccordionSummary>

--- a/services/orchest-webserver/client/src/jobs-view/job-view/EditJobParameters.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/EditJobParameters.tsx
@@ -3,7 +3,6 @@ import {
   AccordionDetails,
   AccordionSummary,
 } from "@/components/Accordion";
-import { useHasChanged } from "@/hooks/useHasChanged";
 import { StrategyJsonValue } from "@/types";
 import { capitalize } from "@mui/material";
 import Typography from "@mui/material/Typography";
@@ -18,29 +17,18 @@ type EditJobParametersProps = {
 };
 
 export const EditJobParameters = ({ isReadOnly }: EditJobParametersProps) => {
-  // When updating parameter values, `state.jobChanges.strategy_json` is also updated.
-  // But we don't want to re-render the whole form when this happens.
-  // Therefore, in `equals` function, check if existingStrategy is still empty.
-  // Don't re-render if it already has properties.
-  const pipelineUuid = useEditJob((state) => state.jobChanges?.pipeline_uuid);
-  const hasChangedPipeline = useHasChanged(pipelineUuid);
-  const initialStrategyJson = useEditJob(
-    (state) => state.jobChanges?.strategy_json,
-    (existingStrategy = {}) => {
-      return hasChangedPipeline && Object.keys(existingStrategy).length > 0;
-    }
-  );
+  const strategyJson = useEditJob((state) => state.jobChanges?.strategy_json);
 
   // Get the "pipeline_parameters" key.
   const { reservedKey } = useParameterReservedKey();
 
   const parameters = React.useMemo(() => {
-    if (!initialStrategyJson || !reservedKey) return undefined;
+    if (!strategyJson || !reservedKey) return undefined;
 
-    const { [reservedKey]: pipelineParams, ...other } = initialStrategyJson;
+    const { [reservedKey]: pipelineParams, ...other } = strategyJson;
 
     return { pipeline: pipelineParams, steps: Object.values(other) };
-  }, [initialStrategyJson, reservedKey]);
+  }, [strategyJson, reservedKey]);
 
   const shouldRenderPipelineEditor = hasValue(parameters);
   const hasNoParameter =


### PR DESCRIPTION
## Description

Sometimes the wrong job parameters show up in the UI: this PR fixes that.
It is a pure rendering problem: the back-end & backing state is fine.

The source of the issue seems to be an optimization to only re-render the form if the pipeline has changed _and_ if any parameters are specified. The problem with that is:
- The parameters may change depending on multiple reasons: project, job, or pipeline (and possibly something else).
- Having no parameters is a perfectly valid state: we should render that.

This caused the UI to behave erratically when jumping between jobs & pipelines: displaying the wrong parameters and names.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.