### PR TITLE
Create the celery app only once

### DIFF
--- a/services/orchest-api/app/app/__init__.py
+++ b/services/orchest-api/app/app/__init__.py
@@ -31,6 +31,7 @@ from app import utils
 from app.apis import blueprint as api
 from app.apis import namespace_ctl
 from app.apis.namespace_jupyter_image_builds import CreateJupyterEnvironmentBuild
+from app.celery_app import make_celery
 from app.connections import db, k8s_core_api
 from app.core.notifications import analytics as api_analytics
 from app.core.scheduler import add_recurring_jobs_to_scheduler
@@ -123,9 +124,11 @@ def create_app(
                 attributes.flag_modified(job, "pipeline_definition")
                 db.session.commit()
 
-    # Keep analytics subscribed to all events of interest.
     with app.app_context():
+        # Keep analytics subscribed to all events of interest.
         api_analytics.upsert_analytics_subscriptions()
+
+        app.config["CELERY"] = make_celery(app)
 
     # Create a background scheduler (in a daemon thread) for every
     # gunicorn worker. The individual schedulers do not cause duplicate

--- a/services/orchest-api/app/app/apis/namespace_git_imports.py
+++ b/services/orchest-api/app/app/apis/namespace_git_imports.py
@@ -9,7 +9,6 @@ from flask_restx import Namespace, Resource
 
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import models, schema, utils
-from app.celery_app import make_celery
 from app.connections import db
 
 api = Namespace("git-imports", description="Initiate and track git imports.")
@@ -102,7 +101,7 @@ class ImportGitProject(TwoPhaseFunction):
         project_name: Optional[str],
         auth_user_uuid: Optional[str],
     ):
