### PR TITLE
Don't redirect to or display "project" on settings/help

### DIFF
--- a/services/orchest-webserver/client/src/routingConfig.tsx
+++ b/services/orchest-webserver/client/src/routingConfig.tsx
@@ -189,7 +189,7 @@ const projectRootPaths = [
   siteMap.jupyterLab.path,
   siteMap.jobs.path,
   siteMap.environments.path,
-  siteMap.filePreview,
+  siteMap.filePreview.path,
 ];
 
 const navigationPaths = [
@@ -269,4 +269,4 @@ export const getPageCommands = (projectUuid: string | undefined) =>
     });
 
 export const isProjectPage = (path: string) =>
-  navigationRoutes.some((route) => route.path === path);
+  withinProjectRoutes.some((route) => route.path === path);


### PR DESCRIPTION
## Description

When going to "settings" or "help" page, the app redirects you to the fallback project, and displays it in the project selector.
These are not project-scoped pages, so they should not do that.

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.
