### PR TITLE
Move Orchest configs to a zustand store

### DIFF
--- a/services/orchest-webserver/client/src/App.tsx
+++ b/services/orchest-webserver/client/src/App.tsx
@@ -1,68 +1,30 @@
-import { useInterval } from "@/hooks/useInterval";
 import { Routes } from "@/Routes";
 import Box from "@mui/material/Box";
-import OpenReplay from "@openreplay/tracker";
-import { makeRequest } from "@orchest/lib-utils";
 import { enableMapSet } from "immer";
 import React from "react";
 import { Prompt } from "react-router-dom";
-import { useIntercom } from "react-use-intercom";
 import { CommandPalette } from "./components/CommandPalette";
 import { OnboardingDialog } from "./components/layout/legacy/OnboardingDialog";
 import { SystemDialog } from "./components/SystemDialog";
 import { useGlobalContext } from "./contexts/GlobalContext";
 import { HeaderBar } from "./header-bar/HeaderBar";
+import { useOnAppStart } from "./hooks/useOnAppStart";
 import Jupyter from "./jupyter/Jupyter";
 
 enableMapSet();
 
 const App = () => {
+  useOnAppStart();
+
   const [jupyter, setJupyter] = React.useState<Jupyter | null>(null);
-  const { boot } = useIntercom();
   const { setConfirm } = useGlobalContext();
 
   // load server side config populated by flask template
   const {
     state: { hasUnsavedChanges },
-    config,
-    user_config,
   } = useGlobalContext();
 
   const jupyterRef = React.useRef<HTMLDivElement>(null);
-
-  // Each client provides an heartbeat, used for telemetry and idle
-  // checking.
-  useInterval(() => {
-    makeRequest("GET", "/heartbeat");
-  }, 5000);
-
-  React.useEffect(() => {
-    if (!user_config || !config) return;
-
-    if (config.FLASK_ENV === "development") {
-      console.log("Orchest is running with --dev.");
-    }
-
-    if (config.CLOUD === true) {
-      console.log("Orchest is running with --cloud.");
-
-      boot({
-        email: user_config.INTERCOM_USER_EMAIL,
-        createdAt: config.INTERCOM_DEFAULT_SIGNUP_DATE,
-        alignment: "right",
-      });
-
-      const tracker = new OpenReplay({
-        projectKey: config.OPENREPLAY_PROJECT_KEY,
-        ingestPoint: config.OPENREPLAY_INGEST_POINT,
-        obscureTextEmails: true,
-        obscureTextNumbers: true,
-        obscureInputEmails: true,
-        defaultInputMode: 1,
-      });
-      tracker.start();
-    }
-  }, [config, user_config]); // eslint-disable-line react-hooks/exhaustive-deps
 
   React.useEffect(() => {
     if (jupyterRef.current)
@@ -94,7 +56,6 @@ const App = () => {
           <div ref={jupyterRef} className="persistent-view jupyter hidden" />
         </Box>
       </Box>
-
       <Prompt when={hasUnsavedChanges} message="hasUnsavedChanges" />
       <SystemDialog />
       <OnboardingDialog />

--- a/services/orchest-webserver/client/src/api/system-config/orchestConfigsApi.ts
+++ b/services/orchest-webserver/client/src/api/system-config/orchestConfigsApi.ts
@@ -1,0 +1,12 @@
+import { OrchestConfigs } from "@/types";
+import { fetcher } from "@orchest/lib-utils";
+
+const BASE_URL = "/async/server-config";
+
+const fetchConfig = async (): Promise<OrchestConfigs> => {
+  return fetcher<OrchestConfigs>(BASE_URL);
+};
+
+export const orchestConfigsApi = {
+  fetch: fetchConfig,
+};

--- a/services/orchest-webserver/client/src/api/system-config/useOrchestConfigsApi.ts
+++ b/services/orchest-webserver/client/src/api/system-config/useOrchestConfigsApi.ts
@@ -1,0 +1,24 @@
+import { OrchestConfig, OrchestUserConfig } from "@/types";
+import create from "zustand";
+import { orchestConfigsApi } from "./orchestConfigsApi";
+
+export type OrchestConfigsApi = {
+  config: OrchestConfig | undefined;
+  userConfig: OrchestUserConfig | undefined;
+  fetch: () => Promise<
+    { config?: OrchestConfig; userConfig: OrchestUserConfig } | undefined
+  >;
+};
+
+export const useOrchestConfigsApi = create<OrchestConfigsApi>((set) => {
+  return {
+    config: undefined,
+    userConfig: undefined,
+    fetch: async () => {
+      const { config, user_config } = await orchestConfigsApi.fetch();
+      const state = { config, userConfig: user_config };
+      set(state);
+      return state;
+    },
+  };
+});

--- a/services/orchest-webserver/client/src/contexts/GlobalContext.tsx
+++ b/services/orchest-webserver/client/src/contexts/GlobalContext.tsx
@@ -1,12 +1,5 @@
-import { useAsync } from "@/hooks/useAsync";
-import {
-  OrchestConfig,
-  OrchestServerConfig,
-  OrchestUserConfig,
-  ReducerActionWithCallback,
-} from "@/types";
+import { ReducerActionWithCallback } from "@/types";
 import { ButtonProps } from "@mui/material/Button";
-import { fetcher, hasValue } from "@orchest/lib-utils";
 import React from "react";
 
 type PlainTextToHtmlProps = { text: string };
@@ -155,10 +148,6 @@ type GlobalContext = {
   setConfirm: ConfirmDispatcher;
   deletePromptMessage: () => void;
   setAsSaved: (value?: boolean) => void;
-  config: OrchestConfig | undefined;
-  user_config: OrchestUserConfig | undefined;
-  hideIntercom: () => void;
-  showIntercom: () => void;
 };
 
 const Context = React.createContext<GlobalContext | null>(null);
@@ -335,26 +324,8 @@ const convertConfirm: PromptMessageConverter<Confirm> = ({
   };
 };
 
-const useFetchSystemConfig = (shouldStart: boolean) => {
-  const { data, run } = useAsync<OrchestServerConfig>();
-  React.useEffect(() => {
-    if (shouldStart) run(fetcher("/async/server-config"));
-  }, [run, shouldStart]);
-  return (data || {}) as {
-    config?: OrchestConfig;
-    user_config?: OrchestUserConfig;
-  };
-};
-
-// `shouldStart` is only useful when running tests.
-// Use it to control the side effects within AppContext when mocking.
-export const GlobalContextProvider: React.FC<{ shouldStart?: boolean }> = ({
-  children,
-  shouldStart = true,
-}) => {
+export const GlobalContextProvider: React.FC = ({ children }) => {
   const [state, dispatch] = React.useReducer(reducer, initialState);
-
-  const { config, user_config } = useFetchSystemConfig(shouldStart);
 
   /**
    * =========================== side effects
@@ -395,36 +366,15 @@ export const GlobalContextProvider: React.FC<{ shouldStart?: boolean }> = ({
     [dispatch]
   );
 
-  const setDisplayOfIntercom = React.useCallback((value: "block" | "none") => {
-    const intercomElement = document.querySelector(
-      ".intercom-lightweight-app"
-    ) as HTMLElement;
-
-    if (hasValue(intercomElement?.style?.display))
-      intercomElement.style.display = value;
-  }, []);
-
-  const hideIntercom = React.useCallback(() => {
-    setDisplayOfIntercom("none");
-  }, [setDisplayOfIntercom]);
-
-  const showIntercom = React.useCallback(() => {
-    setDisplayOfIntercom("block");
-  }, [setDisplayOfIntercom]);
-
   return (
     <Context.Provider
       value={{
-        config,
-        user_config,
         state,
         dispatch,
         setAlert,
         setConfirm,
         deletePromptMessage,
         setAsSaved,
-        hideIntercom,
-        showIntercom,
       }}
     >
       {children}

--- a/services/orchest-webserver/client/src/contexts/Intercom.tsx
+++ b/services/orchest-webserver/client/src/contexts/Intercom.tsx
@@ -1,13 +1,10 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import React from "react";
 import { IntercomProvider } from "react-use-intercom";
-import { useGlobalContext } from "./GlobalContext";
 
 export const Intercom: React.FC = ({ children }) => {
-  const { config } = useGlobalContext();
-
-  return (
-    <IntercomProvider appId={config?.INTERCOM_APP_ID || ""}>
-      {children}
-    </IntercomProvider>
+  const appId = useOrchestConfigsApi(
+    (state) => state.config?.INTERCOM_APP_ID || ""
   );
+  return <IntercomProvider appId={appId}>{children}</IntercomProvider>;
 };

--- a/services/orchest-webserver/client/src/contexts/Providers.tsx
+++ b/services/orchest-webserver/client/src/contexts/Providers.tsx
@@ -1,3 +1,4 @@
+import { useFetchOrchestConfigs } from "@/hooks/useFetchOrchestConfigs";
 import { useEditJob } from "@/jobs-view/stores/useEditJob";
 import theme from "@/theme";
 import { ThemeProvider } from "@mui/material/styles";
@@ -38,6 +39,7 @@ export const GlobalProviders: React.FC = ({ children }) => {
  * - ProjectContext: managing the active project
  */
 export const OrchestProvider: React.FC = ({ children }) => {
+  useFetchOrchestConfigs();
   return (
     <ProjectsContextProvider>
       <SessionsContextProvider>{children}</SessionsContextProvider>

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/CustomImageDetails.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/CustomImageDetails.tsx
@@ -1,4 +1,4 @@
-import { useGlobalContext } from "@/contexts/GlobalContext";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { CustomImage, Language } from "@/types";
 import Alert from "@mui/material/Alert";
 import Checkbox from "@mui/material/Checkbox";
@@ -37,8 +37,7 @@ const isDefaultImage = (baseImage: string) => {
 };
 
 export const CustomImageDetails = () => {
-  const { config } = useGlobalContext();
-
+  const config = useOrchestConfigsApi((state) => state.config);
   const {
     selectedImage,
     customImage,

--- a/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
+++ b/services/orchest-webserver/client/src/environments-view/edit-environment/EnvironmentImageBuildLogs.tsx
@@ -1,11 +1,11 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
 } from "@/components/Accordion";
 import { ImageBuildLog } from "@/components/ImageBuildLog";
-import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useCustomRoute } from "@/hooks/useCustomRoute";
 import { useFocusBrowserTab } from "@/hooks/useFocusBrowserTab";
 import Typography from "@mui/material/Typography";
@@ -17,7 +17,7 @@ import { useEditEnvironment } from "../stores/useEditEnvironment";
 
 export const EnvironmentImageBuildLogs = () => {
   const { projectUuid, environmentUuid } = useCustomRoute();
-  const { config } = useGlobalContext();
+  const config = useOrchestConfigsApi((state) => state.config);
 
   const uuid = useEditEnvironment((state) => state.changes?.uuid);
   const latestBuild = useEditEnvironment((state) => state.changes?.latestBuild);

--- a/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
+++ b/services/orchest-webserver/client/src/environments-view/hooks/useCreateEnvironment.tsx
@@ -1,5 +1,5 @@
 import { useEnvironmentsApi } from "@/api/environments/useEnvironmentsApi";
-import { useGlobalContext } from "@/contexts/GlobalContext";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { useAsync } from "@/hooks/useAsync";
 import { EnvironmentData, EnvironmentSpec, Language } from "@/types";
 import { hasValue } from "@orchest/lib-utils";
@@ -7,7 +7,8 @@ import React from "react";
 import { DEFAULT_BASE_IMAGES, getNewEnvironmentName } from "../common";
 
 export const useCreateEnvironment = () => {
-  const { config } = useGlobalContext();
+  const config = useOrchestConfigsApi((state) => state.config);
+
   const { run, status } = useAsync<EnvironmentData | undefined>();
 
   const environments = useEnvironmentsApi((state) => state.environments);

--- a/services/orchest-webserver/client/src/header-bar/HeaderBar.tsx
+++ b/services/orchest-webserver/client/src/header-bar/HeaderBar.tsx
@@ -1,5 +1,5 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { IconButton } from "@/components/common/IconButton";
-import { useGlobalContext } from "@/contexts/GlobalContext";
 import LogoutIcon from "@mui/icons-material/Logout";
 import AppBar from "@mui/material/AppBar";
 import Stack from "@mui/material/Stack";
@@ -10,7 +10,7 @@ import { NavigationTabs } from "./NavigationTabs";
 import { SessionStatus } from "./SessionStatus";
 
 export const HeaderBar = () => {
-  const { user_config } = useGlobalContext();
+  const userConfig = useOrchestConfigsApi((state) => state.userConfig);
 
   const logoutHandler = () => {
     window.location.href = "/login/clear";
@@ -37,7 +37,7 @@ export const HeaderBar = () => {
         <ProjectSelector />
         <Stack direction="row" justifyContent="flex-end">
           <NavigationTabs />
-          {user_config?.AUTH_ENABLED && (
+          {userConfig?.AUTH_ENABLED && (
             <IconButton
               title="Logout"
               tabIndex={0}

--- a/services/orchest-webserver/client/src/hooks/useFetchOrchestConfigs.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchOrchestConfigs.ts
@@ -1,11 +1,11 @@
-import { orchestConfigsApi } from "@/api/system-config/orchestConfigsApi";
-import { OrchestConfigs } from "@/types";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import React from "react";
 import { useAsync } from "./useAsync";
 
 export const useFetchOrchestConfigs = () => {
-  const { run } = useAsync<OrchestConfigs>();
+  const { run } = useAsync();
+  const fetchConfig = useOrchestConfigsApi((state) => state.fetch);
   React.useEffect(() => {
-    run(orchestConfigsApi.fetch());
-  }, [run]);
+    run(fetchConfig());
+  }, [run, fetchConfig]);
 };

--- a/services/orchest-webserver/client/src/hooks/useFetchOrchestConfigs.ts
+++ b/services/orchest-webserver/client/src/hooks/useFetchOrchestConfigs.ts
@@ -1,0 +1,11 @@
+import { orchestConfigsApi } from "@/api/system-config/orchestConfigsApi";
+import { OrchestConfigs } from "@/types";
+import React from "react";
+import { useAsync } from "./useAsync";
+
+export const useFetchOrchestConfigs = () => {
+  const { run } = useAsync<OrchestConfigs>();
+  React.useEffect(() => {
+    run(orchestConfigsApi.fetch());
+  }, [run]);
+};

--- a/services/orchest-webserver/client/src/hooks/useHideIntercom.tsx
+++ b/services/orchest-webserver/client/src/hooks/useHideIntercom.tsx
@@ -1,4 +1,4 @@
-import { useGlobalContext } from "@/contexts/GlobalContext";
+import { hasValue } from "@orchest/lib-utils";
 import React from "react";
 
 /** Hide Intercom in case the UI component is blocked by it */
@@ -6,8 +6,22 @@ export const useHideIntercom = (
   shouldHidIntercom: boolean,
   shouldAutoShow = true
 ) => {
-  const { hideIntercom, showIntercom } = useGlobalContext();
+  const setDisplayOfIntercom = React.useCallback((value: "block" | "none") => {
+    const intercomElement = document.querySelector(
+      ".intercom-lightweight-app"
+    ) as HTMLElement;
 
+    if (hasValue(intercomElement?.style?.display))
+      intercomElement.style.display = value;
+  }, []);
+
+  const hideIntercom = React.useCallback(() => {
+    setDisplayOfIntercom("none");
+  }, [setDisplayOfIntercom]);
+
+  const showIntercom = React.useCallback(() => {
+    setDisplayOfIntercom("block");
+  }, [setDisplayOfIntercom]);
   React.useEffect(() => {
     if (shouldHidIntercom) {
       hideIntercom();

--- a/services/orchest-webserver/client/src/hooks/useInitIntercom.ts
+++ b/services/orchest-webserver/client/src/hooks/useInitIntercom.ts
@@ -1,0 +1,20 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
+import React from "react";
+import { useIntercom } from "react-use-intercom";
+
+export const useInitIntercom = () => {
+  const { boot } = useIntercom();
+  const config = useOrchestConfigsApi((state) => state.config);
+  const userConfig = useOrchestConfigsApi((state) => state.userConfig);
+
+  React.useEffect(() => {
+    if (!config || !userConfig) return;
+    if (config.CLOUD === true) {
+      boot({
+        email: userConfig.INTERCOM_USER_EMAIL,
+        createdAt: config.INTERCOM_DEFAULT_SIGNUP_DATE,
+        alignment: "right",
+      });
+    }
+  }, [config, userConfig, boot]);
+};

--- a/services/orchest-webserver/client/src/hooks/useOnAppStart.ts
+++ b/services/orchest-webserver/client/src/hooks/useOnAppStart.ts
@@ -1,0 +1,25 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
+import { makeRequest } from "@orchest/lib-utils";
+import React from "react";
+import { useInitIntercom } from "./useInitIntercom";
+import { useInterval } from "./useInterval";
+import { useOpenReplay } from "./useOpenReplay";
+
+/** Initialize background services, such as Intercom and OpenReplay, on App start. */
+export const useOnAppStart = () => {
+  useOpenReplay();
+  useInitIntercom();
+
+  // Each client provides an heartbeat, used for telemetry and idle
+  // checking.
+  useInterval(() => {
+    makeRequest("GET", "/heartbeat");
+  }, 5000);
+
+  const config = useOrchestConfigsApi((state) => state.config);
+  React.useEffect(() => {
+    if (config?.CLOUD === true) console.log("Orchest is running with --cloud.");
+    if (config?.FLASK_ENV === "development")
+      console.log("Orchest is running with --dev.");
+  }, [config]);
+};

--- a/services/orchest-webserver/client/src/hooks/useOpenReplay.ts
+++ b/services/orchest-webserver/client/src/hooks/useOpenReplay.ts
@@ -1,0 +1,22 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
+import OpenReplay from "@openreplay/tracker";
+import React from "react";
+
+export const useOpenReplay = () => {
+  const config = useOrchestConfigsApi((state) => state.config);
+
+  React.useEffect(() => {
+    if (!config) return;
+    if (config.CLOUD === true) {
+      const tracker = new OpenReplay({
+        projectKey: config.OPENREPLAY_PROJECT_KEY,
+        ingestPoint: config.OPENREPLAY_INGEST_POINT,
+        obscureTextEmails: true,
+        obscureTextNumbers: true,
+        obscureInputEmails: true,
+        defaultInputMode: 1,
+      });
+      tracker.start();
+    }
+  }, [config]);
+};

--- a/services/orchest-webserver/client/src/hooks/useSendAnalyticEvent.ts
+++ b/services/orchest-webserver/client/src/hooks/useSendAnalyticEvent.ts
@@ -1,4 +1,4 @@
-import { useGlobalContext } from "@/contexts/GlobalContext";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { fetcher, hasValue, HEADER } from "@orchest/lib-utils";
 import React from "react";
 import { useMounted } from "./useMounted";
@@ -77,7 +77,7 @@ const useSendAnalyticEvent = (
   event?: string | undefined,
   props?: StringifyReactElement
 ) => {
-  const { config } = useGlobalContext();
+  const config = useOrchestConfigsApi((state) => state.config);
   const mounted = useMounted();
   const shouldSend = config?.TELEMETRY_DISABLED === false && mounted.current;
 

--- a/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useParameterReservedKey.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/hooks/useParameterReservedKey.tsx
@@ -1,8 +1,8 @@
-import { useGlobalContext } from "@/contexts/GlobalContext";
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 
 export const useParameterReservedKey = () => {
-  const { config } = useGlobalContext();
-  const reservedKey = config?.PIPELINE_PARAMETERS_RESERVED_KEY;
-
+  const reservedKey = useOrchestConfigsApi(
+    (state) => state.config?.PIPELINE_PARAMETERS_RESERVED_KEY
+  );
   return { reservedKey };
 };

--- a/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
+++ b/services/orchest-webserver/client/src/settings-view/SettingsView.tsx
@@ -1,3 +1,4 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/layout/Layout";
@@ -34,8 +35,9 @@ const SettingsView: React.FC = () => {
     setAsSaved,
     setConfirm,
     state: { hasUnsavedChanges },
-    config: orchestConfig,
   } = useGlobalContext();
+
+  const orchestConfig = useOrchestConfigsApi((state) => state.config);
 
   const { orchestVersion, checkUpdate } = useAppContext();
 

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -110,7 +110,7 @@ export interface OrchestUserConfig {
   TELEMETRY_UUID: string;
 }
 
-export interface OrchestServerConfig {
+export interface OrchestConfigs {
   config: OrchestConfig;
   user_config: OrchestUserConfig;
 }

--- a/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
+++ b/services/orchest-webserver/client/src/views/ConfigureJupyterLabView.tsx
@@ -1,3 +1,4 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { BackToOrchestSettingsButton } from "@/components/BackToOrchestSettingsButton";
 import { Code } from "@/components/common/Code";
 import { PageTitle } from "@/components/common/PageTitle";
@@ -33,8 +34,8 @@ const ConfigureJupyterLabView: React.FC = () => {
     setAlert,
     setConfirm,
     setAsSaved,
-    config,
   } = useGlobalContext();
+  const config = useOrchestConfigsApi((state) => state.config);
   const {
     deleteAllSessions,
     state: { sessionsKillAllInProgress, sessions },

--- a/services/orchest-webserver/client/src/views/HelpView.tsx
+++ b/services/orchest-webserver/client/src/views/HelpView.tsx
@@ -1,7 +1,7 @@
+import { useOrchestConfigsApi } from "@/api/system-config/useOrchestConfigsApi";
 import { PageTitle } from "@/components/common/PageTitle";
 import { Layout } from "@/components/layout/Layout";
 import { useOnboardingDialog } from "@/components/layout/legacy/OnboardingDialog";
-import { useGlobalContext } from "@/contexts/GlobalContext";
 import { useSendAnalyticEvent } from "@/hooks/useSendAnalyticEvent";
 import { siteMap } from "@/routingConfig";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
@@ -45,7 +45,7 @@ const HelpItem: React.FC<{
 };
 
 const HelpView: React.FC = () => {
-  const { config } = useGlobalContext();
+  const config = useOrchestConfigsApi((state) => state.config);
 
   useSendAnalyticEvent("view:loaded", { name: siteMap.help.path });
   const { setIsOnboardingDialogOpen } = useOnboardingDialog();


### PR DESCRIPTION
## Description

Move the fetching Orchest config mechanism from GlobalContext to a zustand store.
After this refactor, GlobalContext is side-effect-free, which is easier for further clean-up.
The side effects such as initialize Intercom and OpenReplay were moved to `useOnAppStart`.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.

