### PR TITLE
Fix double-click issues in the file browser

### DIFF
--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileManager.tsx
@@ -1,4 +1,5 @@
 import { useFileApi } from "@/api/files/useFileApi";
+import { useCurrentQuery } from "@/hooks/useCustomRoute";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useFetchFileRoots } from "@/hooks/useFetchFileRoots";
 import { useUploader } from "@/hooks/useUploader";
@@ -61,6 +62,11 @@ export function FileManager() {
   const expanded = useExpandedFiles();
   const setExpanded = useFileManagerState((state) => state.setExpanded);
   const [progress, setProgress] = React.useState(0);
+  const { fileRoot, filePath } = useCurrentQuery();
+  const currentPath =
+    fileRoot && filePath
+      ? combinePath({ root: fileRoot as FileRoot, path: filePath })
+      : undefined;
 
   const { root, path: cwd } = unpackPath(
     nearestDirectory(selectedFiles[0] || DEFAULT_CWD)
@@ -165,15 +171,12 @@ export function FileManager() {
     [openPipeline, previewFile]
   );
 
-  const handleSelection = React.useCallback(
-    (selected: string[]) => {
-      if (selected.length !== 1) return;
-
-      // We want selections to apply, animations to finish,
-      // and so on, before opening the preview window
-      setTimeout(() => handleViewFile(unpackPath(selected[0])), 50);
+  const handlePreview = React.useCallback(
+    (selected: string) => {
+      if (currentPath === selected) return;
+      handleViewFile(unpackPath(selected));
     },
-    [handleViewFile]
+    [currentPath, handleViewFile]
   );
 
   return (
@@ -196,7 +199,7 @@ export function FileManager() {
         {allTreesHaveLoaded && (
           <>
             <FileTree
-              onSelect={handleSelection}
+              onSelect={handlePreview}
               treeRoots={fileRoots}
               expanded={expanded}
               onMoved={onMoved}

--- a/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
+++ b/services/orchest-webserver/client/src/pipeline-view/file-manager/FileTree.tsx
@@ -48,7 +48,7 @@ import { FileTreeRow } from "./FileTreeRow";
 export type FileTreeProps = {
   treeRoots: readonly FileRoot[];
   expanded: string[];
-  onSelect: (selected: string[]) => void;
+  onSelect: (combinedPath: string) => void;
   handleToggle: (
     event: React.SyntheticEvent<Element, Event>,
     nodeIds: string[]
@@ -421,7 +421,6 @@ export const FileTree = React.memo(function FileTreeComponent({
           if (event.type === "IGNORE") return;
 
           handleSelect(event, selected);
-          onSelect(selected);
         }}
         onNodeToggle={handleToggle}
         multiSelect
@@ -450,6 +449,7 @@ export const FileTree = React.memo(function FileTreeComponent({
                 hoveredPath={hoveredPath}
                 root={root}
                 onOpen={onOpen}
+                onClick={onSelect}
                 onRename={(oldPath, newPath) =>
                   handleMoves([[oldPath, newPath]])
                 }


### PR DESCRIPTION
## Description

It currently isn't possible to open files by double-clicking in the file browser. In short, this is because our `onSelect` and `onDoubleClick` handlers are "fighting each other", since they both cause a navigation.

This PR changes so that the "click to preview" reacts to `onClick` instead of `onNodeSelect`, and sets up a more lenient double-click handler alongside the default double-click handler to capture more clicks and provide more granular control over click behavior.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
