### PR TITLE
Remove unnecessary filter when listing images on node using docker container runtime

### DIFF
--- a/services/node-agent/app/container_runtime.py
+++ b/services/node-agent/app/container_runtime.py
@@ -9,8 +9,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import aiodocker
 
-from _orchest.internals import config as _config
-
 
 class RuntimeType(Enum):
     Docker = "docker"
@@ -231,12 +229,7 @@ class ContainerRuntime(object):
         image_names = []
         if self.container_runtime == RuntimeType.Docker:
             try:
-                filters = {
-                    "label": [
-                        f"maintainer={_config.ORCHEST_MAINTAINER_LABEL}",
-                    ]
-                }
-                for img in await self.aclient.images.list(filters=filters):
+                for img in await self.aclient.images.list():
                     names = img.get("RepoTags")
                     # Unfortunately RepoTags is mapped to None
                     # instead of not being there in some cases.


### PR DESCRIPTION
## Description

This effectively makes `list_images` behave equally for both docker and containerd, and makes it work as documented by the docstring in the docker case. The filter brought in the assumption that all images that are of interest for the caller of `list_images` should have the "Orchest" maintainer label, but that's not the case when an environment has been built with a custom base image.

The returned images affected the downstream logic of the `node-agent` of removing unused images from the node, making it so that unused images of environments built with custom images would not be deleted. 

## Checklist

- [X] I have manually tested my changes and I am happy with the result.
