### PR TITLE
Add "view" link back to job runs, fix sort order and "open in new tab"

### DIFF
--- a/services/orchest-api/app/app/apis/namespace_jobs.py
+++ b/services/orchest-api/app/app/apis/namespace_jobs.py
@@ -414,19 +414,6 @@ class PipelineRunsList(Resource):
             undefer(models.NonInteractivePipelineRun.env_variables),
         )
 
-        if sort == "oldest":
-            job_runs_query = job_runs_query.order_by(
-                asc(models.NonInteractivePipelineRun.created_time),
-                asc(models.NonInteractivePipelineRun.job_run_index),
-                asc(models.NonInteractivePipelineRun.job_run_pipeline_run_index),
-            )
-        else:
-            job_runs_query = job_runs_query.order_by(
-                desc(models.NonInteractivePipelineRun.created_time),
-                desc(models.NonInteractivePipelineRun.job_run_index),
-                desc(models.NonInteractivePipelineRun.job_run_pipeline_run_index),
-            )
-
         if project_uuids is not None or project_pipeline_uuids is not None:
             exp = None
             if project_uuids is not None:
@@ -459,6 +446,19 @@ class PipelineRunsList(Resource):
             job_runs_query = fuzzy_filter_non_interactive_pipeline_runs(
                 job_runs_query,
                 args.fuzzy_filter,
+            )
+
+        if sort == "oldest":
+            job_runs_query = job_runs_query.order_by(
+                asc(models.NonInteractivePipelineRun.started_time),
+                asc(models.NonInteractivePipelineRun.job_run_index),
+                asc(models.NonInteractivePipelineRun.job_run_pipeline_run_index),
+            )
+        else:
+            job_runs_query = job_runs_query.order_by(
+                desc(models.NonInteractivePipelineRun.started_time),
+                desc(models.NonInteractivePipelineRun.job_run_index),
+                desc(models.NonInteractivePipelineRun.job_run_pipeline_run_index),
             )
 
         if args.page is not None and args.page_size is not None:

