### PR TITLE
Fix: losing environment build status when switching browser tabs

### DIFF
--- a/services/orchest-webserver/client/src/api/environments/useEnvironmentsApi.ts
+++ b/services/orchest-webserver/client/src/api/environments/useEnvironmentsApi.ts
@@ -7,7 +7,7 @@ import {
   EnvironmentState,
   EnvironmentValidationData,
 } from "@/types";
-import { pick, toMap } from "@/utils/record";
+import { mapRecord, pick } from "@/utils/record";
 import create from "zustand";
 
 export type EnvironmentBuildStatus =
@@ -117,11 +117,11 @@ export const useEnvironmentsApi = create<EnvironmentsApi>((set, get) => {
 
       set((state) => {
         // `latestBuild` should be persisted as it was fetched from another endpoint..
-        const environmentsMap = toMap(state.environments || []);
+        const environmentsMap = mapRecord(state.environments || []);
         return {
           projectUuid,
           environments: environments.map((env) => {
-            const latestBuild = environmentsMap.get(env.uuid)?.latestBuild;
+            const latestBuild = environmentsMap[env.uuid]?.latestBuild;
             return { ...env, latestBuild };
           }),
         };
@@ -232,10 +232,10 @@ export const useEnvironmentsApi = create<EnvironmentsApi>((set, get) => {
 
       if (hasActionChanged || status !== get().status) {
         set((state) => {
-          const environmentsMap = toMap(state.environments || []);
+          const environmentsMap = mapRecord(state.environments || []);
           return {
             environments: validatedEnvironments.map((env) => ({
-              ...environmentsMap.get(env.uuid),
+              ...environmentsMap[env.uuid],
               ...env,
             })),
             status,

--- a/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
+++ b/services/orchest-webserver/client/src/environments-view/EnvironmentMenuList.tsx
@@ -1,4 +1,5 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
+import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { pick } from "@/utils/record";
 import MenuList from "@mui/material/MenuList";
 import Stack from "@mui/material/Stack";
@@ -28,7 +29,8 @@ export const EnvironmentMenuList = () => {
     selectEnvironment(event, uuid);
   };
 
-  const { hasLoadedBuildStatus } = useFetchBuildStatus();
+  const { environmentUuid } = useCustomRoute();
+  const { hasLoadedBuildStatus } = useFetchBuildStatus(environmentUuid);
 
   return (
     <Stack

--- a/services/orchest-webserver/client/src/environments-view/hooks/useFetchBuildStatus.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useFetchBuildStatus.tsx
@@ -8,7 +8,7 @@ import React from "react";
  * Fetches the latest environment image builds by polling.
  * Returns the latest environmentImageBuild of the given environment UUID.
  */
-export const useFetchBuildStatus = (environmentUuid?: string) => {
+export const useFetchBuildStatus = (environmentUuid: string | undefined) => {
   const projectUuid = useEnvironmentsApi((state) => state.projectUuid);
   const { projectUuid: validProjectUuid } = useValidQueryArgs({ projectUuid });
   const isStoreLoaded = useEnvironmentsApi(

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -196,7 +196,7 @@ export type CustomImage = Pick<
 >;
 
 export type EnvironmentImageBuild = {
-  uuid: string;
+  uuid: null; // TODO: clean this up on BE
   environment_uuid: string;
   finished_time: string;
   project_path: string;

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -213,7 +213,7 @@ export type JupyterImageBuild = {
   requested_time: string;
   started_time: null | string;
   status: TStatus;
-  uuid: string;
+  uuid: null;
 };
 
 export type PipelineStepStatus =

--- a/services/orchest-webserver/client/src/utils/record.ts
+++ b/services/orchest-webserver/client/src/utils/record.ts
@@ -61,3 +61,7 @@ export const equalsShallow = <T extends AnyRecord, A extends T>(
   actual: A,
   props = propsOf(expected)
 ) => props.every((prop) => actual[prop] === expected[prop]);
+
+export const toMap = <T>(arr: T[], key = "uuid") => {
+  return new Map<typeof key, T>(arr.map((env) => [env[key], env]));
+};

--- a/services/orchest-webserver/client/src/utils/record.ts
+++ b/services/orchest-webserver/client/src/utils/record.ts
@@ -62,6 +62,9 @@ export const equalsShallow = <T extends AnyRecord, A extends T>(
   props = propsOf(expected)
 ) => props.every((prop) => actual[prop] === expected[prop]);
 
-export const toMap = <T>(arr: T[], key = "uuid") => {
-  return new Map<typeof key, T>(arr.map((env) => [env[key], env]));
+export const mapRecord = <T>(arr: T[], key = "uuid") => {
+  return Object.fromEntries(arr.map((env) => [env[key], env])) as Record<
+    typeof key,
+    T
+  >;
 };


### PR DESCRIPTION
## Description

In /environments, when the browser tab regains focus, `fetchAll` is called to keep the environment list up-to-date, but `fetchAll` also washes away the current UI state (i.e. `lastBuild`), and thus the build state is then only re-stored in the next round of polling. This PR persists `lastBuild` so the UI state is persisted.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