-        celery = make_celery(current_app)
+        celery = current_app.config["CELERY"]
         celery.send_task(
             "app.core.tasks.git_import",
             kwargs={

--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -18,7 +18,6 @@ from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunc
 from app import errors, schema
 from app import types as app_types
 from app.apis.namespace_runs import AbortPipelineRun
-from app.celery_app import make_celery
 from app.connections import db
 from app.core import environments, events
 from app.core.pipelines import Pipeline, construct_pipeline
@@ -663,8 +662,8 @@ class DeleteNonRetainedJobPipelineRuns(TwoPhaseFunction):
         job_uuid: str,
         pipeline_run_uuids: List[str],
     ):
-        celery = make_celery(current_app)
 
+        celery = current_app.config["CELERY"]
         # Delete in batches to have a balance between the number of
         # created tasks and the size of the celery job args. Googling a
         # bit returns some sparse results on possible issues, so an
@@ -896,7 +895,7 @@ class RunJob(TwoPhaseFunction):
             return
 
         # Launch each task through celery.
-        celery = make_celery(current_app)
+        celery = current_app.config["CELERY"]
 
         for task_id, pipeline in tasks_to_launch:
             celery_job_kwargs = {
@@ -1021,7 +1020,7 @@ class AbortJob(TwoPhaseFunction):
     def _collateral(self, project_uuid: str, run_uuids: List[str], **kwargs):
         # Aborts and revokes all pipeline runs and waits for a reply for
         # 1.0s.
-        celery = make_celery(current_app)
+        celery = current_app.config["CELERY"]
         celery.control.revoke(run_uuids, timeout=1.0)
 
         for run_uuid in run_uuids:
@@ -1622,7 +1621,8 @@ class DeleteJobPipelineRun(TwoPhaseFunction):
             "kwargs": celery_job_kwargs,
             "task_id": str(uuid.uuid4()),
         }
-        res = make_celery(current_app).send_task(**task_args)
+        celery = current_app.config["CELERY"]
+        res = celery.send_task(**task_args)
         res.forget()
 
 

--- a/services/orchest-api/app/app/apis/namespace_runs.py
+++ b/services/orchest-api/app/app/apis/namespace_runs.py
@@ -14,7 +14,6 @@ import app.models as models
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import errors as self_errors
 from app import schema
-from app.celery_app import make_celery
 from app.connections import db
 from app.core import environments, events
 from app.core.pipelines import Pipeline, construct_pipeline
@@ -161,12 +160,12 @@ class AbortPipelineRun(TwoPhaseFunction):
         if not run_uuid:
             return
 
-        celery_app = make_celery(current_app)
-        res = AbortableAsyncResult(run_uuid, app=celery_app)
+        celery = current_app.config["CELERY"]
+        res = AbortableAsyncResult(run_uuid, app=celery)
         # It is responsibility of the task to terminate by reading it's
         # aborted status.
         res.abort()
-        celery_app.control.revoke(run_uuid)
+        celery.control.revoke(run_uuid)
 
 
 class AbortInteractivePipelineRun(TwoPhaseFunction):
@@ -270,7 +269,7 @@ class CreateInteractiveRun(TwoPhaseFunction):
 
         # Create Celery object with the Flask context and construct the
         # kwargs for the job.
-        celery = make_celery(current_app)
+        celery = current_app.config["CELERY"]
         run_config["env_uuid_to_image"] = env_uuid_to_image
         run_config["user_env_variables"] = env_variables
         run_config["session_uuid"] = (

--- a/services/orchest-api/app/app/core/scheduler.py
+++ b/services/orchest-api/app/app/core/scheduler.py
@@ -31,7 +31,6 @@ from sqlalchemy.orm import load_only
 from _orchest.internals.two_phase_executor import TwoPhaseExecutor, TwoPhaseFunction
 from app import models, utils
 from app.apis.namespace_jobs import RunJob
-from app.celery_app import make_celery
 from app.connections import db
 from app.core import environments
 
@@ -439,7 +438,7 @@ def process_images_for_deletion(app, task_uuid: str) -> None:
                 notify_scheduled_job_succeeded(task_uuid)
                 return
 
-            celery = make_celery(app)
+            celery = app.config["CELERY"]
             app.logger.info("Sending registry garbage collection task.")
             res = celery.send_task(
                 name="app.core.tasks.registry_garbage_collection", task_id=task_uuid
@@ -453,7 +452,7 @@ def process_images_for_deletion(app, task_uuid: str) -> None:
 def process_notification_deliveries(app, task_uuid: str) -> None:
     with app.app_context():
         app.logger.debug("Sending process notifications deliveries task.")
-        celery = make_celery(app)
+        celery = app.config["CELERY"]
         res = celery.send_task(
             name="app.core.tasks.process_notifications_deliveries", task_id=task_uuid
         )

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -16,7 +16,6 @@ from _orchest.internals.utils import copytree
 from app import create_app
 from app import errors as self_errors
 from app import models, utils
-from app.celery_app import make_celery
 from app.connections import db, k8s_core_api, k8s_custom_obj_api
 from app.core import environments, notifications, pod_scheduling, registry, scheduler
 from app.core.environment_image_builds import build_environment_image_task
@@ -34,7 +33,7 @@ logger = get_task_logger(__name__)
 # /userdir bind to access the DB which is probably not a good idea.
 # create_all should only be called once per app right?
 application = create_app(CONFIG_CLASS, use_db=True, register_api=False)
-celery = make_celery(application, use_backend_db=True)
+celery = application.config["CELERY"]
 
 
 @worker_process_init.connect

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -26,7 +26,6 @@ from _orchest.internals import config as _config
 from _orchest.internals import errors as _errors
 from app import errors as self_errors
 from app import types as app_types
-from app.celery_app import make_celery
 from app.connections import db, k8s_core_api
 from config import CONFIG_CLASS
 
@@ -346,14 +345,14 @@ def _set_celery_worker_parallelism_at_runtime(
     # We don't query the celery-worker and rely on arguments because the
     # worker might take some time to spawn new processes, leading to
     # race conditions.
-    celery = make_celery(current_app)
+    celery = current_app.config["CELERY"]
     worker = f"celery@{worker}"
     celery.control.pool_grow(new_parallelism - current_parallelism, [worker])
     return True
 
 
 def _get_worker_parallelism(worker: str) -> int:
-    celery = make_celery(current_app)
+    celery = current_app.config["CELERY"]
     worker = f"celery@{worker}"
     stats = celery.control.inspect([worker]).stats()
     return len(stats[worker]["pool"]["processes"])


### PR DESCRIPTION
## Description

Fixes a memory leak that happened when creating an instance of celery before sending a task, I've simply made it so that celery is instanced only once, although according to the [docs](https://docs.celeryq.dev/en/stable/userguide/application.html) it should have been safe not to do so. 
