### PR TITLE
Fix bad "open" link next to pipeline selector

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-preview/StepPipelineSelector.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-preview/StepPipelineSelector.tsx
@@ -89,7 +89,7 @@ export const StepPipelineSelector = () => {
   };
 
   const pipelineLink = useRouteLink({
-    route: hasValue(jobUuid) ? "pipeline" : "jobRun",
+    route: hasValue(jobUuid) ? "jobRun" : "pipeline",
     query: { pipelineUuid },
     clear: ["stepUuid"],
   });


### PR DESCRIPTION
## Description

When clicking "open" in the step pipeline selector, you end up at the jobs page if you're at the pipelines page, and the pipelines page if you're on the job page.

This PR fixes that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.