--- a/services/orchest-webserver/client/src/components/common/SystemStatusIcon.tsx
+++ b/services/orchest-webserver/client/src/components/common/SystemStatusIcon.tsx
@@ -18,7 +18,7 @@ export type SystemStatusIconProps = {
 export type SystemStatusIconSize = "small" | "medium" | "large";
 
 const progressSize: Record<SystemStatusIconSize, number> = {
-  small: 16,
+  small: 18,
   medium: 24,
   large: 30,
 };

--- a/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
+++ b/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
@@ -88,7 +88,11 @@ export const PipelineRunRow = ({
 
         <TableCell sx={{ textAlign: "right" }}>
           <Stack direction="row" justifyContent="flex-end">
-            <SystemStatusChip status={run.status} flavor="job" size="small" />
+            <SystemStatusChip
+              status={run.status}
+              flavor={isJobRun(run) ? "job" : "pipeline"}
+              size="small"
+            />
 
             {viewLink && (
               <Button LinkComponent={RouteLink} size="small" href={runLink}>

--- a/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
+++ b/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
@@ -102,7 +102,9 @@ export const PipelineRunRow = ({
           </Stack>
         </TableCell>
 
-        <TableCell sx={{ textAlign: "right", whiteSpace: "nowrap" }}>
+        <TableCell
+          sx={{ textAlign: "right", whiteSpace: "nowrap", minWidth: 177 }}
+        >
           {run.started_time ? humanizeDate(run.started_time) : "—"}
         </TableCell>
 

--- a/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
+++ b/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunRow.tsx
@@ -1,3 +1,4 @@
+import { useRouteLink } from "@/hooks/useCustomRoute";
 import { useToggle } from "@/hooks/useToggle";
 import { formatPipelineParams } from "@/jobs-view/common";
 import { PipelineRun } from "@/types";
@@ -5,6 +6,7 @@ import { humanizeDate } from "@/utils/date-time";
 import { isJobRun } from "@/utils/pipeline-run";
 import { ChevronRightSharp } from "@mui/icons-material";
 import MoreHorizOutlined from "@mui/icons-material/MoreHorizOutlined";
+import { Button } from "@mui/material";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import IconButton from "@mui/material/IconButton";
@@ -14,6 +16,7 @@ import TableRow from "@mui/material/TableRow";
 import Typography from "@mui/material/Typography";
 import React from "react";
 import { SystemStatusChip } from "../common/SystemStatusChip";
+import { RouteLink } from "../RouteLink";
 import { PipelineRunBreadcrumbs } from "./PipelineRunBreadcrumbs";
 import { PipelineRunContextMenu } from "./PipelineRunContextMenu";
 
@@ -24,16 +27,28 @@ export type PipelineRunRowProps = {
   expandable?: boolean;
   /** Whether or not breadcrumbs (project, pipeline, job) should be displayed in each row. */
   breadcrumbs?: boolean;
+  /** Whether or not a link to the pipeline/job run should be displayed. */
+  viewLink?: boolean;
 };
 
 export const PipelineRunRow = ({
   run,
   expandable = false,
   breadcrumbs = false,
+  viewLink = false,
 }: PipelineRunRowProps) => {
   const [isExpanded, toggleRow] = useToggle();
   const [isMenuOpen, toggleMenu] = useToggle();
   const moreButtonRef = React.useRef<HTMLButtonElement>(null);
+  const runLink = useRouteLink({
+    route: isJobRun(run) ? "jobRun" : "pipeline",
+    query: {
+      projectUuid: run.project_uuid,
+      pipelineUuid: run.pipeline_uuid,
+      jobUuid: isJobRun(run) ? run.job_uuid : undefined,
+      runUuid: run.uuid,
+    },
+  });
 
   return (
     <>
@@ -72,7 +87,15 @@ export const PipelineRunRow = ({
         </TableCell>
 
         <TableCell sx={{ textAlign: "right" }}>
-          <SystemStatusChip status={run.status} flavor="job" size="small" />
+          <Stack direction="row" justifyContent="flex-end">
+            <SystemStatusChip status={run.status} flavor="job" size="small" />
+
+            {viewLink && (
+              <Button LinkComponent={RouteLink} size="small" href={runLink}>
+                View
+              </Button>
+            )}
+          </Stack>
         </TableCell>
 
         <TableCell sx={{ textAlign: "right", whiteSpace: "nowrap" }}>

--- a/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunsTable.tsx
+++ b/services/orchest-webserver/client/src/components/pipeline-runs/PipelineRunsTable.tsx
@@ -9,6 +9,7 @@ export type JobRunsTableProps = {
   runs: PipelineRun[];
   expandable?: boolean;
   breadcrumbs?: boolean;
+  viewLink?: boolean;
 };
 
 export const PipelineRunsTable = ({ runs, ...rowProps }: JobRunsTableProps) => {

--- a/services/orchest-webserver/client/src/home-view/AllRunsTab.tsx
+++ b/services/orchest-webserver/client/src/home-view/AllRunsTab.tsx
@@ -110,7 +110,9 @@ const usePollJobRunsWithFilter = (filter: RunFilterState, page: number) => {
           }))
         : undefined,
       statuses: filter.statuses.length
-        ? filter.statuses.map(toPipelineRunStatus)
+        ? filter.statuses
+            .filter((status) => status !== "PENDING")
+            .map(toPipelineRunStatus)
         : undefined,
     }),
     [

--- a/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
+++ b/services/orchest-webserver/client/src/hooks/useCustomRoute.ts
@@ -164,7 +164,7 @@ export const useCustomRoute = () => {
         : toQueryString(query);
 
       if (shouldOpenNewTab) {
-        openInNewTab(`${window.location.origin}${pathname}?${queryString}`);
+        openInNewTab(window.location.origin + pathname + queryString);
       } else {
         const mutateHistory = replace ? history.replace : history.push;
         mutateHistory({

--- a/services/orchest-webserver/client/src/jobs-view/job-view/JobRuns.tsx
+++ b/services/orchest-webserver/client/src/jobs-view/job-view/JobRuns.tsx
@@ -79,7 +79,7 @@ export const JobRuns = () => {
 
         {pagination && runs && (
           <>
-            <PipelineRunsTable expandable runs={runs} />
+            <PipelineRunsTable runs={runs} expandable viewLink />
             <TablePagination
               rowsPerPageOptions={[5, 10, 25]}
               component="div"

--- a/services/orchest-webserver/client/src/types.d.ts
+++ b/services/orchest-webserver/client/src/types.d.ts
@@ -297,7 +297,7 @@ export type PipelineRun = {
   pipeline_uuid: string;
   status: PipelineRunStatus;
   server_time: string;
-  started_time: string;
+  started_time?: string;
   finished_time: string | null;
   pipeline_steps: PipelineRunStep[];
   env_variables: Record<string, string>;

--- a/services/orchest-webserver/client/src/utils/system-status.ts
+++ b/services/orchest-webserver/client/src/utils/system-status.ts
@@ -21,8 +21,6 @@ export type SystemStatus =
 
 export type StatusFlavor = "job" | "pipeline" | "build";
 
-export const isRunning = (status: SystemStatus) => status === "STARTED";
-
 export const hasEnded = (status: SystemStatus) =>
   status === "ABORTED" || status === "SUCCESS" || status === "FAILURE";
 


### PR DESCRIPTION
## Description

- Adds the view link back to the job runs table. This time after the status (for alignment purposes).
- Fixes some alignment issues for "Started time" in the table
- Fixes so pending interactive runs are included in All Runs
- Fixes "open in new tab" when there are important query parameters
- Fixes sort order in job runs table

... and some minor other fixes (see commits).

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/8259221/214959703-bc931203-e504-4884-9ed1-a25fdc76e959.png">

## Checklist

- [x] I have manually tested my changes and I am happy with the result.
- [x] The PR branch is set up to merge into `dev` instead of `master`.