### PR TITLE
Fix: schemas not loading

### DIFF
--- a/services/orchest-webserver/app/app/views/views.py
+++ b/services/orchest-webserver/app/app/views/views.py
@@ -1095,7 +1095,7 @@ def register_views(app, db):
             return jsonify({"message": "Failed to process file_path."}), 500
 
         if os.path.isfile(file_path):
-            return send_file(filename_or_fp=file_path, max_age=0)
+            return send_file(file_path, max_age=0)
         else:
             return jsonify({"message": "File does not exists."}), 404
 


### PR DESCRIPTION
`file_path` is a positional (not named) argument now:
https://github.com/pallets/flask/issues/4753

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.